### PR TITLE
feat: send workspace credentials email on provisioning

### DIFF
--- a/src/Humans.Application/Interfaces/IEmailRenderer.cs
+++ b/src/Humans.Application/Interfaces/IEmailRenderer.cs
@@ -115,4 +115,9 @@ public interface IEmailRenderer
     /// Magic link signup email for a new user.
     /// </summary>
     EmailContent RenderMagicLinkSignup(string magicLinkUrl, string? culture = null);
+
+    /// <summary>
+    /// Workspace credentials email sent after provisioning a @nobodies.team account.
+    /// </summary>
+    EmailContent RenderWorkspaceCredentials(string userName, string workspaceEmail, string tempPassword, string? culture = null);
 }

--- a/src/Humans.Application/Interfaces/IEmailService.cs
+++ b/src/Humans.Application/Interfaces/IEmailService.cs
@@ -280,4 +280,15 @@ public interface IEmailService
         string magicLinkUrl,
         string? culture = null,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Sends workspace credentials to the user's recovery email after provisioning a @nobodies.team account.
+    /// </summary>
+    Task SendWorkspaceCredentialsAsync(
+        string recoveryEmail,
+        string userName,
+        string workspaceEmail,
+        string tempPassword,
+        string? culture = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Infrastructure/Services/EmailRenderer.cs
+++ b/src/Humans.Infrastructure/Services/EmailRenderer.cs
@@ -445,6 +445,21 @@ public class EmailRenderer : IEmailRenderer
         }
     }
 
+    public EmailContent RenderWorkspaceCredentials(string userName, string workspaceEmail, string tempPassword, string? culture = null)
+    {
+        using (WithCulture(culture))
+        {
+            var subject = _localizer["Email_WorkspaceCredentials_Subject"].Value;
+            var body = string.Format(
+                CultureInfo.CurrentCulture,
+                _localizer["Email_WorkspaceCredentials_Body"].Value,
+                HtmlEncode(userName),
+                HtmlEncode(workspaceEmail),
+                HtmlEncode(tempPassword));
+            return new EmailContent(subject, body);
+        }
+    }
+
     private CultureScope WithCulture(string? culture)
     {
         return new CultureScope(culture, _logger);

--- a/src/Humans.Infrastructure/Services/OutboxEmailService.cs
+++ b/src/Humans.Infrastructure/Services/OutboxEmailService.cs
@@ -299,6 +299,20 @@ public class OutboxEmailService : IEmailService
             triggerImmediate: true);
     }
 
+    /// <inheritdoc />
+    public async Task SendWorkspaceCredentialsAsync(
+        string recoveryEmail,
+        string userName,
+        string workspaceEmail,
+        string tempPassword,
+        string? culture = null,
+        CancellationToken cancellationToken = default)
+    {
+        var content = _renderer.RenderWorkspaceCredentials(userName, workspaceEmail, tempPassword, culture);
+        await EnqueueAsync(recoveryEmail, userName, content, "workspace_credentials", cancellationToken,
+            triggerImmediate: true);
+    }
+
     private async Task EnqueueAsync(
         string recipientEmail,
         string recipientName,

--- a/src/Humans.Infrastructure/Services/SmtpEmailService.cs
+++ b/src/Humans.Infrastructure/Services/SmtpEmailService.cs
@@ -288,6 +288,15 @@ public class SmtpEmailService : IEmailService
         _metrics.RecordEmailSent("magic_link_signup");
     }
 
+    public async Task SendWorkspaceCredentialsAsync(
+        string recoveryEmail, string userName, string workspaceEmail, string tempPassword,
+        string? culture = null, CancellationToken cancellationToken = default)
+    {
+        var content = _renderer.RenderWorkspaceCredentials(userName, workspaceEmail, tempPassword, culture);
+        await SendEmailAsync(recoveryEmail, content.Subject, content.HtmlBody, cancellationToken);
+        _metrics.RecordEmailSent("workspace_credentials");
+    }
+
     private async Task SendEmailAsync(
         string toAddress,
         string subject,

--- a/src/Humans.Infrastructure/Services/StubEmailService.cs
+++ b/src/Humans.Infrastructure/Services/StubEmailService.cs
@@ -262,4 +262,12 @@ public class StubEmailService : IEmailService
         _logger.LogInformation("[STUB] Would send magic link signup to {Email}", toEmail);
         return Task.CompletedTask;
     }
+
+    public Task SendWorkspaceCredentialsAsync(
+        string recoveryEmail, string userName, string workspaceEmail, string tempPassword,
+        string? culture = null, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("[STUB] Would send workspace credentials for {WorkspaceEmail} to {RecoveryEmail}", workspaceEmail, recoveryEmail);
+        return Task.CompletedTask;
+    }
 }

--- a/src/Humans.Web/Controllers/HumanController.cs
+++ b/src/Humans.Web/Controllers/HumanController.cs
@@ -486,7 +486,15 @@ public class HumanController : HumansControllerBase
                 await _dbContext.SaveChangesAsync();
             }
 
