### PR TITLE
Fix CI: remove unused Postgres service container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,21 +13,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: humans
-          POSTGRES_PASSWORD: humans
-          POSTGRES_DB: humans_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
     - uses: actions/checkout@v4
 
@@ -44,8 +29,6 @@ jobs:
 
     - name: Test
       run: dotnet test Humans.slnx --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
-      env:
-        ConnectionStrings__DefaultConnection: "Host=localhost;Database=humans_test;Username=humans;Password=humans"
 
     - name: Upload test results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Remove the unused `services.postgres` container and `ConnectionStrings__DefaultConnection` env var from the build workflow

## Problem

Integration tests use **Testcontainers** (ephemeral Postgres per test run), not the workflow's `services.postgres` container. The unused service container and its connection string env var caused app startup components (Hangfire, EF migrations) to connect to the bare service-container DB (no schema) instead of the Testcontainers DB, producing migration FK constraint errors on post-merge push runs.

Fixes #66.

## Test plan

- [ ] CI `build` job passes on this PR (Testcontainers still provide the DB)
- [ ] Post-merge push to `main` no longer fails with migration errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)