### PR TITLE
Fix role description layout in team roster tables

### DIFF
--- a/src/Humans.Web/Views/Team/Roster.cshtml
+++ b/src/Humans.Web/Views/Team/Roster.cshtml
@@ -79,11 +79,6 @@ else
                                href="#@collapseId" role="button" aria-expanded="false" aria-controls="@collapseId">
                                 <i class="fa-solid fa-chevron-down role-desc-chevron"></i>
                             </a>
-                            <div class="collapse" id="@collapseId">
-                                <div class="role-description small text-muted mt-1">
-                                    @Html.Raw(ConvertMarkdownToHtml(slot.RoleDescription!))
-                                </div>
-                            </div>
                         }
                     </td>
                     <td>@slot.SlotNumber</td>
@@ -99,6 +94,16 @@ else
                         }
                     </td>
                 </tr>
+                @if (isFirstSlotForRole)
+                {
+                    <tr class="collapse" id="@collapseId">
+                        <td colspan="5">
+                            <div class="role-description small text-muted">
+                                @Html.Raw(ConvertMarkdownToHtml(slot.RoleDescription!))
+                            </div>
+                        </td>
+                    </tr>
+                }
             }
         </tbody>
     </table>

--- a/src/Humans.Web/Views/Team/_RosterSection.cshtml
+++ b/src/Humans.Web/Views/Team/_RosterSection.cshtml
@@ -52,11 +52,6 @@
                                                href="#@collapseId" role="button" aria-expanded="false" aria-controls="@collapseId">
                                                 <i class="fa-solid fa-chevron-down role-desc-chevron"></i> Details
                                             </a>
-                                            <div class="collapse" id="@collapseId">
-                                                <div class="role-description small text-muted mt-1">
-                                                    @Html.Raw(ConvertMarkdownToHtml(role.Description))
-                                                </div>
-                                            </div>
                                         }
                                     </td>
                                 }
@@ -71,6 +66,16 @@
                                     {
                                         <span class="text-muted fst-italic">Open</span>
                                     }
+                                </td>
+                            </tr>
+                        }
+                        @if (!string.IsNullOrEmpty(role.Description))
+                        {
+                            <tr class="collapse" id="@collapseId">
+                                <td colspan="4">
+                                    <div class="role-description small text-muted">
+                                        @Html.Raw(ConvertMarkdownToHtml(role.Description))
+                                    </div>
                                 </td>
                             </tr>
                         }


### PR DESCRIPTION
## Summary
- Fix rowspan bug where hidden collapse rows broke table column alignment on teams with many roles
- Role description now expands as a full-width row beneath the role's slots, outside the rowspan, giving it the full table width

## Test plan
- [ ] Check /Teams/participant-wellness — all role names should appear in the correct column
- [ ] Click "Details" chevron — description expands full-width below the role's slots
- [ ] Verify /Teams/Roster expander works the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)