-            SetSuccess($"Account {fullEmail} provisioned and linked. Temporary password: {tempPassword}");
+            // Send credentials to recovery email
+            if (!string.IsNullOrEmpty(recoveryEmail))
+            {
+                await _emailService.SendWorkspaceCredentialsAsync(
+                    recoveryEmail, user.DisplayName, fullEmail, tempPassword,
+                    user.PreferredLanguage);
+            }
+
+            SetSuccess($"Account {fullEmail} provisioned and linked. Credentials sent to {recoveryEmail}.");
         }
         catch (Exception ex)
         {

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1203,6 +1203,17 @@
 
   <data name="MagicLinkSent_Message" xml:space="preserve"><value>Wir haben einen Link an diese E-Mail-Adresse von humans@nobodies.team gesendet. Überprüfen Sie Ihren Posteingang (und den Spam-Ordner).</value></data>
 
+  <!-- Workspace Credentials -->
+  <data name="Email_WorkspaceCredentials_Subject" xml:space="preserve"><value>Dein @nobodies.team-Konto ist bereit</value></data>
+  <data name="Email_WorkspaceCredentials_Body" xml:space="preserve"><value>&lt;h2&gt;Dein @nobodies.team-Konto ist bereit&lt;/h2&gt;
+&lt;p&gt;Hallo {0},&lt;/p&gt;
+&lt;p&gt;Dein Google Workspace-Konto wurde erstellt:&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Benutzername:&lt;/strong&gt; {1}&lt;br/&gt;
+&lt;strong&gt;Temporäres Passwort:&lt;/strong&gt; {2}&lt;/p&gt;
+&lt;p&gt;Melde dich bei &lt;a href="https://mail.google.com/"&gt;mail.google.com&lt;/a&gt; an — du wirst beim ersten Login aufgefordert, dein Passwort zu ändern.&lt;/p&gt;
+&lt;p&gt;Unsere Organisation hat die Zwei-Faktor-Authentifizierung (2FA) aktiviert. Du musst beim Anmelden auch einen zweiten Faktor einrichten (z.B. ein Telefon oder eine Authenticator-App).&lt;/p&gt;
+&lt;p&gt;Das Humans-Team&lt;/p&gt;</value><comment>{0} = user name, {1} = workspace email, {2} = temporary password</comment></data>
+
   <!-- Camp Cards -->
   <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>Dieses Barrio braucht ein Foto!</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1223,6 +1223,17 @@
 
   <data name="MagicLinkSent_Message" xml:space="preserve"><value>Hemos enviado un enlace a esa dirección de correo desde humans@nobodies.team. Revisa tu bandeja de entrada (y la carpeta de spam).</value></data>
 
+  <!-- Workspace Credentials -->
+  <data name="Email_WorkspaceCredentials_Subject" xml:space="preserve"><value>Tu cuenta @nobodies.team está lista</value></data>
+  <data name="Email_WorkspaceCredentials_Body" xml:space="preserve"><value>&lt;h2&gt;Tu cuenta @nobodies.team está lista&lt;/h2&gt;
+&lt;p&gt;Hola {0},&lt;/p&gt;
+&lt;p&gt;Tu cuenta de Google Workspace ha sido creada:&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Usuario:&lt;/strong&gt; {1}&lt;br/&gt;
+&lt;strong&gt;Contraseña temporal:&lt;/strong&gt; {2}&lt;/p&gt;
+&lt;p&gt;Inicia sesión en &lt;a href="https://mail.google.com/"&gt;mail.google.com&lt;/a&gt; y se te pedirá cambiar tu contraseña en el primer inicio de sesión.&lt;/p&gt;
+&lt;p&gt;Nuestra organización tiene la autenticación en dos pasos (2FA) activada, por lo que también tendrás que configurar un segundo factor (como un teléfono o una app de autenticación) durante el inicio de sesión.&lt;/p&gt;
+&lt;p&gt;El equipo de Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = workspace email, {2} = temporary password</comment></data>
+
   <!-- Camp Cards -->
   <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>¡Este barrio necesita una foto!</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1203,6 +1203,17 @@
 
   <data name="MagicLinkSent_Message" xml:space="preserve"><value>Nous avons envoyé un lien à cette adresse e-mail depuis humans@nobodies.team. Vérifiez votre boîte de réception (et le dossier spam).</value></data>
 
+  <!-- Workspace Credentials -->
+  <data name="Email_WorkspaceCredentials_Subject" xml:space="preserve"><value>Ton compte @nobodies.team est prêt</value></data>
+  <data name="Email_WorkspaceCredentials_Body" xml:space="preserve"><value>&lt;h2&gt;Ton compte @nobodies.team est prêt&lt;/h2&gt;
+&lt;p&gt;Bonjour {0},&lt;/p&gt;
+&lt;p&gt;Ton compte Google Workspace a été créé :&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Nom d'utilisateur :&lt;/strong&gt; {1}&lt;br/&gt;
+&lt;strong&gt;Mot de passe temporaire :&lt;/strong&gt; {2}&lt;/p&gt;
+&lt;p&gt;Connecte-toi sur &lt;a href="https://mail.google.com/"&gt;mail.google.com&lt;/a&gt; — tu devras changer ton mot de passe lors de la première connexion.&lt;/p&gt;
+&lt;p&gt;Notre organisation a l'authentification à deux facteurs (2FA) activée. Tu devras également configurer un second facteur (comme un téléphone ou une application d'authentification) lors de la connexion.&lt;/p&gt;
+&lt;p&gt;L'équipe Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = workspace email, {2} = temporary password</comment></data>
+
   <!-- Camp Cards -->
   <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>Ce barrio a besoin d'une photo !</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1203,6 +1203,17 @@
 
   <data name="MagicLinkSent_Message" xml:space="preserve"><value>Abbiamo inviato un link a quell'indirizzo email da humans@nobodies.team. Controlla la posta in arrivo (e la cartella spam).</value></data>
 
