### PR TITLE
Add outstanding counts to Board daily digest email

### DIFF
--- a/src/Humans.Application/DTOs/BoardDigestOutstandingCounts.cs
+++ b/src/Humans.Application/DTOs/BoardDigestOutstandingCounts.cs
@@ -1,0 +1,14 @@
+namespace Humans.Application.DTOs;
+
+/// <summary>
+/// Outstanding item counts for the Board daily digest email.
+/// BoardVotingYours is personalized per board member; all others are shared.
+/// </summary>
+public record BoardDigestOutstandingCounts(
+    int OnboardingReview,
+    int StillOnboarding,
+    int BoardVotingTotal,
+    int BoardVotingYours,
+    int TeamJoinRequests,
+    int PendingConsents,
+    int PendingDeletions);

--- a/src/Humans.Application/Interfaces/IEmailRenderer.cs
+++ b/src/Humans.Application/Interfaces/IEmailRenderer.cs
@@ -81,7 +81,7 @@ public interface IEmailRenderer
     EmailContent RenderTermRenewalReminder(string userName, string tierName, string expiresAt, string? culture = null);
 
     /// <summary>
-    /// Board daily digest of new approvals.
+    /// Board daily digest of new approvals and outstanding items.
     /// </summary>
-    EmailContent RenderBoardDailyDigest(string boardMemberName, string date, IReadOnlyList<BoardDigestTierGroup> tierGroups, string? culture = null);
+    EmailContent RenderBoardDailyDigest(string boardMemberName, string date, IReadOnlyList<BoardDigestTierGroup> tierGroups, BoardDigestOutstandingCounts? outstandingCounts = null, string? culture = null);
 }

--- a/src/Humans.Application/Interfaces/IEmailService.cs
+++ b/src/Humans.Application/Interfaces/IEmailService.cs
@@ -221,12 +221,13 @@ public interface IEmailService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Sends a Board daily digest email summarizing new approvals.
+    /// Sends a Board daily digest email summarizing new approvals and outstanding items.
     /// </summary>
     /// <param name="email">The Board member's email.</param>
     /// <param name="name">The Board member's display name.</param>
     /// <param name="date">The date being summarized (e.g. "2026-02-22").</param>
     /// <param name="groups">Tier groups with approved display names.</param>
+    /// <param name="outstandingCounts">Outstanding item counts (personalized per board member).</param>
     /// <param name="culture">The recipient's preferred culture (ISO code, e.g. "es").</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task SendBoardDailyDigestAsync(
@@ -234,6 +235,7 @@ public interface IEmailService
         string name,
         string date,
         IReadOnlyList<BoardDigestTierGroup> groups,
+        BoardDigestOutstandingCounts? outstandingCounts = null,
         string? culture = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Infrastructure/Services/SmtpEmailService.cs
+++ b/src/Humans.Infrastructure/Services/SmtpEmailService.cs
@@ -229,10 +229,11 @@ public class SmtpEmailService : IEmailService
         string name,
         string date,
         IReadOnlyList<BoardDigestTierGroup> groups,
+        BoardDigestOutstandingCounts? outstandingCounts = null,
         string? culture = null,
         CancellationToken cancellationToken = default)
     {
-        var content = _renderer.RenderBoardDailyDigest(name, date, groups, culture);
+        var content = _renderer.RenderBoardDailyDigest(name, date, groups, outstandingCounts, culture);
         await SendEmailAsync(email, content.Subject, content.HtmlBody, cancellationToken);
         _metrics.RecordEmailSent("board_daily_digest");
     }

--- a/src/Humans.Infrastructure/Services/StubEmailService.cs
+++ b/src/Humans.Infrastructure/Services/StubEmailService.cs
@@ -206,12 +206,13 @@ public class StubEmailService : IEmailService
         string name,
         string date,
         IReadOnlyList<BoardDigestTierGroup> groups,
+        BoardDigestOutstandingCounts? outstandingCounts = null,
         string? culture = null,
         CancellationToken cancellationToken = default)
     {
         _logger.LogInformation(
-            "[STUB] Would send Board daily digest to {Email} ({Name}) [Culture: {Culture}] for {Date} with {GroupCount} tier groups",
-            email, name, culture, date, groups.Count);
+            "[STUB] Would send Board daily digest to {Email} ({Name}) [Culture: {Culture}] for {Date} with {GroupCount} tier groups, outstanding: {@Outstanding}",
+            email, name, culture, date, groups.Count, outstandingCounts);
         return Task.CompletedTask;
     }
 }

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -1330,7 +1330,15 @@ public class AdminController : Controller
                 new("Volunteer", new[] { "Alice Johnson", "Bob Smith" }),
                 new("Colaborador", new[] { "Carlos García" })
             };
