### PR TITLE
fix(tickets): align TT API models with real response structure

### DIFF
--- a/src/Humans.Infrastructure/Services/TicketTailorService.cs
+++ b/src/Humans.Infrastructure/Services/TicketTailorService.cs
@@ -84,19 +84,15 @@ public class TicketTailorService : ITicketVendorService
 
             foreach (var order in body.Data)
             {
-                if (!long.TryParse(order.CreatedAt, System.Globalization.CultureInfo.InvariantCulture, out var epochSeconds))
-                {
-                    _logger.LogWarning("Order {OrderId} has unparseable created_at '{CreatedAt}', skipping", order.Id, order.CreatedAt);
-                    continue;
-                }
-                var purchasedAt = Instant.FromUnixTimeSeconds(epochSeconds);
+                var purchasedAt = Instant.FromUnixTimeSeconds(order.CreatedAt);
+                var buyer = order.BuyerDetails;
 
                 orders.Add(new VendorOrderDto(
                     VendorOrderId: order.Id,
-                    BuyerName: $"{order.BuyerFirstName} {order.BuyerLastName}".Trim(),
-                    BuyerEmail: order.BuyerEmail ?? string.Empty,
+                    BuyerName: buyer?.Name ?? $"{buyer?.FirstName} {buyer?.LastName}".Trim(),
+                    BuyerEmail: buyer?.Email ?? string.Empty,
                     TotalAmount: (order.Total ?? 0) / 100m, // TT stores amounts in cents
-                    Currency: order.Currency?.ToUpperInvariant() ?? "EUR",
+                    Currency: order.Currency?.Code?.ToUpperInvariant() ?? "EUR",
                     DiscountCode: order.VoucherCode,
                     PaymentStatus: order.Status ?? "completed",
                     VendorDashboardUrl: null, // TT doesn't expose dashboard URLs via API
@@ -139,10 +135,10 @@ public class TicketTailorService : ITicketVendorService
                 tickets.Add(new VendorTicketDto(
                     VendorTicketId: ticket.Id,
                     VendorOrderId: ticket.OrderId ?? string.Empty,
-                    AttendeeName: $"{ticket.FirstName} {ticket.LastName}".Trim(),
+                    AttendeeName: ticket.FullName ?? $"{ticket.FirstName} {ticket.LastName}".Trim(),
                     AttendeeEmail: ticket.Email,
-                    TicketTypeName: ticket.TicketTypeName ?? "Unknown",
-                    Price: (ticket.Price ?? 0) / 100m,
+                    TicketTypeName: ticket.Description ?? "Unknown",
+                    Price: (ticket.ListedPrice ?? 0) / 100m,
                     Status: ticket.Status ?? "valid"));
             }
 
@@ -163,12 +159,16 @@ public class TicketTailorService : ITicketVendorService
 
         var evt = await response.Content.ReadFromJsonAsync<TtEvent>(JsonOptions, ct);
 
+        // Capacity = sum of quantity_total across all ticket types
+        var totalCapacity = evt?.TicketTypes?.Sum(tt => tt.QuantityTotal ?? 0) ?? 0;
+        var ticketsSold = evt?.TotalIssuedTickets ?? 0;
+
         return new VendorEventSummaryDto(
             EventId: eventId,
             EventName: evt?.Name ?? "Unknown",
-            TotalCapacity: evt?.TotalHolds ?? 0,
-            TicketsSold: evt?.TotalIssuedTickets ?? 0,
-            TicketsRemaining: (evt?.TotalHolds ?? 0) - (evt?.TotalIssuedTickets ?? 0));
+            TotalCapacity: totalCapacity,
+            TicketsSold: ticketsSold,
+            TicketsRemaining: totalCapacity - ticketsSold);
     }
 
     public async Task<IReadOnlyList<string>> GenerateDiscountCodesAsync(
@@ -239,29 +239,44 @@ public class TicketTailorService : ITicketVendorService
 
     internal sealed record TtOrder(
         [property: JsonPropertyName("id")] string Id,
-        [property: JsonPropertyName("buyer_first_name")] string? BuyerFirstName,
-        [property: JsonPropertyName("buyer_last_name")] string? BuyerLastName,
-        [property: JsonPropertyName("buyer_email")] string? BuyerEmail,
+        [property: JsonPropertyName("buyer_details")] TtBuyerDetails? BuyerDetails,
         [property: JsonPropertyName("total")] int? Total,
-        [property: JsonPropertyName("currency")] string? Currency,
+        [property: JsonPropertyName("currency")] TtCurrency? Currency,
         [property: JsonPropertyName("voucher_code")] string? VoucherCode,
         [property: JsonPropertyName("status")] string? Status,
-        [property: JsonPropertyName("created_at")] string CreatedAt);
+        [property: JsonPropertyName("created_at")] long CreatedAt);
+
+    internal sealed record TtBuyerDetails(
+        [property: JsonPropertyName("first_name")] string? FirstName,
+        [property: JsonPropertyName("last_name")] string? LastName,
+        [property: JsonPropertyName("email")] string? Email,
+        [property: JsonPropertyName("name")] string? Name);
+
+    internal sealed record TtCurrency(
+        [property: JsonPropertyName("code")] string? Code,
+        [property: JsonPropertyName("base_multiplier")] int? BaseMultiplier);
 
     internal sealed record TtIssuedTicket(
         [property: JsonPropertyName("id")] string Id,
         [property: JsonPropertyName("first_name")] string? FirstName,
         [property: JsonPropertyName("last_name")] string? LastName,
+        [property: JsonPropertyName("full_name")] string? FullName,
         [property: JsonPropertyName("email")] string? Email,
-        [property: JsonPropertyName("ticket_type_name")] string? TicketTypeName,
-        [property: JsonPropertyName("price")] int? Price,
+        [property: JsonPropertyName("description")] string? Description,
+        [property: JsonPropertyName("listed_price")] int? ListedPrice,
         [property: JsonPropertyName("status")] string? Status,
         [property: JsonPropertyName("order_id")] string? OrderId);
 
     internal sealed record TtEvent(
         [property: JsonPropertyName("name")] string? Name,
         [property: JsonPropertyName("total_holds")] int? TotalHolds,
-        [property: JsonPropertyName("total_issued_tickets")] int? TotalIssuedTickets);
+        [property: JsonPropertyName("total_issued_tickets")] int? TotalIssuedTickets,
+        [property: JsonPropertyName("total_orders")] int? TotalOrders,
+        [property: JsonPropertyName("ticket_types")] List<TtTicketType>? TicketTypes);
+
+    internal sealed record TtTicketType(
+        [property: JsonPropertyName("quantity_total")] int? QuantityTotal,
+        [property: JsonPropertyName("quantity_issued")] int? QuantityIssued);
 
     internal sealed record TtVoucherCode(
         [property: JsonPropertyName("code")] string? Code,

--- a/tests/Humans.Application.Tests/Services/TicketTailorServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketTailorServiceTests.cs
@@ -35,14 +35,12 @@ public class TicketTailorServiceTests
                 new
                 {
                     id = "ord_001",
-                    buyer_first_name = "Jane",
-                    buyer_last_name = "Doe",
-                    buyer_email = "jane@example.com",
+                    buyer_details = new { first_name = "Jane", last_name = "Doe", email = "jane@example.com", name = "Jane Doe" },
                     total = 15000,
-                    currency = "eur",
+                    currency = new { code = "eur", base_multiplier = 100 },
                     voucher_code = "NOBO25",
                     status = "completed",
-                    created_at = "1716811200"
+                    created_at = 1716811200L
                 }
             },
             links = new { next = (string?)null }
