### PR TITLE
fix: remove pagination from teams index page

### DIFF
--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -45,9 +45,8 @@ public class TeamController : Controller
     }
 
     [HttpGet("")]
-    public async Task<IActionResult> Index(int page = 1)
+    public async Task<IActionResult> Index()
     {
-        var pageSize = 12;
         var user = await _userManager.GetUserAsync(User);
         if (user == null)
         {
@@ -83,10 +82,7 @@ public class TeamController : Controller
             .Where(t => !userTeamIds.Contains(t.Id))
             .ToList();
 
-        var totalCount = otherTeams.Count;
         var teams = otherTeams
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
             .Select(ToSummary)
             .ToList();
 
@@ -96,10 +92,7 @@ public class TeamController : Controller
         {
             MyTeams = myTeams,
             Teams = teams,
-            CanCreateTeam = isBoardMember,
-            TotalCount = totalCount,
-            PageNumber = page,
-            PageSize = pageSize
+            CanCreateTeam = isBoardMember
         };
 
         return View(viewModel);

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -9,9 +9,6 @@ public class TeamIndexViewModel
     public List<TeamSummaryViewModel> MyTeams { get; set; } = [];
     public List<TeamSummaryViewModel> Teams { get; set; } = [];
     public bool CanCreateTeam { get; set; }
-    public int TotalCount { get; set; }
-    public int PageNumber { get; set; } = 1;
-    public int PageSize { get; set; } = 12;
 }
 
 public class TeamSummaryViewModel

--- a/src/Humans.Web/Views/Team/Index.cshtml
+++ b/src/Humans.Web/Views/Team/Index.cshtml
@@ -58,18 +58,3 @@ else
         @Localizer["Teams_NoOtherTeams"]
     </div>
 }
-
-@if (Model.TotalCount > Model.PageSize)
-{
-    var totalPages = (int)Math.Ceiling((double)Model.TotalCount / Model.PageSize);
-    <nav class="mt-4">
-        <ul class="pagination justify-content-center">
-            @for (var i = 1; i <= totalPages && i <= 10; i++)
-            {
-                <li class="page-item @(i == Model.PageNumber ? "active" : "")">
-                    <a class="page-link" asp-action="Index" asp-route-page="@i">@i</a>
-                </li>
-            }
-        </ul>
-    </nav>
-}


### PR DESCRIPTION
## Summary
- Removed pagination from the Teams index page — all teams display on a single page
- Cleaned up unused `TotalCount`, `PageNumber`, `PageSize` from view model and controller

## Test plan
- [ ] Verify `/Teams` shows all teams without pagination controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)