### PR TITLE
feat(tickets): add Full Re-sync button

### DIFF
--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -508,6 +508,23 @@ public class TicketController : Controller
         return RedirectToAction(nameof(Index));
     }
 
+    [HttpPost("FullResync")]
+    [ValidateAntiForgeryToken]
+    [Authorize(Roles = RoleNames.Admin)]
+    public async Task<IActionResult> FullResync()
+    {
+        var syncState = await _dbContext.TicketSyncStates.FindAsync(1);
+        if (syncState != null)
+        {
+            syncState.LastSyncAt = null;
+            await _dbContext.SaveChangesAsync();
+        }
+
+        BackgroundJob.Enqueue<TicketSyncJob>(job => job.ExecuteAsync(CancellationToken.None));
+        TempData["SuccessMessage"] = "Full re-sync triggered. All orders will be re-fetched.";
+        return RedirectToAction(nameof(Index));
+    }
+
     [HttpGet("Export/Attendees")]
     [Authorize(Roles = $"{RoleNames.TicketAdmin},{RoleNames.Admin}")]
     public async Task<IActionResult> ExportAttendees()

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -208,6 +208,16 @@
                         <i class="fa-solid fa-sync"></i> Sync Now
                     </button>
                 </form>
+                @if (User.IsInRole(Humans.Domain.Constants.RoleNames.Admin))
+                {
+                    <form asp-action="FullResync" method="post" class="d-inline ms-2"
+                          onsubmit="return confirm('This will re-fetch ALL orders from the vendor. Continue?');">
+                        @Html.AntiForgeryToken()
+                        <button type="submit" class="btn btn-sm btn-danger">
+                            <i class="fa-solid fa-arrows-rotate"></i> Full Re-sync
+                        </button>
+                    </form>
+                }
             }
         </div>
     </div>


### PR DESCRIPTION
## Summary

- Admin-only red "Full Re-sync" button on Tickets dashboard
- Resets `LastSyncAt` to null so next sync re-fetches ALL orders
- Needed now: previous syncs stored orders without discount codes (extraction fix was deployed after initial sync)
- Confirmation dialog before triggering

## Test plan

- [x] Build clean
- [ ] Click Full Re-sync in prod, verify discount codes populate on orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)