@@ -67,9 +65,10 @@ public class TicketTailorServiceTests
             {
                 new
                 {
-                    id = "ord_001", buyer_first_name = "A", buyer_last_name = "B",
-                    buyer_email = "a@b.com", total = 100, currency = "eur",
-                    voucher_code = (string?)null, status = "completed", created_at = "1716811200"
+                    id = "ord_001",
+                    buyer_details = new { first_name = "A", last_name = "B", email = "a@b.com", name = "A B" },
+                    total = 100, currency = new { code = "eur", base_multiplier = 100 },
+                    voucher_code = (string?)null, status = "completed", created_at = 1716811200L
                 }
             },
             links = new { next = "has_more" }
@@ -80,9 +79,10 @@ public class TicketTailorServiceTests
             {
                 new
                 {
-                    id = "ord_002", buyer_first_name = "C", buyer_last_name = "D",
-                    buyer_email = "c@d.com", total = 200, currency = "eur",
-                    voucher_code = (string?)null, status = "completed", created_at = "1716811200"
+                    id = "ord_002",
+                    buyer_details = new { first_name = "C", last_name = "D", email = "c@d.com", name = "C D" },
+                    total = 200, currency = new { code = "eur", base_multiplier = 100 },
+                    voucher_code = (string?)null, status = "completed", created_at = 1716811200L
                 }
             },
             links = new { next = (string?)null }
@@ -119,9 +119,10 @@ public class TicketTailorServiceTests
                     id = "it_001",
                     first_name = "Jane",
                     last_name = "Doe",
+                    full_name = "Jane Doe",
                     email = "jane@example.com",
-                    ticket_type_name = "Full Week",
-                    price = 15000,
+                    description = "Full Week",
+                    listed_price = 15000,
                     status = "valid",
                     order_id = "ord_001"
                 }
@@ -145,18 +146,25 @@ public class TicketTailorServiceTests
         var handler = new MockHttpHandler();
         handler.EnqueueResponse(HttpStatusCode.OK, new
         {
-            name = "Nowhere 2026",
-            total_holds = 3000,
-            total_issued_tickets = 1847
+            name = "Elsewhere 2026",
+            total_holds = 0,
+            total_issued_tickets = 96,
+            total_orders = 88,
+            ticket_types = new[]
+            {
+                new { quantity_total = 2000, quantity_issued = 86 },
+                new { quantity_total = 500, quantity_issued = 6 },
+                new { quantity_total = 500, quantity_issued = 4 },
+            }
         });
 
         var service = CreateService(handler);
         var summary = await service.GetEventSummaryAsync("ev_test");
 
-        summary.EventName.Should().Be("Nowhere 2026");
+        summary.EventName.Should().Be("Elsewhere 2026");
         summary.TotalCapacity.Should().Be(3000);
-        summary.TicketsSold.Should().Be(1847);
-        summary.TicketsRemaining.Should().Be(1153);
+        summary.TicketsSold.Should().Be(96);
+        summary.TicketsRemaining.Should().Be(2904);
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixed TicketTailor API response model mismatches discovered by sniff-testing against the live API
- `buyer_details` is a nested object, not flat fields
- `currency` is an object `{code, base_multiplier}`, not a string
- `created_at` is a long (unix epoch), not a string
- Ticket type name field is `description`, not `ticket_type_name`
- Ticket price field is `listed_price`, not `price`
- Event capacity computed from `ticket_types[].quantity_total` (not `total_holds` which is always 0)
- Also includes deploy-qa.sh --no-pull guard and Admin Configuration page ticket vendor settings

## Test plan

- [x] 13 ticket tests passing with corrected mock data matching real TT API shapes
- [x] 432 total unit tests passing
- [x] Build succeeds with 0 errors, 0 warnings
- [ ] Verify sync runs successfully in production with real API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)