### PR TITLE
Fix Staff page crash when user holds multiple roles

### DIFF
--- a/src/Humans.Web/Helpers/ProfilePictureUrlHelper.cs
+++ b/src/Humans.Web/Helpers/ProfilePictureUrlHelper.cs
@@ -20,7 +20,7 @@ public static class ProfilePictureUrlHelper
         IEnumerable<(Guid UserId, string? GoogleProfilePictureUrl)> users,
         CancellationToken ct = default)
     {
-        var userList = users.ToList();
+        var userList = users.DistinctBy(u => u.UserId).ToList();
         var userIds = userList.Select(u => u.UserId).ToList();
 
         var customPictures = await profileService.GetCustomPictureInfoByUserIdsAsync(userIds, ct);


### PR DESCRIPTION
## Summary
- Staff page (`/About/Staff`) crashes with `ArgumentException: duplicate key` when a user holds multiple governance roles (e.g., Board President + Coordinator)
- `ProfilePictureUrlHelper.BuildEffectiveUrlsAsync` now deduplicates input by UserId before building the dictionary
- Deeper refactor tracked in #332 (UserAvatar component should resolve pictures from UserId directly)

## Test plan
- [ ] Visit `/About/Staff` with a user who holds 2+ roles — page loads without error
- [ ] Verify that user appears in both role sections with correct profile picture

🤖 Generated with [Claude Code](https://claude.com/claude-code)