+  <!-- Workspace Credentials -->
+  <data name="Email_WorkspaceCredentials_Subject" xml:space="preserve"><value>Il tuo account @nobodies.team è pronto</value></data>
+  <data name="Email_WorkspaceCredentials_Body" xml:space="preserve"><value>&lt;h2&gt;Il tuo account @nobodies.team è pronto&lt;/h2&gt;
+&lt;p&gt;Ciao {0},&lt;/p&gt;
+&lt;p&gt;Il tuo account Google Workspace è stato creato:&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Nome utente:&lt;/strong&gt; {1}&lt;br/&gt;
+&lt;strong&gt;Password temporanea:&lt;/strong&gt; {2}&lt;/p&gt;
+&lt;p&gt;Accedi su &lt;a href="https://mail.google.com/"&gt;mail.google.com&lt;/a&gt; — ti verrà chiesto di cambiare la password al primo accesso.&lt;/p&gt;
+&lt;p&gt;La nostra organizzazione ha l'autenticazione a due fattori (2FA) attivata. Dovrai anche configurare un secondo fattore (come un telefono o un'app di autenticazione) durante l'accesso.&lt;/p&gt;
+&lt;p&gt;Il team di Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = workspace email, {2} = temporary password</comment></data>
+
   <!-- Camp Cards -->
   <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>Questo barrio ha bisogno di una foto!</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1248,6 +1248,17 @@
   <data name="MagicLinkConfirm_Message" xml:space="preserve"><value>Click the button below to sign in to your account.</value></data>
   <data name="MagicLinkConfirm_SignIn" xml:space="preserve"><value>Sign in</value></data>
 
+  <!-- Workspace Credentials -->
+  <data name="Email_WorkspaceCredentials_Subject" xml:space="preserve"><value>Your @nobodies.team account is ready</value></data>
+  <data name="Email_WorkspaceCredentials_Body" xml:space="preserve"><value>&lt;h2&gt;Your @nobodies.team account is ready&lt;/h2&gt;
+&lt;p&gt;Hi {0},&lt;/p&gt;
+&lt;p&gt;Your Google Workspace account has been created:&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;Username:&lt;/strong&gt; {1}&lt;br/&gt;
+&lt;strong&gt;Temporary password:&lt;/strong&gt; {2}&lt;/p&gt;
+&lt;p&gt;Sign in at &lt;a href="https://mail.google.com/"&gt;mail.google.com&lt;/a&gt; and you will be asked to change your password on first login.&lt;/p&gt;
+&lt;p&gt;Our organization has two-factor authentication (2FA) enabled, so you will also need to set up a second factor (such as a phone or authenticator app) during sign-in.&lt;/p&gt;
+&lt;p&gt;The Humans team&lt;/p&gt;</value><comment>{0} = user name, {1} = workspace email, {2} = temporary password</comment></data>
+
   <!-- Camp Cards -->
   <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>This barrio needs a photo!</value></data>
 


### PR DESCRIPTION
## Summary
- After provisioning a @nobodies.team Google Workspace account, automatically sends the username, temporary password, and login link to the user's recovery (personal) email
- Includes note about mandatory 2FA setup
- Localized in all 5 locales (en/es/de/fr/it)
- Uses `triggerImmediate: true` so the email goes out right away via the outbox

## Test plan
- [ ] Provision a @nobodies.team account for a user with a recovery email set
- [ ] Verify the credentials email arrives at the recovery address
- [ ] Verify email contains correct username, temp password, mail.google.com link, and 2FA note
- [ ] Verify admin success message now says "Credentials sent to {email}" instead of showing the password
- [ ] Verify localized email content for non-English users

🤖 Generated with [Claude Code](https://claude.com/claude-code)