### PR TITLE
feat: add site policies page for app-specific legal disclosures (#56)

### DIFF
--- a/src/Humans.Infrastructure/Services/LegalDocumentService.cs
+++ b/src/Humans.Infrastructure/Services/LegalDocumentService.cs
@@ -14,6 +14,7 @@ public partial class LegalDocumentService : ILegalDocumentService
     private static readonly IReadOnlyList<LegalDocumentDefinition> Documents =
     [
         new("statutes", "Statutes", "Estatutos", "ESTATUTOS"),
+        new("privacy-policy", "Privacy Policy", "PrivacyPolicy", "PRIVACY-POLICY"),
     ];
 
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(1);

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -21,6 +21,7 @@ public class HomeController : HumansControllerBase
     private readonly IClock _clock;
     private readonly TicketVendorSettings _ticketSettings;
     private readonly ITicketQueryService _ticketQueryService;
+    private readonly ILegalDocumentService _legalDocService;
     private readonly ILogger<HomeController> _logger;
 
     public HomeController(
@@ -34,6 +35,7 @@ public class HomeController : HumansControllerBase
         IClock clock,
         IOptions<TicketVendorSettings> ticketSettings,
         ITicketQueryService ticketQueryService,
+        ILegalDocumentService legalDocService,
         ILogger<HomeController> logger)
         : base(userManager)
     {
@@ -46,6 +48,7 @@ public class HomeController : HumansControllerBase
         _clock = clock;
         _ticketSettings = ticketSettings.Value;
         _ticketQueryService = ticketQueryService;
+        _legalDocService = legalDocService;
         _logger = logger;
     }
 
@@ -245,10 +248,16 @@ public class HomeController : HumansControllerBase
         return View("Dashboard", viewModel);
     }
 
-    public IActionResult Privacy()
+    public async Task<IActionResult> Privacy()
     {
-        ViewData["DpoEmail"] = _configuration["Email:DpoAddress"];
-        return View();
+        var privacyContent = await _legalDocService.GetDocumentContentAsync("privacy-policy");
+        var viewModel = new SitePoliciesViewModel
+        {
+            PrivacyPolicyContent = privacyContent,
+            DpoEmail = _configuration["Email:DpoAddress"] ?? string.Empty,
+            SupportEmail = _configuration["Email:AdminAddress"] ?? string.Empty
+        };
+        return View(viewModel);
     }
 
     public IActionResult About()

