### PR TITLE
Restrict board voting finalize to Admin role

### DIFF
--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -424,7 +424,7 @@ public class OnboardingReviewController : Controller
                 .ToList(),
             CurrentUserVote = currentVote?.Vote,
             CurrentUserNote = currentVote?.Note,
-            CanFinalize = isBoard || isAdmin
+            CanFinalize = isAdmin
         };
 
         return View(viewModel);

--- a/src/Humans.Web/Views/OnboardingReview/BoardVotingDetail.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/BoardVotingDetail.cshtml
@@ -155,8 +155,8 @@
 
         @if (Model.CanFinalize)
         {
-            <div class="card mb-4">
-                <div class="card-header">@Localizer["BoardVoting_FinalizeDecision"]</div>
+            <div class="card border-danger mb-4">
+                <div class="card-header text-bg-danger">@Localizer["BoardVoting_FinalizeDecision"]</div>
                 <div class="card-body">
                     <form asp-action="Finalize" method="post">
                         @Html.AntiForgeryToken()


### PR DESCRIPTION
## Summary
- Finalize decision box on Board Voting detail page now only visible to Admin role (was Board + Admin)
- Card styled with red border and header to visually distinguish it as a privileged action

## Test plan
- [ ] Log in as Board member — finalize decision box should not appear
- [ ] Log in as Admin — finalize decision box should appear with red styling
- [ ] Verify approve/reject finalization still works for Admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)