-            var c15 = renderer.RenderBoardDailyDigest(name, "2026-02-22", sampleDigestGroups, culture);
+            var sampleOutstanding = new BoardDigestOutstandingCounts(
+                OnboardingReview: 3,
+                StillOnboarding: 5,
+                BoardVotingTotal: 7,
+                BoardVotingYours: 4,
+                TeamJoinRequests: 2,
+                PendingConsents: 12,
+                PendingDeletions: 1);
+            var c15 = renderer.RenderBoardDailyDigest(name, "2026-02-22", sampleDigestGroups, sampleOutstanding, culture);
             items.Add(new EmailPreviewItem { Id = "board-daily-digest", Name = "Board Daily Digest", Recipient = email, Subject = c15.Subject, Body = c15.HtmlBody });
 
             previews[culture] = items;

--- a/src/Humans.Web/Extensions/RecurringJobExtensions.cs
+++ b/src/Humans.Web/Extensions/RecurringJobExtensions.cs
@@ -48,7 +48,7 @@ public static class RecurringJobExtensions
         RecurringJob.AddOrUpdate<ProcessGoogleSyncOutboxJob>(
             "process-google-sync-outbox",
             job => job.ExecuteAsync(CancellationToken.None),
-            Cron.Minutely);
+            "*/10 * * * *");
 
         RecurringJob.AddOrUpdate<DriveActivityMonitorJob>(
             "drive-activity-monitor",

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1069,12 +1069,21 @@
 &lt;p&gt;Ohne Verl&#xE4;ngerung bleibst du ein aktiver Human, hast aber keinen {1}-Zugang mehr.&lt;/p&gt;
 &lt;p&gt;Vielen Dank f&#xFC;r dein Engagement!&lt;br/&gt;Das Humans-Team&lt;/p&gt;</value><comment>{0} = user name, {1} = tier name, {2} = expiry date, {3} = base URL</comment></data>
 
-  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>Vorstandsbericht: Neue Genehmigungen am {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
+  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>Vorstandsbericht: {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
 
-  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;T&#xE4;gliche Genehmigungen&lt;/h2&gt;
+  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;Vorstandsbericht &amp;mdash; {1}&lt;/h2&gt;
 &lt;p&gt;Hallo {0},&lt;/p&gt;
-&lt;p&gt;Die folgenden Humans wurden am &lt;strong&gt;{1}&lt;/strong&gt; genehmigt:&lt;/p&gt;
+{3}
 {2}
-&lt;p&gt;Das Humans-Team&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = tier sections HTML</comment></data>
+&lt;p&gt;Das Humans-Team&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = approvals HTML, {3} = outstanding HTML</comment></data>
+
+  <data name="Email_BoardDigest_OutstandingHeader" xml:space="preserve"><value>Offene Punkte</value></data>
+  <data name="Email_BoardDigest_NoApprovals" xml:space="preserve"><value>Gestern gab es keine neuen Genehmigungen.</value></data>
+  <data name="Email_BoardDigest_OnboardingReview" xml:space="preserve"><value>{0} warten auf Onboarding-Pr&#xFC;fung</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_StillOnboarding" xml:space="preserve"><value>{0} schlie&#xDF;en noch das Onboarding ab</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_BoardVoting" xml:space="preserve"><value>{0} Stufenantr&#xE4;ge warten auf Abstimmung ({1} brauchen deine)</value><comment>{0} = total count, {1} = member's unvoted count</comment></data>
+  <data name="Email_BoardDigest_TeamJoinRequests" xml:space="preserve"><value>{0} Team-Beitrittsanfragen ausstehend</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingConsents" xml:space="preserve"><value>{0} mit ausstehenden Einwilligungen</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} Kontol&#xF6;schungen ausstehend</value><comment>{0} = count</comment></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1074,12 +1074,21 @@
 &lt;p&gt;Si no renuevas, seguir&#xE1;s siendo un human activo pero ya no tendr&#xE1;s acceso de nivel {1}.&lt;/p&gt;
 &lt;p&gt;&#xA1;Gracias por tu participaci&#xF3;n!&lt;br/&gt;El equipo de Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = tier name, {2} = expiry date, {3} = base URL</comment></data>
 
-  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>Resumen de la Junta: Nuevas aprobaciones del {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
+  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>Resumen de la Junta: {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
 
-  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;Resumen diario de aprobaciones&lt;/h2&gt;
+  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;Resumen de la Junta &amp;mdash; {1}&lt;/h2&gt;
 &lt;p&gt;Hola {0},&lt;/p&gt;
-&lt;p&gt;Los siguientes humans fueron aprobados el &lt;strong&gt;{1}&lt;/strong&gt;:&lt;/p&gt;
+{3}
 {2}
-&lt;p&gt;El equipo de Humans&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = tier sections HTML</comment></data>
+&lt;p&gt;El equipo de Humans&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = approvals HTML, {3} = outstanding HTML</comment></data>
+
+  <data name="Email_BoardDigest_OutstandingHeader" xml:space="preserve"><value>Elementos pendientes</value></data>
+  <data name="Email_BoardDigest_NoApprovals" xml:space="preserve"><value>No hubo nuevas aprobaciones ayer.</value></data>
+  <data name="Email_BoardDigest_OnboardingReview" xml:space="preserve"><value>{0} en espera de revisi&#xF3;n de incorporaci&#xF3;n</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_StillOnboarding" xml:space="preserve"><value>{0} a&#xFA;n completando la incorporaci&#xF3;n</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_BoardVoting" xml:space="preserve"><value>{0} solicitudes de nivel pendientes de voto ({1} necesitan el tuyo)</value><comment>{0} = total count, {1} = member's unvoted count</comment></data>
+  <data name="Email_BoardDigest_TeamJoinRequests" xml:space="preserve"><value>{0} solicitudes de equipo pendientes</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingConsents" xml:space="preserve"><value>{0} con requisitos de consentimiento pendientes</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} eliminaciones de cuenta pendientes</value><comment>{0} = count</comment></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1069,12 +1069,21 @@
 &lt;p&gt;Sans renouvellement, vous resterez un human actif mais n'aurez plus l'acc&#xE8;s de niveau {1}.&lt;/p&gt;
 &lt;p&gt;Merci pour votre engagement !&lt;br/&gt;L'&#xE9;quipe Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = tier name, {2} = expiry date, {3} = base URL</comment></data>
 
-  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>R&#xE9;sum&#xE9; du conseil : Nouvelles approbations du {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
+  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>R&#xE9;sum&#xE9; du conseil : {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
 
-  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;R&#xE9;sum&#xE9; quotidien des approbations&lt;/h2&gt;
+  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;R&#xE9;sum&#xE9; du conseil &amp;mdash; {1}&lt;/h2&gt;
 &lt;p&gt;Bonjour {0},&lt;/p&gt;
-&lt;p&gt;Les humans suivants ont &#xE9;t&#xE9; approuv&#xE9;s le &lt;strong&gt;{1}&lt;/strong&gt; :&lt;/p&gt;
+{3}
 {2}
-&lt;p&gt;L'&#xE9;quipe Humans&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = tier sections HTML</comment></data>
+&lt;p&gt;L'&#xE9;quipe Humans&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = approvals HTML, {3} = outstanding HTML</comment></data>
+
+  <data name="Email_BoardDigest_OutstandingHeader" xml:space="preserve"><value>&#xC9;l&#xE9;ments en attente</value></data>
+  <data name="Email_BoardDigest_NoApprovals" xml:space="preserve"><value>Aucune nouvelle approbation hier.</value></data>
+  <data name="Email_BoardDigest_OnboardingReview" xml:space="preserve"><value>{0} en attente de v&#xE9;rification d'int&#xE9;gration</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_StillOnboarding" xml:space="preserve"><value>{0} encore en cours d'int&#xE9;gration</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_BoardVoting" xml:space="preserve"><value>{0} candidatures de niveau en attente de vote ({1} n&#xE9;cessitent le v&#xF4;tre)</value><comment>{0} = total count, {1} = member's unvoted count</comment></data>
+  <data name="Email_BoardDigest_TeamJoinRequests" xml:space="preserve"><value>{0} demandes d'adh&#xE9;sion &#xE0; une &#xE9;quipe en attente</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingConsents" xml:space="preserve"><value>{0} avec des exigences de consentement en attente</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} suppressions de compte en attente</value><comment>{0} = count</comment></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1069,12 +1069,21 @@
 &lt;p&gt;Senza rinnovo, rimarrai un human attivo ma non avrai pi&#xF9; l'accesso di livello {1}.&lt;/p&gt;
 &lt;p&gt;Grazie per il tuo impegno!&lt;br/&gt;Il team di Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = tier name, {2} = expiry date, {3} = base URL</comment></data>
 
-  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>Riepilogo del consiglio: Nuove approvazioni del {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
+  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>Riepilogo del consiglio: {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
 
-  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;Riepilogo giornaliero delle approvazioni&lt;/h2&gt;
+  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;Riepilogo del consiglio &amp;mdash; {1}&lt;/h2&gt;
 &lt;p&gt;Ciao {0},&lt;/p&gt;
-&lt;p&gt;I seguenti humans sono stati approvati il &lt;strong&gt;{1}&lt;/strong&gt;:&lt;/p&gt;
+{3}
 {2}
-&lt;p&gt;Il team di Humans&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = tier sections HTML</comment></data>
+&lt;p&gt;Il team di Humans&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = approvals HTML, {3} = outstanding HTML</comment></data>
+
+  <data name="Email_BoardDigest_OutstandingHeader" xml:space="preserve"><value>Elementi in sospeso</value></data>
+  <data name="Email_BoardDigest_NoApprovals" xml:space="preserve"><value>Nessuna nuova approvazione ieri.</value></data>
+  <data name="Email_BoardDigest_OnboardingReview" xml:space="preserve"><value>{0} in attesa di verifica di integrazione</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_StillOnboarding" xml:space="preserve"><value>{0} ancora in fase di integrazione</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_BoardVoting" xml:space="preserve"><value>{0} candidature di livello in attesa di voto ({1} richiedono il tuo)</value><comment>{0} = total count, {1} = member's unvoted count</comment></data>
+  <data name="Email_BoardDigest_TeamJoinRequests" xml:space="preserve"><value>{0} richieste di adesione al team in sospeso</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingConsents" xml:space="preserve"><value>{0} con requisiti di consenso in sospeso</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} eliminazioni di account in sospeso</value><comment>{0} = count</comment></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1069,12 +1069,21 @@
 &lt;p&gt;If you do not renew, you will remain an active human but will no longer have {1}-level access.&lt;/p&gt;
 &lt;p&gt;Thank you for your continued involvement!&lt;br/&gt;The Humans Team&lt;/p&gt;</value><comment>{0} = user name, {1} = tier name, {2} = expiry date, {3} = base URL</comment></data>
 
-  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>Board Digest: New Approvals on {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
+  <data name="Email_BoardDailyDigest_Subject" xml:space="preserve"><value>Board Digest: {0}</value><comment>{0} = date (YYYY-MM-DD)</comment></data>
 
-  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;Daily Approval Digest&lt;/h2&gt;
+  <data name="Email_BoardDailyDigest_Body" xml:space="preserve"><value>&lt;h2&gt;Board Digest &amp;mdash; {1}&lt;/h2&gt;
 &lt;p&gt;Dear {0},&lt;/p&gt;
-&lt;p&gt;The following humans were approved on &lt;strong&gt;{1}&lt;/strong&gt;:&lt;/p&gt;
+{3}
 {2}
-&lt;p&gt;The Humans Team&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = tier sections HTML</comment></data>
+&lt;p&gt;The Humans Team&lt;/p&gt;</value><comment>{0} = board member name, {1} = date, {2} = approvals HTML, {3} = outstanding HTML</comment></data>
+
+  <data name="Email_BoardDigest_OutstandingHeader" xml:space="preserve"><value>Outstanding Items</value></data>
+  <data name="Email_BoardDigest_NoApprovals" xml:space="preserve"><value>No new approvals yesterday.</value></data>
+  <data name="Email_BoardDigest_OnboardingReview" xml:space="preserve"><value>{0} awaiting onboarding review</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_StillOnboarding" xml:space="preserve"><value>{0} still completing onboarding</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_BoardVoting" xml:space="preserve"><value>{0} tier applications awaiting vote ({1} need yours)</value><comment>{0} = total count, {1} = member's unvoted count</comment></data>
+  <data name="Email_BoardDigest_TeamJoinRequests" xml:space="preserve"><value>{0} team join requests pending</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingConsents" xml:space="preserve"><value>{0} with outstanding consent requirements</value><comment>{0} = count</comment></data>
+  <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} account deletions pending</value><comment>{0} = count</comment></data>
 
 </root>


### PR DESCRIPTION
## Summary
- Board daily digest now includes an "Outstanding Items" section with counts for onboarding review, still onboarding, Board voting (personalized per member), team join requests, pending consents, and pending deletions
- Email is sent even with zero approvals if outstanding items exist, turning the digest from a backward-looking report into a daily action nudge
- Google sync outbox job frequency reduced from every 1 minute to every 10 minutes

## Test plan
- [ ] Verify email preview at `/Admin/EmailPreview` renders outstanding section in all 5 locales
- [ ] Trigger `send-board-daily-digest` job via Hangfire dashboard and check stub log output includes counts
- [ ] Confirm digest is still skipped when both approvals and outstanding counts are zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)