--- a/src/Humans.Web/Models/SitePoliciesViewModel.cs
+++ b/src/Humans.Web/Models/SitePoliciesViewModel.cs
@@ -1,0 +1,19 @@
+namespace Humans.Web.Models;
+
+public class SitePoliciesViewModel
+{
+    /// <summary>
+    /// Privacy policy content by language code (e.g., "es" → markdown, "en" → markdown).
+    /// </summary>
+    public Dictionary<string, string> PrivacyPolicyContent { get; set; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// DPO email address from configuration.
+    /// </summary>
+    public string DpoEmail { get; set; } = string.Empty;
+
+    /// <summary>
+    /// General support email for app-related inquiries.
+    /// </summary>
+    public string SupportEmail { get; set; } = string.Empty;
+}

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -59,7 +59,7 @@
   <data name="Nav_Roster" xml:space="preserve"><value>Dienstplan</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Vereinbarungen</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Governance</value></data>
-  <data name="Nav_Privacy" xml:space="preserve"><value>Datenschutz</value></data>
+  <data name="Nav_Privacy" xml:space="preserve"><value>Website-Richtlinien</value></data>
   <data name="Nav_About" xml:space="preserve"><value>&#xDC;ber uns</value></data>
   <data name="Nav_Admin" xml:space="preserve"><value>Admin</value></data>
   <data name="Nav_OnboardingReview" xml:space="preserve"><value>Pr&#xFC;fwarteschlange</value></data>
@@ -164,9 +164,26 @@
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Grund</value></data>
 
   <!-- ======================== -->
-  <!-- Privacy Policy Page      -->
+  <!-- Site Policies Page       -->
   <!-- ======================== -->
   <data name="Privacy_Title" xml:space="preserve"><value>Datenschutzrichtlinie</value></data>
+  <data name="SitePolicies_Title" xml:space="preserve"><value>Website-Richtlinien</value></data>
+  <data name="SitePolicies_Lead" xml:space="preserve"><value>Wie Humans Ihre Daten verwaltet und wie diese Website funktioniert.</value></data>
+  <data name="SitePolicies_DisclosuresTitle" xml:space="preserve"><value>Wie diese Website funktioniert</value></data>
+  <data name="SitePolicies_DelegatedAccessTitle" xml:space="preserve"><value>Delegierte Zugriffsrollen</value></data>
+  <data name="SitePolicies_DelegatedAccessText" xml:space="preserve"><value>Der Vorstand kann &lt;strong&gt;Einwilligungskoordinatoren&lt;/strong&gt; und &lt;strong&gt;Freiwilligenkoordinatoren&lt;/strong&gt; ernennen, die erweiterten Zugriff auf Mitgliederdaten (Profildetails, Onboarding-Status) erhalten, um ihre Aufgaben zu erf&#xFC;llen. Diese Rollenzuweisungen werden protokolliert und gepr&#xFC;ft.</value></data>
+  <data name="SitePolicies_VisibilityTitle" xml:space="preserve"><value>Datensichtbarkeit</value></data>
+  <data name="SitePolicies_VisibilityIntro" xml:space="preserve"><value>Wenn Sie Kontaktinformationen zu Ihrem Profil hinzuf&#xFC;gen, w&#xE4;hlen Sie, wer jedes Feld sehen kann. Die Sichtbarkeitsstufen sind:</value></data>
+  <data name="SitePolicies_VisibilityBoardOnly" xml:space="preserve"><value>Nur f&#xFC;r Vorstandsmitglieder sichtbar.</value></data>
+  <data name="SitePolicies_VisibilityCoordinatorsAndBoard" xml:space="preserve"><value>Sichtbar f&#xFC;r Team-Koordinatoren und Vorstandsmitglieder.</value></data>
+  <data name="SitePolicies_VisibilityMyTeams" xml:space="preserve"><value>Sichtbar f&#xFC;r Humans, die mindestens ein Team mit Ihnen teilen.</value></data>
+  <data name="SitePolicies_VisibilityAllActive" xml:space="preserve"><value>Sichtbar f&#xFC;r alle aktiven Humans in der Organisation.</value></data>
+  <data name="SitePolicies_ProvisioningTitle" xml:space="preserve"><value>Automatisierte Verarbeitung</value></data>
+  <data name="SitePolicies_ProvisioningText" xml:space="preserve"><value>Wenn Sie einem Team beitreten oder es verlassen, stellt das System automatisch den Zugang zu den entsprechenden Google-Workspace-Ressourcen (freigegebene Drive-Ordner und Google Groups) bereit oder entfernt ihn. Diese &#xC4;nderungen werden im Audit-Protokoll erfasst.</value></data>
+  <data name="SitePolicies_ContactTitle" xml:space="preserve"><value>Kontakt</value></data>
+  <data name="SitePolicies_ContactText" xml:space="preserve"><value>Bei Fragen oder Problemen mit der Anwendung kontaktieren Sie uns unter</value></data>
+  <data name="SitePolicies_DpoText" xml:space="preserve"><value>F&#xFC;r formelle Datenschutzanfragen kontaktieren Sie unseren Datenschutzbeauftragten unter</value></data>
+  <data name="SitePolicies_ManageData" xml:space="preserve"><value>Verwalten Sie Ihre pers&#xF6;nlichen Daten</value></data>
 
   <!-- ======================== -->
   <!-- Profile                  -->
@@ -267,7 +284,7 @@
   <data name="ProfilePrivacy_CancelDeletion" xml:space="preserve"><value>Löschantrag zurückziehen</value></data>
   <data name="ProfilePrivacy_DPOContact" xml:space="preserve"><value>Bei Fragen zu Ihren Daten oder Datenschutzrechten wenden Sie sich an unseren Datenschutzbeauftragten:</value></data>
   <data name="ProfilePrivacy_Email" xml:space="preserve"><value>E-Mail:</value></data>
-  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>Vollständige Datenschutzrichtlinie anzeigen</value></data>
+  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>Website-Richtlinien anzeigen</value></data>
   <data name="ProfilePrivacy_ConfirmDeletion" xml:space="preserve"><value>Kontolöschung bestätigen</value></data>
   <data name="ProfilePrivacy_ConfirmDeletionQuestion" xml:space="preserve"><value>Sind Sie sicher, dass Sie die Löschung Ihres Kontos beantragen möchten?</value></data>
   <data name="ProfilePrivacy_YesDeleteMyAccount" xml:space="preserve"><value>Ja, mein Konto löschen</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -59,7 +59,7 @@
   <data name="Nav_Roster" xml:space="preserve"><value>Lista</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Acuerdos</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Gobernanza</value></data>
-  <data name="Nav_Privacy" xml:space="preserve"><value>Privacidad</value></data>
+  <data name="Nav_Privacy" xml:space="preserve"><value>Pol&#xED;ticas del sitio</value></data>
   <data name="Nav_About" xml:space="preserve"><value>Acerca de</value></data>
   <data name="Nav_Admin" xml:space="preserve"><value>Admin</value></data>
   <data name="Nav_OnboardingReview" xml:space="preserve"><value>Cola de revisi&#xF3;n</value></data>
@@ -164,9 +164,26 @@
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motivo</value></data>
 
   <!-- ======================== -->
-  <!-- Privacy Policy Page      -->
+  <!-- Site Policies Page       -->
   <!-- ======================== -->
   <data name="Privacy_Title" xml:space="preserve"><value>Pol&#xED;tica de privacidad</value></data>
+  <data name="SitePolicies_Title" xml:space="preserve"><value>Pol&#xED;ticas del sitio</value></data>
+  <data name="SitePolicies_Lead" xml:space="preserve"><value>C&#xF3;mo Humans gestiona tus datos y c&#xF3;mo funciona este sitio.</value></data>
+  <data name="SitePolicies_DisclosuresTitle" xml:space="preserve"><value>C&#xF3;mo funciona este sitio</value></data>
+  <data name="SitePolicies_DelegatedAccessTitle" xml:space="preserve"><value>Roles de acceso delegado</value></data>
+  <data name="SitePolicies_DelegatedAccessText" xml:space="preserve"><value>La Junta puede designar &lt;strong&gt;Coordinadores de Consentimiento&lt;/strong&gt; y &lt;strong&gt;Coordinadores de Voluntarios&lt;/strong&gt; que reciben acceso elevado a los datos de los miembros (detalles del perfil, estado de incorporaci&#xF3;n) para desempe&#xF1;ar sus funciones. Estas asignaciones de roles se registran y auditan.</value></data>
+  <data name="SitePolicies_VisibilityTitle" xml:space="preserve"><value>Visibilidad de datos</value></data>
+  <data name="SitePolicies_VisibilityIntro" xml:space="preserve"><value>Cuando a&#xF1;ades informaci&#xF3;n de contacto a tu perfil, eliges qui&#xE9;n puede ver cada campo. Los niveles de visibilidad son:</value></data>
+  <data name="SitePolicies_VisibilityBoardOnly" xml:space="preserve"><value>Solo visible para miembros de la Junta.</value></data>
+  <data name="SitePolicies_VisibilityCoordinatorsAndBoard" xml:space="preserve"><value>Visible para Coordinadores de equipo y miembros de la Junta.</value></data>
+  <data name="SitePolicies_VisibilityMyTeams" xml:space="preserve"><value>Visible para humans que comparten al menos un equipo contigo.</value></data>
+  <data name="SitePolicies_VisibilityAllActive" xml:space="preserve"><value>Visible para todos los humans activos de la organizaci&#xF3;n.</value></data>
+  <data name="SitePolicies_ProvisioningTitle" xml:space="preserve"><value>Procesamiento automatizado</value></data>
+  <data name="SitePolicies_ProvisioningText" xml:space="preserve"><value>Cuando te unes o sales de un equipo, el sistema aprovisiona o elimina autom&#xE1;ticamente tu acceso a los recursos correspondientes de Google Workspace (carpetas de Drive compartido y Google Groups). Estos cambios se registran en el historial de auditor&#xED;a.</value></data>
+  <data name="SitePolicies_ContactTitle" xml:space="preserve"><value>Contacto</value></data>
+  <data name="SitePolicies_ContactText" xml:space="preserve"><value>Para preguntas o problemas relacionados con la aplicaci&#xF3;n, cont&#xE1;ctanos en</value></data>
+  <data name="SitePolicies_DpoText" xml:space="preserve"><value>Para consultas formales sobre protecci&#xF3;n de datos, contacta con nuestro Delegado de Protecci&#xF3;n de Datos en</value></data>
+  <data name="SitePolicies_ManageData" xml:space="preserve"><value>Gestiona tus datos personales</value></data>
 
   <!-- ======================== -->
   <!-- Profile                  -->
@@ -269,7 +286,7 @@
   <data name="ProfilePrivacy_CancelDeletion" xml:space="preserve"><value>Cancelar solicitud de eliminaci&#xF3;n</value></data>
   <data name="ProfilePrivacy_DPOContact" xml:space="preserve"><value>Si tiene preguntas sobre sus datos o derechos de privacidad, contacte con nuestro Delegado de Protecci&#xF3;n de Datos:</value></data>
   <data name="ProfilePrivacy_Email" xml:space="preserve"><value>Correo electr&#xF3;nico:</value></data>
-  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>Ver pol&#xED;tica de privacidad completa</value></data>
+  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>Ver pol&#xED;ticas del sitio</value></data>
   <data name="ProfilePrivacy_ConfirmDeletion" xml:space="preserve"><value>Confirmar eliminaci&#xF3;n de cuenta</value></data>
   <data name="ProfilePrivacy_ConfirmDeletionQuestion" xml:space="preserve"><value>&#xBF;Est&#xE1; seguro de que desea solicitar la eliminaci&#xF3;n de su cuenta?</value></data>
   <data name="ProfilePrivacy_YesDeleteMyAccount" xml:space="preserve"><value>S&#xED;, eliminar mi cuenta</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -59,7 +59,7 @@
   <data name="Nav_Roster" xml:space="preserve"><value>Liste</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Accords</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Gouvernance</value></data>
-  <data name="Nav_Privacy" xml:space="preserve"><value>Confidentialit&#xE9;</value></data>
+  <data name="Nav_Privacy" xml:space="preserve"><value>Politiques du site</value></data>
   <data name="Nav_About" xml:space="preserve"><value>&#xC0; propos</value></data>
   <data name="Nav_Admin" xml:space="preserve"><value>Admin</value></data>
   <data name="Nav_OnboardingReview" xml:space="preserve"><value>File d'attente</value></data>
@@ -164,9 +164,26 @@
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motif</value></data>
 
   <!-- ======================== -->
-  <!-- Privacy Policy Page      -->
+  <!-- Site Policies Page       -->
   <!-- ======================== -->
   <data name="Privacy_Title" xml:space="preserve"><value>Politique de confidentialit&#xE9;</value></data>
+  <data name="SitePolicies_Title" xml:space="preserve"><value>Politiques du site</value></data>
+  <data name="SitePolicies_Lead" xml:space="preserve"><value>Comment Humans g&#xE8;re vos donn&#xE9;es et comment ce site fonctionne.</value></data>
+  <data name="SitePolicies_DisclosuresTitle" xml:space="preserve"><value>Comment ce site fonctionne</value></data>
+  <data name="SitePolicies_DelegatedAccessTitle" xml:space="preserve"><value>R&#xF4;les d&#x27;acc&#xE8;s d&#xE9;l&#xE9;gu&#xE9;s</value></data>
+  <data name="SitePolicies_DelegatedAccessText" xml:space="preserve"><value>Le Conseil peut d&#xE9;signer des &lt;strong&gt;Coordinateurs de consentement&lt;/strong&gt; et des &lt;strong&gt;Coordinateurs de b&#xE9;n&#xE9;voles&lt;/strong&gt; qui re&#xE7;oivent un acc&#xE8;s &#xE9;largi aux donn&#xE9;es des membres (d&#xE9;tails du profil, statut d&#x27;int&#xE9;gration) pour exercer leurs fonctions. Ces attributions de r&#xF4;les sont enregistr&#xE9;es et audit&#xE9;es.</value></data>
+  <data name="SitePolicies_VisibilityTitle" xml:space="preserve"><value>Visibilit&#xE9; des donn&#xE9;es</value></data>
+  <data name="SitePolicies_VisibilityIntro" xml:space="preserve"><value>Lorsque vous ajoutez des coordonn&#xE9;es &#xE0; votre profil, vous choisissez qui peut voir chaque champ. Les niveaux de visibilit&#xE9; sont :</value></data>
+  <data name="SitePolicies_VisibilityBoardOnly" xml:space="preserve"><value>Visible uniquement par les membres du Conseil.</value></data>
+  <data name="SitePolicies_VisibilityCoordinatorsAndBoard" xml:space="preserve"><value>Visible par les Coordinateurs d&#x27;&#xE9;quipe et les membres du Conseil.</value></data>
+  <data name="SitePolicies_VisibilityMyTeams" xml:space="preserve"><value>Visible par les humans qui partagent au moins une &#xE9;quipe avec vous.</value></data>
+  <data name="SitePolicies_VisibilityAllActive" xml:space="preserve"><value>Visible par tous les humans actifs de l&#x27;organisation.</value></data>
+  <data name="SitePolicies_ProvisioningTitle" xml:space="preserve"><value>Traitement automatis&#xE9;</value></data>
+  <data name="SitePolicies_ProvisioningText" xml:space="preserve"><value>Lorsque vous rejoignez ou quittez une &#xE9;quipe, le syst&#xE8;me provisionne ou supprime automatiquement votre acc&#xE8;s aux ressources Google Workspace correspondantes (dossiers Drive partag&#xE9;s et Google Groups). Ces modifications sont enregistr&#xE9;es dans le journal d&#x27;audit.</value></data>
+  <data name="SitePolicies_ContactTitle" xml:space="preserve"><value>Contact</value></data>
+  <data name="SitePolicies_ContactText" xml:space="preserve"><value>Pour toute question ou probl&#xE8;me li&#xE9; &#xE0; l&#x27;application, contactez-nous &#xE0;</value></data>
+  <data name="SitePolicies_DpoText" xml:space="preserve"><value>Pour les demandes formelles de protection des donn&#xE9;es, contactez notre D&#xE9;l&#xE9;gu&#xE9; &#xE0; la protection des donn&#xE9;es &#xE0;</value></data>
+  <data name="SitePolicies_ManageData" xml:space="preserve"><value>G&#xE9;rer vos donn&#xE9;es personnelles</value></data>
 
   <!-- ======================== -->
   <!-- Profile                  -->
@@ -267,7 +284,7 @@
   <data name="ProfilePrivacy_CancelDeletion" xml:space="preserve"><value>Annuler la demande de suppression</value></data>
   <data name="ProfilePrivacy_DPOContact" xml:space="preserve"><value>Pour toute question concernant vos donn&#xE9;es ou vos droits en mati&#xE8;re de confidentialit&#xE9;, contactez notre D&#xE9;l&#xE9;gu&#xE9; &#xE0; la protection des donn&#xE9;es :</value></data>
   <data name="ProfilePrivacy_Email" xml:space="preserve"><value>E-mail :</value></data>
-  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>Voir la politique de confidentialit&#xE9; compl&#xE8;te</value></data>
+  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>Voir les politiques du site</value></data>
   <data name="ProfilePrivacy_ConfirmDeletion" xml:space="preserve"><value>Confirmer la suppression du compte</value></data>
   <data name="ProfilePrivacy_ConfirmDeletionQuestion" xml:space="preserve"><value>&#xCA;tes-vous s&#xFB;r de vouloir demander la suppression de votre compte ?</value></data>
   <data name="ProfilePrivacy_YesDeleteMyAccount" xml:space="preserve"><value>Oui, supprimer mon compte</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -59,7 +59,7 @@
   <data name="Nav_Roster" xml:space="preserve"><value>Elenco</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Accordi</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Governance</value></data>
-  <data name="Nav_Privacy" xml:space="preserve"><value>Privacy</value></data>
+  <data name="Nav_Privacy" xml:space="preserve"><value>Politiche del sito</value></data>
   <data name="Nav_About" xml:space="preserve"><value>Chi siamo</value></data>
   <data name="Nav_Admin" xml:space="preserve"><value>Admin</value></data>
   <data name="Nav_OnboardingReview" xml:space="preserve"><value>Coda di revisione</value></data>
@@ -164,9 +164,26 @@
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motivo</value></data>
 
   <!-- ======================== -->
-  <!-- Privacy Policy Page      -->
+  <!-- Site Policies Page       -->
   <!-- ======================== -->
   <data name="Privacy_Title" xml:space="preserve"><value>Informativa sulla Privacy</value></data>
+  <data name="SitePolicies_Title" xml:space="preserve"><value>Politiche del sito</value></data>
+  <data name="SitePolicies_Lead" xml:space="preserve"><value>Come Humans gestisce i tuoi dati e come funziona questo sito.</value></data>
+  <data name="SitePolicies_DisclosuresTitle" xml:space="preserve"><value>Come funziona questo sito</value></data>
+  <data name="SitePolicies_DelegatedAccessTitle" xml:space="preserve"><value>Ruoli di accesso delegato</value></data>
+  <data name="SitePolicies_DelegatedAccessText" xml:space="preserve"><value>Il Consiglio pu&#xF2; designare &lt;strong&gt;Coordinatori del consenso&lt;/strong&gt; e &lt;strong&gt;Coordinatori dei volontari&lt;/strong&gt; che ricevono un accesso elevato ai dati dei membri (dettagli del profilo, stato di inserimento) per svolgere le loro funzioni. Queste assegnazioni di ruolo vengono registrate e verificate.</value></data>
+  <data name="SitePolicies_VisibilityTitle" xml:space="preserve"><value>Visibilit&#xE0; dei dati</value></data>
+  <data name="SitePolicies_VisibilityIntro" xml:space="preserve"><value>Quando aggiungi informazioni di contatto al tuo profilo, scegli chi pu&#xF2; vedere ogni campo. I livelli di visibilit&#xE0; sono:</value></data>
+  <data name="SitePolicies_VisibilityBoardOnly" xml:space="preserve"><value>Visibile solo ai membri del Consiglio.</value></data>
+  <data name="SitePolicies_VisibilityCoordinatorsAndBoard" xml:space="preserve"><value>Visibile ai Coordinatori di squadra e ai membri del Consiglio.</value></data>
+  <data name="SitePolicies_VisibilityMyTeams" xml:space="preserve"><value>Visibile agli humans che condividono almeno una squadra con te.</value></data>
+  <data name="SitePolicies_VisibilityAllActive" xml:space="preserve"><value>Visibile a tutti gli humans attivi dell&#x27;organizzazione.</value></data>
+  <data name="SitePolicies_ProvisioningTitle" xml:space="preserve"><value>Elaborazione automatizzata</value></data>
+  <data name="SitePolicies_ProvisioningText" xml:space="preserve"><value>Quando ti unisci o lasci una squadra, il sistema fornisce o rimuove automaticamente il tuo accesso alle risorse Google Workspace corrispondenti (cartelle Drive condivise e Google Groups). Queste modifiche vengono registrate nel registro di audit.</value></data>
+  <data name="SitePolicies_ContactTitle" xml:space="preserve"><value>Contatto</value></data>
+  <data name="SitePolicies_ContactText" xml:space="preserve"><value>Per domande o problemi relativi all&#x27;applicazione, contattaci a</value></data>
+  <data name="SitePolicies_DpoText" xml:space="preserve"><value>Per richieste formali sulla protezione dei dati, contatta il nostro Responsabile della Protezione dei Dati a</value></data>
+  <data name="SitePolicies_ManageData" xml:space="preserve"><value>Gestisci i tuoi dati personali</value></data>
 
   <!-- ======================== -->
   <!-- Profile                  -->
@@ -267,7 +284,7 @@
   <data name="ProfilePrivacy_CancelDeletion" xml:space="preserve"><value>Annulla richiesta di eliminazione</value></data>
   <data name="ProfilePrivacy_DPOContact" xml:space="preserve"><value>Per domande sui Suoi dati o diritti alla privacy, contatti il nostro Responsabile della Protezione dei Dati:</value></data>
   <data name="ProfilePrivacy_Email" xml:space="preserve"><value>Email:</value></data>
-  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>Visualizza informativa completa sulla privacy</value></data>
+  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>Visualizza le politiche del sito</value></data>
   <data name="ProfilePrivacy_ConfirmDeletion" xml:space="preserve"><value>Conferma eliminazione account</value></data>
   <data name="ProfilePrivacy_ConfirmDeletionQuestion" xml:space="preserve"><value>È sicuro/a di voler richiedere l'eliminazione del Suo account?</value></data>
   <data name="ProfilePrivacy_YesDeleteMyAccount" xml:space="preserve"><value>Sì, elimina il mio account</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -59,7 +59,7 @@
   <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Agreements</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Governance</value></data>
-  <data name="Nav_Privacy" xml:space="preserve"><value>Privacy</value></data>
+  <data name="Nav_Privacy" xml:space="preserve"><value>Site Policies</value></data>
   <data name="Nav_About" xml:space="preserve"><value>About</value></data>
   <data name="Nav_Admin" xml:space="preserve"><value>Admin</value></data>
   <data name="Nav_OnboardingReview" xml:space="preserve"><value>Review Queue</value></data>
@@ -164,9 +164,26 @@
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Reason</value></data>
 
   <!-- ======================== -->
-  <!-- Privacy Policy Page      -->
+  <!-- Site Policies Page       -->
   <!-- ======================== -->
   <data name="Privacy_Title" xml:space="preserve"><value>Privacy Policy</value></data>
+  <data name="SitePolicies_Title" xml:space="preserve"><value>Site Policies</value></data>
+  <data name="SitePolicies_Lead" xml:space="preserve"><value>How Humans handles your data and how this site operates.</value></data>
+  <data name="SitePolicies_DisclosuresTitle" xml:space="preserve"><value>How This Site Works</value></data>
+  <data name="SitePolicies_DelegatedAccessTitle" xml:space="preserve"><value>Delegated Access Roles</value></data>
+  <data name="SitePolicies_DelegatedAccessText" xml:space="preserve"><value>The Board may designate &lt;strong&gt;Consent Coordinators&lt;/strong&gt; and &lt;strong&gt;Volunteer Coordinators&lt;/strong&gt; who receive elevated access to member data (profile details, onboarding status) in order to perform their duties. These role assignments are tracked and audited.</value></data>
+  <data name="SitePolicies_VisibilityTitle" xml:space="preserve"><value>Data Visibility</value></data>
+  <data name="SitePolicies_VisibilityIntro" xml:space="preserve"><value>When you add contact information to your profile, you choose who can see each field. The visibility tiers are:</value></data>
+  <data name="SitePolicies_VisibilityBoardOnly" xml:space="preserve"><value>Only visible to Board members.</value></data>
+  <data name="SitePolicies_VisibilityCoordinatorsAndBoard" xml:space="preserve"><value>Visible to team Coordinators and Board members.</value></data>
+  <data name="SitePolicies_VisibilityMyTeams" xml:space="preserve"><value>Visible to humans who share at least one team with you.</value></data>
+  <data name="SitePolicies_VisibilityAllActive" xml:space="preserve"><value>Visible to all active humans in the organization.</value></data>
+  <data name="SitePolicies_ProvisioningTitle" xml:space="preserve"><value>Automated Processing</value></data>
+  <data name="SitePolicies_ProvisioningText" xml:space="preserve"><value>When you join or leave a team, the system automatically provisions or removes your access to the corresponding Google Workspace resources (Shared Drive folders and Google Groups). These changes are logged in the audit trail.</value></data>
+  <data name="SitePolicies_ContactTitle" xml:space="preserve"><value>Contact</value></data>
+  <data name="SitePolicies_ContactText" xml:space="preserve"><value>For app-related questions or issues, contact us at</value></data>
+  <data name="SitePolicies_DpoText" xml:space="preserve"><value>For formal data protection inquiries, contact our Data Protection Officer at</value></data>
+  <data name="SitePolicies_ManageData" xml:space="preserve"><value>Manage your personal data</value></data>
 
   <!-- ======================== -->
   <!-- Profile                  -->
@@ -272,7 +289,7 @@
   <data name="ProfilePrivacy_CancelDeletion" xml:space="preserve"><value>Cancel Deletion Request</value></data>
   <data name="ProfilePrivacy_DPOContact" xml:space="preserve"><value>For questions about your data or privacy rights, contact our Data Protection Officer:</value></data>
   <data name="ProfilePrivacy_Email" xml:space="preserve"><value>Email:</value></data>
-  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>View Full Privacy Policy</value></data>
+  <data name="ProfilePrivacy_ViewFullPolicy" xml:space="preserve"><value>View Site Policies</value></data>
   <data name="ProfilePrivacy_ConfirmDeletion" xml:space="preserve"><value>Confirm Account Deletion</value></data>
   <data name="ProfilePrivacy_ConfirmDeletionQuestion" xml:space="preserve"><value>Are you sure you want to request deletion of your account?</value></data>
   <data name="ProfilePrivacy_YesDeleteMyAccount" xml:space="preserve"><value>Yes, Delete My Account</value></data>

--- a/src/Humans.Web/Views/Home/Privacy.cshtml
+++ b/src/Humans.Web/Views/Home/Privacy.cshtml
@@ -1,105 +1,69 @@
+@model Humans.Web.Models.SitePoliciesViewModel
 @{
-    ViewData["Title"] = Localizer["Privacy_Title"].Value;
+    ViewData["Title"] = Localizer["SitePolicies_Title"].Value;
+
+    var orderedLanguages = Model.PrivacyPolicyContent
+        .OrderByDisplayLanguage(canonicalFirst: true)
+        .ToList();
+    var privacyTabs = new Humans.Web.Models.TabbedMarkdownDocumentsViewModel
+    {
+        Documents = orderedLanguages,
+        TabsId = "privacyTabs",
+        ContentId = "privacyTabsContent",
+        DefaultLanguage = Model.PrivacyPolicyContent.GetDefaultDocumentLanguage(),
+        TabsCssClass = "nav nav-tabs px-3 pt-3",
+        EmptyMessage = Localizer["ConsentReview_ContentNotAvailable"].Value
+    };
 }
-<h1>@Localizer["Privacy_Title"]</h1>
 
-<p class="lead">Humans manages membership for Nobodies Collective and processes personal data in accordance with GDPR and Spanish data protection law (LOPDGDD).</p>
+<h1>@Localizer["SitePolicies_Title"]</h1>
+<p class="lead">@Localizer["SitePolicies_Lead"]</p>
 
-<p><em>Last updated: @DateTime.UtcNow.ToDisplayMonthYear()</em></p>
+<div class="card mb-4">
+    <div class="card-header">@Localizer["SitePolicies_DisclosuresTitle"]</div>
+    <div class="card-body">
+        <h5>@Localizer["SitePolicies_DelegatedAccessTitle"]</h5>
+        <p>@Html.Raw(Localizer["SitePolicies_DelegatedAccessText"].Value)</p>
 
-<h2>Data Controller</h2>
-<p>
-    <strong>Nobodies Collective</strong><br />
-    A Spanish nonprofit association registered in Andalucia.<br />
-    For data protection inquiries, contact our Data Protection Officer at: <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>
-</p>
+        <h5>@Localizer["SitePolicies_VisibilityTitle"]</h5>
+        <p>@Localizer["SitePolicies_VisibilityIntro"]</p>
+        <ul>
+            <li><strong>BoardOnly</strong> &mdash; @Localizer["SitePolicies_VisibilityBoardOnly"]</li>
+            <li><strong>CoordinatorsAndBoard</strong> &mdash; @Localizer["SitePolicies_VisibilityCoordinatorsAndBoard"]</li>
+            <li><strong>MyTeams</strong> &mdash; @Localizer["SitePolicies_VisibilityMyTeams"]</li>
+            <li><strong>AllActiveProfiles</strong> &mdash; @Localizer["SitePolicies_VisibilityAllActive"]</li>
+        </ul>
 
-<h2>Data We Collect</h2>
-<p>We collect and process the following categories of personal data:</p>
-<ul>
-    <li><strong>Identity data:</strong> Name, email address (from Google authentication), display name/burner name</li>
-    <li><strong>Contact data:</strong> Phone number, city, country (optional)</li>
-    <li><strong>Profile data:</strong> Bio, team memberships, role assignments</li>
-    <li><strong>Technical data:</strong> IP address and user agent (for consent records)</li>
-    <li><strong>Application data:</strong> Membership applications and motivation statements</li>
-    <li><strong>Consent records:</strong> Records of your agreement to legal documents</li>
-</ul>
+        <h5>@Localizer["SitePolicies_ProvisioningTitle"]</h5>
+        <p>@Localizer["SitePolicies_ProvisioningText"]</p>
 
-<h2>Legal Basis for Processing</h2>
-<p>We process your data based on:</p>
-<ul>
-    <li><strong>Contract:</strong> Processing necessary for membership management</li>
-    <li><strong>Legitimate interest:</strong> Maintaining organizational records and communication</li>
-    <li><strong>Legal obligation:</strong> Compliance with Spanish nonprofit regulations</li>
-    <li><strong>Consent:</strong> For optional data you choose to provide</li>
-</ul>
+        <h5>@Localizer["SitePolicies_ContactTitle"]</h5>
+        <p>
+            @Localizer["SitePolicies_ContactText"]
+            <a href="mailto:@Model.SupportEmail">@Model.SupportEmail</a>
+        </p>
+        <p>
+            @Localizer["SitePolicies_DpoText"]
+            <a href="mailto:@Model.DpoEmail">@Model.DpoEmail</a>
+        </p>
+        <p>
+            <a asp-controller="Profile" asp-action="Privacy">@Localizer["SitePolicies_ManageData"]</a>
+        </p>
+    </div>
+</div>
 
-<h2>How We Use Your Data</h2>
-<ul>
-    <li>To manage your membership and team participation</li>
-    <li>To communicate with you about organizational activities</li>
-    <li>To maintain legal compliance records</li>
-    <li>To facilitate connections between humans (based on your visibility settings)</li>
-</ul>
-
-<h2>Data Retention</h2>
-<p>We retain your data according to the following policies:</p>
-<ul>
-    <li><strong>Active accounts:</strong> Data retained while your account is active</li>
-    <li><strong>Inactive accounts:</strong> Data retained for up to 7 years for legal compliance</li>
-    <li><strong>Consent records:</strong> Retained indefinitely as required for GDPR compliance</li>
-    <li><strong>Deleted accounts:</strong> Anonymized after 30-day grace period</li>
-</ul>
-
-<h2>Your Rights</h2>
-<p>Under GDPR, you have the following rights:</p>
-<ul>
-    <li><strong>Access:</strong> Request a copy of your personal data</li>
-    <li><strong>Rectification:</strong> Request correction of inaccurate data</li>
-    <li><strong>Erasure:</strong> Request deletion of your data ("right to be forgotten")</li>
-    <li><strong>Portability:</strong> Receive your data in a machine-readable format</li>
-    <li><strong>Restriction:</strong> Request limitation of processing</li>
-    <li><strong>Objection:</strong> Object to certain types of processing</li>
-</ul>
-<p>
-    To exercise these rights, visit your <a asp-controller="Profile" asp-action="Privacy">Privacy & Data</a> settings or contact us at
-    <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>.
-</p>
-
-<h2>Cookies</h2>
-<p>This site uses only essential cookies required for:</p>
-<ul>
-    <li>User authentication and session management</li>
-    <li>Anti-forgery tokens for form security</li>
-    <li>Cookie consent preference</li>
-</ul>
-<p>We do not use analytics, advertising, or third-party tracking cookies.</p>
-
-<h2>Data Security</h2>
-<p>We implement appropriate technical and organizational measures to protect your data, including:</p>
-<ul>
-    <li>Encryption in transit (HTTPS)</li>
-    <li>Secure authentication via Google OAuth</li>
-    <li>Access controls and audit logging</li>
-    <li>Regular security reviews</li>
-</ul>
-
-<h2>Third-Party Services</h2>
-<p>We use the following third-party services:</p>
-<ul>
-    <li><strong>Google OAuth:</strong> For secure authentication (Google's <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>)</li>
-    <li><strong>Google Workspace:</strong> For team resource provisioning (shared drives, groups)</li>
-</ul>
-
-<h2>Changes to This Policy</h2>
-<p>We may update this privacy policy from time to time. We will notify active humans of significant changes via email.</p>
-
-<h2>Contact & Complaints</h2>
-<p>
-    For questions or concerns about this policy, contact our Data Protection Officer at
-    <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>.
-</p>
-<p>
-    If you are not satisfied with our response, you have the right to lodge a complaint with the
-    Spanish Data Protection Agency (AEPD) at <a href="https://www.aepd.es" target="_blank" rel="noopener noreferrer">www.aepd.es</a>.
-</p>
+<div class="card">
+    <div class="card-header">@Localizer["Privacy_Title"]</div>
+    @if (Model.PrivacyPolicyContent.Count > 0)
+    {
+        <div class="card-body p-0">
+            @await Html.PartialAsync("_TabbedMarkdownDocuments", privacyTabs)
+        </div>
+    }
+    else
+    {
+        <div class="card-body">
+            <p class="text-muted mb-0">@Localizer["ConsentReview_ContentNotAvailable"]</p>
+        </div>
+    }
+</div>


### PR DESCRIPTION
## Summary

Closes #56

- **Replaces** the hardcoded English-only Privacy page with a combined **Site Policies** page at `/Home/Privacy`
- **Top section** discloses app-specific operational details: delegated access roles (Consent/Volunteer Coordinators), contact field visibility tiers, automated Google Workspace provisioning, and support/DPO contact emails
- **Bottom section** displays the privacy policy in a multi-language tabbed viewer (same pattern as Governance statutes), sourced from the legal repo via `LegalDocumentService`
- **Localized** all new content in 5 languages (en, es, de, fr, it)
- **Updated** footer link, user dropdown, and Profile/Privacy cross-link text from "Privacy" to "Site Policies"
- Spanish tab marked as canonical/legal; user's locale auto-selected as default tab
- Graceful fallback when privacy policy content is not yet available in the legal repo

## Test plan

- [ ] Visit `/Home/Privacy` while unauthenticated — page loads with disclosures and privacy policy tabs
- [ ] Visit while authenticated — same page, "Manage your personal data" link navigates to Profile/Privacy
- [ ] Switch language — all SitePolicies text renders in selected locale
- [ ] Footer link shows "Site Policies" (localized) and navigates correctly
- [ ] User dropdown shows "Site Policies" (localized) and navigates correctly
- [ ] Cookie banner "Learn more" link still points to the page
- [ ] Privacy policy tabs show content when legal repo has `PrivacyPolicy/` folder; show fallback message when empty
- [ ] Spanish tab marked as "(Legal)" in the tab label

🤖 Generated with [Claude Code](https://claude.com/claude-code)