### PR TITLE
[codex] add dev budget and ticket seeders

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Business requirements, user stories, data model, and workflows for each feature 
 |----------|-------------|
 | [Admin Role Setup](admin-role-setup.md) | Adding initial admin users via SQL |
 | [GUID Reservations](guid-reservations.md) | Reserved deterministic GUID blocks for seeded data |
+| [Seed Data Strategy](seed-data.md) | When to use `HasData`, migration backfills, and dev-only runtime seeders |
 | [Google & External Service Setup](google-service-account-setup.md) | OAuth, service account, Maps, GitHub credentials |
 
 ## Repository Metrics

--- a/docs/seed-data.md
+++ b/docs/seed-data.md
@@ -1,0 +1,183 @@
+# Seed Data Strategy
+
+## Purpose
+
+This document explains how seed data should be created in Humans, and which approach to use for which kind of data.
+
+The short version:
+
+- Use EF Core `HasData` for tiny, foundational, well-known rows the app must always have.
+- Use migration SQL for one-off backfills or transformations of existing real data.
+- Use explicit dev-only runtime seeders for rich local demo data and operational feature data.
+
+## Existing Patterns In This Repository
+
+Humans already uses three different seed patterns:
+
+### 1. Foundational seed data via `HasData`
+
+Use this for stable bootstrap rows with deterministic identities.
+
+Examples:
+
+- System teams in [TeamConfiguration.cs](../src/Humans.Infrastructure/Data/Configurations/TeamConfiguration.cs)
+- Shift tags in [ShiftTagConfiguration.cs](../src/Humans.Infrastructure/Data/Configurations/ShiftTagConfiguration.cs)
+- Sync service settings in [SyncServiceSettingsConfiguration.cs](../src/Humans.Infrastructure/Data/Configurations/SyncServiceSettingsConfiguration.cs)
+- Camp settings in [CampSettingsConfiguration.cs](../src/Humans.Infrastructure/Data/Configurations/CampSettingsConfiguration.cs)
+- System settings in [SystemSettingConfiguration.cs](../src/Humans.Infrastructure/Data/Configurations/SystemSettingConfiguration.cs)
+- Ticket sync singleton state in [TicketSyncStateConfiguration.cs](../src/Humans.Infrastructure/Data/Configurations/TicketSyncStateConfiguration.cs)
+
+These rows are part of the app's baseline shape. They belong in migrations and should exist in every environment.
+
+### 2. One-off backfills via migration SQL
+
+Use this when the app already has real data and a migration needs to populate or reshape it once.
+
+Example:
+
+- [20260311161510_SeedLeadRoleDefinitions.cs](../src/Humans.Infrastructure/Migrations/20260311161510_SeedLeadRoleDefinitions.cs)
+
+This is not a local demo-data mechanism. It is a schema-evolution mechanism.
+
+### 3. Dev-only runtime seeding
+
+Use this for local or preview convenience data that should be created only on demand.
+
+Existing example:
+
+- [DevLoginController.cs](../src/Humans.Web/Controllers/DevLoginController.cs)
+
+This creates development personas dynamically so local and preview environments can log in without real Google OAuth users.
+
+## Default Rule Going Forward
+
+For operational, realistic, feature-level demo data, the default approach should be:
+
+**Use an explicit dev-only runtime seeder.**
+
+This includes data like:
+
+- budget years, categories, and line items
+- ticket orders and attendees
+- realistic department/team data for local UI work
+- sample operational records that exist to make screens useful in development
+
+The first dedicated example of this pattern is the budget demo seeder:
+
+- [DevSeedController.cs](../src/Humans.Web/Controllers/DevSeedController.cs)
+- [DevelopmentBudgetSeeder.cs](../src/Humans.Web/Infrastructure/DevelopmentBudgetSeeder.cs)
+
+The second concrete example is the ticketing demo seeder:
+
+- [DevSeedController.cs](../src/Humans.Web/Controllers/DevSeedController.cs)
+- [DevelopmentTicketSeeder.cs](../src/Humans.Web/Infrastructure/DevelopmentTicketSeeder.cs)
+
+## Why This Is The Preferred Approach For Operational Demo Data
+
+Operational feature data is different from bootstrap data:
+
+- it is larger
+- it is more domain-specific
+- it changes more often
+- it is useful mainly for local development, previews, demos, and manual verification
+- it should not be inserted into production automatically
+
+Trying to model this kind of data with `HasData` or migrations creates the wrong coupling.
+
+## Pros
+
+- It is opt-in. Nothing happens unless a developer explicitly runs the seeder.
+- It keeps production bootstrap data separate from local demo data.
+- It can use real application services and workflows instead of bypassing business logic.
+- It can be idempotent, so developers can run it repeatedly without duplicate records.
+- It can evolve quickly as screens and workflows change.
+- It can create richer cross-entity data than `HasData` comfortably supports.
+- It can be paired with dev-only stubs when a feature normally depends on external infrastructure.
+
+## Cons
+
+- It adds extra code paths that need guardrails.
+- If misconfigured, a non-production app pointed at a real database could still write demo data.
+- It is not automatically available in tests or migrations.
+- It can drift from production-like reality if nobody maintains it.
+- It needs explicit documentation and discoverability or people will not know it exists.
+- It may need companion dev-only infrastructure so the seeded data is actually visible in the UI.
+
+## Required Guardrails For Dev Seeders
+
+All new dev seeders should follow these rules:
+
+1. They must never run automatically at startup, during migration, or from recurring jobs.
+2. They must be disabled in `Production`.
+3. They must require an explicit enablement flag.
+4. They must require an authenticated privileged user, not anonymous access.
+5. They should be idempotent.
+6. They should be deterministic where that improves reruns and cleanup.
+7. They should call application/infrastructure services where possible, instead of duplicating business rules with raw inserts.
+8. They should avoid production secrets, real customer data, or environment-specific identifiers.
+9. If a feature normally depends on an external provider, the seeder may be paired with a dev-only stub service, but that stub must also be disabled in `Production`.
+
+## Preferred Implementation Shape
+
+For local/demo operational data, prefer this structure:
+
+- A thin dev-only controller or command entry point in `Humans.Web`
+- A dedicated seeder service that owns the data creation workflow
+- Business writes delegated to existing services where practical
+- Direct `DbContext` usage only for setup glue that is not yet exposed through a proper service
+
+The budget seeder follows this shape:
+
+- [DevSeedController.cs](../src/Humans.Web/Controllers/DevSeedController.cs) exposes the explicit endpoint
+- [DevelopmentBudgetSeeder.cs](../src/Humans.Web/Infrastructure/DevelopmentBudgetSeeder.cs) owns the orchestration
+
+The ticketing seeder follows the same shape, with one extra piece:
+
+- [DevelopmentTicketSeeder.cs](../src/Humans.Web/Infrastructure/DevelopmentTicketSeeder.cs) seeds orders and attendees
+- [StubTicketVendorService.cs](../src/Humans.Infrastructure/Services/StubTicketVendorService.cs) is a dev-only companion that lets the seeded local data drive `/Tickets` without real TicketTailor credentials
+
+Operational seeders may also encode realistic business assumptions for local development, such as:
+
+- sales cadence over time
+- release timing patterns, such as an initial burst followed by a taper
+- ticket type mix and price points
+- donation and discount behavior
+- VAT rules, thresholds, and other reporting-sensitive calculations
+
+When they do, keep those assumptions aligned with the relevant feature docs and shared constants rather than scattering duplicate rules.
+
+For example, the ticket seeder is allowed to model a plausible launch curve for local development, while still taking VAT behavior from `TicketConstants` and the ticketing feature documentation rather than hard-coding disconnected rules in multiple places.
+
+## Decision Guide
+
+Use this table when adding new seed data:
+
+| Scenario | Default approach |
+|----------|------------------|
+| Well-known app bootstrap rows that every environment needs | EF Core `HasData` |
+| Existing production data needs a one-time corrective insert/update during schema evolution | Migration SQL |
+| Rich local demo data for feature development or manual QA | Dev-only runtime seeder |
+| Test-only records for unit/integration tests | Test fixtures/factories, not app seed data |
+
+## Budget Seeder Decision
+
+The budget demo seeder was intentionally implemented as a dev-only runtime seeder rather than `HasData` or a migration because:
+
+- budgets are operational data, not app bootstrap data
+- the data is useful for local browsing and demos, not for every environment
+- it should never run implicitly in production
+- it benefits from using the real budget services and app behavior
+
+## Future Guidance
+
+Future operational demo datasets should follow the same pattern as the budget seeder unless there is a strong reason not to.
+
+Examples:
+
+- ticket sales demo data
+- realistic attendee datasets
+- richer department or finance walkthrough datasets
+
+If a future seeder would be dangerous to expose over HTTP, use the same dev-only principles behind a local command or other explicit development-only trigger instead.
+
+If a future operational dataset depends on an external API to render correctly, prefer a local stub companion over weakening production-facing configuration rules.

--- a/src/Humans.Infrastructure/Services/StubTicketVendorService.cs
+++ b/src/Humans.Infrastructure/Services/StubTicketVendorService.cs
@@ -1,0 +1,174 @@
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NodaTime;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Development-only ticket vendor stub backed by the local database.
+/// It allows the Tickets UI to work with seeded local data without real TicketTailor credentials.
+/// </summary>
+public sealed class StubTicketVendorService : ITicketVendorService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly TicketVendorSettings _settings;
+
+    public StubTicketVendorService(
+        HumansDbContext dbContext,
+        IOptions<TicketVendorSettings> settings)
+    {
+        _dbContext = dbContext;
+        _settings = settings.Value;
+    }
+
+    public async Task<IReadOnlyList<VendorOrderDto>> GetOrdersAsync(
+        Instant? since,
+        string eventId,
+        CancellationToken ct = default)
+    {
+        var query = _dbContext.TicketOrders
+            .AsNoTracking()
+            .Where(o => o.VendorEventId == eventId);
+
+        if (since.HasValue)
+        {
+            query = query.Where(o => o.SyncedAt >= since.Value);
+        }
+
+        var orders = await query
+            .OrderBy(o => o.PurchasedAt)
+            .ToListAsync(ct);
+
+        return orders
+            .Select(o => new VendorOrderDto(
+                VendorOrderId: o.VendorOrderId,
+                BuyerName: o.BuyerName,
+                BuyerEmail: o.BuyerEmail,
+                TotalAmount: o.TotalAmount,
+                Currency: o.Currency,
+                DiscountCode: o.DiscountCode,
+                PaymentStatus: o.PaymentStatus switch
+                {
+                    TicketPaymentStatus.Paid => "completed",
+                    TicketPaymentStatus.Pending => "pending",
+                    TicketPaymentStatus.Refunded => "refunded",
+                    TicketPaymentStatus.Cancelled => "cancelled",
+                    _ => "pending"
+                },
+                VendorDashboardUrl: o.VendorDashboardUrl,
+                PurchasedAt: o.PurchasedAt,
+                Tickets: Array.Empty<VendorTicketDto>(),
+                StripePaymentIntentId: o.StripePaymentIntentId,
+                DiscountAmount: o.DiscountAmount,
+                DonationAmount: o.DonationAmount))
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<VendorTicketDto>> GetIssuedTicketsAsync(
+        Instant? since,
+        string eventId,
+        CancellationToken ct = default)
+    {
+        var query = _dbContext.TicketAttendees
+            .AsNoTracking()
+            .Include(a => a.TicketOrder)
+            .Where(a => a.VendorEventId == eventId);
+
+        if (since.HasValue)
+        {
+            query = query.Where(a => a.SyncedAt >= since.Value);
+        }
+
+        var attendees = await query
+            .OrderBy(a => a.TicketOrder.PurchasedAt)
+            .ThenBy(a => a.AttendeeName)
+            .ToListAsync(ct);
+
+        return attendees
+            .Select(a => new VendorTicketDto(
+                VendorTicketId: a.VendorTicketId,
+                VendorOrderId: a.TicketOrder.VendorOrderId,
+                AttendeeName: a.AttendeeName,
+                AttendeeEmail: a.AttendeeEmail,
+                TicketTypeName: a.TicketTypeName,
+                Price: a.Price,
+                Status: a.Status switch
+                {
+                    TicketAttendeeStatus.Valid => "valid",
+                    TicketAttendeeStatus.Void => "void",
+                    TicketAttendeeStatus.CheckedIn => "checked_in",
+                    _ => "void"
+                }))
+            .ToList();
+    }
+
+    public async Task<VendorEventSummaryDto> GetEventSummaryAsync(
+        string eventId,
+        CancellationToken ct = default)
+    {
+        var ticketsSold = await _dbContext.TicketAttendees
+            .CountAsync(
+                a => a.VendorEventId == eventId &&
+                     (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn),
+                ct);
+
+        var breakEvenTarget = _settings.BreakEvenTarget > 0 ? _settings.BreakEvenTarget : 2000;
+        var totalCapacity = Math.Max(
+            breakEvenTarget,
+            ticketsSold > 0 ? (int)Math.Ceiling(ticketsSold / 0.30m) : breakEvenTarget);
+
+        return new VendorEventSummaryDto(
+            EventId: eventId,
+            EventName: "Seeded Local Ticket Event",
+            TotalCapacity: totalCapacity,
+            TicketsSold: ticketsSold,
+            TicketsRemaining: Math.Max(totalCapacity - ticketsSold, 0));
+    }
+
+    public Task<IReadOnlyList<string>> GenerateDiscountCodesAsync(
+        DiscountCodeSpec spec,
+        CancellationToken ct = default)
+    {
+        var prefix = spec.DiscountType == DiscountType.Percentage ? "PCT" : "FIX";
+        IReadOnlyList<string> codes = Enumerable.Range(1, spec.Count)
+            .Select(i => $"DEMO-{prefix}-{i:0000}")
+            .ToList();
+        return Task.FromResult(codes);
+    }
+
+    public async Task<IReadOnlyList<DiscountCodeStatusDto>> GetDiscountCodeUsageAsync(
+        IEnumerable<string> codes,
+        CancellationToken ct = default)
+    {
+        var codeList = codes
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (codeList.Count == 0)
+        {
+            return Array.Empty<DiscountCodeStatusDto>();
+        }
+
+        var orderCounts = await _dbContext.TicketOrders
+            .AsNoTracking()
+            .Where(o => o.DiscountCode != null && codeList.Contains(o.DiscountCode))
+            .GroupBy(o => o.DiscountCode!)
+            .Select(g => new { Code = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
+
+        var lookup = orderCounts.ToDictionary(x => x.Code, x => x.Count, StringComparer.OrdinalIgnoreCase);
+
+        return codeList
+            .Select(code => new DiscountCodeStatusDto(
+                Code: code,
+                IsRedeemed: lookup.TryGetValue(code, out var count) && count > 0,
+                TimesUsed: lookup.TryGetValue(code, out count) ? count : 0))
+            .ToList();
+    }
+}

--- a/src/Humans.Web/Controllers/DevSeedController.cs
+++ b/src/Humans.Web/Controllers/DevSeedController.cs
@@ -1,0 +1,115 @@
+using Humans.Application.Configuration;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Web.Infrastructure;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+[Authorize]
+[Route("dev/seed")]
+public class DevSeedController : HumansControllerBase
+{
+    private readonly IWebHostEnvironment _environment;
+    private readonly IConfiguration _configuration;
+    private readonly ConfigurationRegistry _configRegistry;
+    private readonly DevelopmentBudgetSeeder _budgetSeeder;
+    private readonly DevelopmentTicketSeeder _ticketSeeder;
+
+    public DevSeedController(
+        IWebHostEnvironment environment,
+        IConfiguration configuration,
+        ConfigurationRegistry configRegistry,
+        DevelopmentBudgetSeeder budgetSeeder,
+        DevelopmentTicketSeeder ticketSeeder,
+        UserManager<User> userManager)
+        : base(userManager)
+    {
+        _environment = environment;
+        _configuration = configuration;
+        _configRegistry = configRegistry;
+        _budgetSeeder = budgetSeeder;
+        _ticketSeeder = ticketSeeder;
+    }
+
+    [Authorize(Roles = RoleGroups.FinanceAdminOrAdmin)]
+    [HttpGet("budget")]
+    public async Task<IActionResult> SeedBudget(CancellationToken cancellationToken)
+    {
+        if (!IsDevSeedEnabled())
+        {
+            return NotFound();
+        }
+
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null)
+        {
+            return errorResult;
+        }
+
+        var result = await _budgetSeeder.SeedAsync(user.Id, cancellationToken);
+
+        return Ok(new
+        {
+            message = $"Seeded budget demo data for {result.BudgetYearName}.",
+            result.BudgetYearId,
+            result.BudgetYearCode,
+            result.BudgetYearName,
+            result.ActivatedBudgetYear,
+            result.TeamsCreated,
+            result.TeamsUpdated,
+            result.DepartmentCategoriesSynced,
+            result.GroupsCreated,
+            result.CategoriesCreated,
+            result.LineItemsCreated,
+            financeYearDetailUrl = Url.Action(nameof(FinanceController.YearDetail), "Finance", new { id = result.BudgetYearId }),
+            financeAdminUrl = Url.Action(nameof(FinanceController.Admin), "Finance")
+        });
+    }
+
+    [Authorize(Roles = RoleGroups.TicketAdminBoardOrAdmin + "," + RoleNames.FinanceAdmin)]
+    [HttpGet("tickets")]
+    public async Task<IActionResult> SeedTickets(CancellationToken cancellationToken)
+    {
+        if (!IsDevSeedEnabled())
+        {
+            return NotFound();
+        }
+
+        var result = await _ticketSeeder.SeedAsync(cancellationToken);
+
+        return Ok(new
+        {
+            message = "Seeded ticketing demo data.",
+            result.PaidOrders,
+            result.NonPaidOrders,
+            result.OrdersCreated,
+            result.AttendeesCreated,
+            result.PaidTicketsSold,
+            result.GrossRevenue,
+            result.DonationRevenue,
+            result.DiscountTotal,
+            result.OrdersWithDonation,
+            result.OrdersWithDiscountCode,
+            result.MatchedOrders,
+            result.MatchedAttendees,
+            result.TwoTicketOrders,
+            ticketsDashboardUrl = Url.Action(nameof(TicketController.Index), "Ticket"),
+            ticketsOrdersUrl = Url.Action(nameof(TicketController.Orders), "Ticket"),
+            ticketsAttendeesUrl = Url.Action(nameof(TicketController.Attendees), "Ticket")
+        });
+    }
+
+    private bool IsDevSeedEnabled()
+    {
+        if (_environment.IsProduction())
+        {
+            return false;
+        }
+
+        return _configuration.GetSettingValue(
+            _configRegistry, "DevAuth:Enabled", "Development", defaultValue: false);
+    }
+}

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -199,13 +199,39 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<LogApiKeyAuthFilter>();
 
         // Ticket vendor integration
+        var ticketVendorApiKey = Environment.GetEnvironmentVariable("TICKET_VENDOR_API_KEY") ?? string.Empty;
+        var hasTicketVendorApiKey = !string.IsNullOrWhiteSpace(ticketVendorApiKey);
+        var ticketVendorEventId = configuration[$"{TicketVendorSettings.SectionName}:EventId"] ?? string.Empty;
+        var hasTicketVendorEventId = !string.IsNullOrWhiteSpace(ticketVendorEventId);
+        var isDevelopmentWithDevAuth = !environment.IsProduction() && configuration.GetValue<bool>("DevAuth:Enabled");
+
+        // Production, and any environment with real credentials, should use the live TicketTailor client.
+        // Development can fall back to the local stub only when DevAuth is enabled, the ticket feature
+        // is configured with an event id, and there is no real API key available.
+        var useDevelopmentTicketStub = isDevelopmentWithDevAuth
+            && hasTicketVendorEventId
+            && !hasTicketVendorApiKey;
+
         services.Configure<TicketVendorSettings>(opts =>
         {
             configuration.GetSection(TicketVendorSettings.SectionName).Bind(opts);
-            // Populate API key from environment variable (not in appsettings — sensitive)
-            opts.ApiKey = Environment.GetEnvironmentVariable("TICKET_VENDOR_API_KEY") ?? string.Empty;
+
+            // API keys are always sourced from the environment, never from appsettings.
+            // The dev stub still needs settings to look configured, so give it a sentinel key.
+            opts.ApiKey = useDevelopmentTicketStub
+                ? "__dev_stub__"
+                : ticketVendorApiKey;
         });
-        services.AddHttpClient<ITicketVendorService, TicketTailorService>();
+
+        if (useDevelopmentTicketStub)
+        {
+            services.AddScoped<ITicketVendorService, StubTicketVendorService>();
+        }
+        else
+        {
+            services.AddHttpClient<ITicketVendorService, TicketTailorService>();
+        }
+
         services.AddScoped<ITicketSyncService, TicketSyncService>();
         services.AddScoped<ITicketQueryService, TicketQueryService>();
 

--- a/src/Humans.Web/Infrastructure/DevelopmentBudgetSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentBudgetSeeder.cs
@@ -1,0 +1,575 @@
+using Humans.Application.Extensions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using NodaTime;
+
+namespace Humans.Web.Infrastructure;
+
+public sealed record DevelopmentBudgetSeedResult(
+    Guid BudgetYearId,
+    string BudgetYearCode,
+    string BudgetYearName,
+    bool ActivatedBudgetYear,
+    int TeamsCreated,
+    int TeamsUpdated,
+    int DepartmentCategoriesSynced,
+    int GroupsCreated,
+    int CategoriesCreated,
+    int LineItemsCreated);
+
+public sealed class DevelopmentBudgetSeeder
+{
+    private static readonly BudgetTeamSeed[] TeamSeeds =
+    [
+        new(
+            Slug: "demo-kitchen",
+            Name: "Kitchen",
+            Description: "Food, water, and volunteer hydration operations.",
+            AllocatedAmount: -55199.22m,
+            ExpenditureType: ExpenditureType.OpEx,
+            LineItems:
+            [
+                new("Dry goods and staples", -21230.47m, "Bulk pantry order for crew meals and volunteer kitchen stock.", new LocalDate(2026, 4, 16), 10),
+                new("Cold storage rental", -17483.92m, "Walk-in refrigeration for perishables across build and event week.", new LocalDate(2026, 5, 8), 21),
+                new("Fresh produce top-up", -11551.87m, "Mid-season restock for the final kitchen push.", new LocalDate(2026, 6, 19), 10),
+                new("Water station consumables", -4932.96m, "Cups, filtration cartridges, and cleaning supplies.", new LocalDate(2026, 7, 6), 21)
+            ]),
+        new(
+            Slug: "demo-site-ops",
+            Name: "Site Ops",
+            Description: "Core site readiness, lighting, fencing, and directional systems.",
+            AllocatedAmount: -82111.96m,
+            ExpenditureType: ExpenditureType.OpEx,
+            LineItems:
+            [
+                new("Perimeter fencing rental", -32470.13m, "Event perimeter, backstage zoning, and access control fencing.", new LocalDate(2026, 4, 24), 21),
+                new("Portable lighting towers", -26850.30m, "Night-safe lighting coverage for work zones and public paths.", new LocalDate(2026, 5, 15), 21),
+                new("Wayfinding and safety signage", -14986.21m, "Directional signs, hazard boards, and reflective markers.", new LocalDate(2026, 6, 3), 21),
+                new("Tooling and repairs", -7805.32m, "Consumables and small repairs during build week.", new LocalDate(2026, 7, 2), 21)
+            ]),
+        new(
+            Slug: "demo-welfare",
+            Name: "Welfare",
+            Description: "Shade, wellbeing, first aid, and volunteer care.",
+            AllocatedAmount: -37215.76m,
+            ExpenditureType: ExpenditureType.OpEx,
+            LineItems:
+            [
+                new("Shade structures and soft seating", -16547.28m, "Quiet-zone shade, beanbags, and recovery seating.", new LocalDate(2026, 4, 29), 21),
+                new("First aid replenishment", -8866.84m, "Restock of trauma packs, consumables, and sunscreen.", new LocalDate(2026, 5, 28), 21),
+                new("Hydration support", -6119.37m, "Electrolytes, coolers, and water transport backup.", new LocalDate(2026, 6, 17), 10),
+                new("Volunteer wellbeing budget", -5682.27m, "Hot-weather extras and crew decompression supplies.", new LocalDate(2026, 7, 9), 21)
+            ]),
+        new(
+            Slug: "demo-build-crew",
+            Name: "Build Crew",
+            Description: "Build and strike materials, fixings, and shared fabrication support.",
+            AllocatedAmount: -64471.94m,
+            ExpenditureType: ExpenditureType.CapEx,
+            LineItems:
+            [
+                new("Timber and structural hardware", -29972.43m, "Primary materials for shade, shelving, and public-facing structures.", new LocalDate(2026, 4, 11), 21),
+                new("Power distro cabling", -16547.28m, "Cables, connectors, and protective runs for key install areas.", new LocalDate(2026, 5, 20), 21),
+                new("Workshop consumables", -10303.02m, "Blades, fixings, abrasives, and adhesives.", new LocalDate(2026, 6, 14), 21),
+                new("Strike and recovery transport", -7649.21m, "Shared van hire and late-stage teardown extras.", new LocalDate(2026, 7, 13), 21)
+            ])
+    ];
+
+    private static readonly BudgetCategorySeed[] SharedServicesCategories =
+    [
+        new(
+            Name: "Insurance & Permits",
+            AllocatedAmount: -36966.01m,
+            ExpenditureType: ExpenditureType.OpEx,
+            LineItems:
+            [
+                new("Event insurance", -19357.21m, "Public liability and equipment cover for the season.", new LocalDate(2026, 3, 21), 0),
+                new("Local permits and filings", -10240.58m, "Permit processing, translations, and administrative fees.", new LocalDate(2026, 4, 5), 0),
+                new("Site compliance documentation", -7368.22m, "Occupancy plan, signage review, and external checks.", new LocalDate(2026, 5, 6), 21)
+            ]),
+        new(
+            Name: "Sanctuary & Welfare Reserve",
+            AllocatedAmount: -25008.24m,
+            ExpenditureType: ExpenditureType.OpEx,
+            LineItems:
+            [
+                new("Accessibility reserve", -11239.66m, "Last-minute accessibility rentals and support.", new LocalDate(2026, 5, 12), 21),
+                new("Quiet space fit-out", -8898.06m, "Soft furnishings, blackout materials, and care supplies.", new LocalDate(2026, 6, 8), 21),
+                new("De-escalation training", -4870.52m, "Short-format crew support and safeguarding refreshers.", new LocalDate(2026, 6, 21), 0)
+            ]),
+        new(
+            Name: "Infrastructure Upgrades",
+            AllocatedAmount: -64190.95m,
+            ExpenditureType: ExpenditureType.CapEx,
+            LineItems:
+            [
+                new("Battery bank expansion", -28224.04m, "Additional storage for overnight critical loads.", new LocalDate(2026, 3, 29), 21),
+                new("Storage and workshop racks", -14236.90m, "Safer storage layout for tools and spares.", new LocalDate(2026, 4, 18), 21),
+                new("Weatherproof staging fixes", -21730.01m, "Reinforcement and replacement of high-wear materials.", new LocalDate(2026, 6, 2), 21)
+            ])
+    ];
+
+    private static readonly BudgetCategorySeed[] TicketingCategories =
+    [
+        new(
+            Name: "Ticket Revenue",
+            AllocatedAmount: 441882.24m,
+            ExpenditureType: ExpenditureType.OpEx,
+            LineItems:
+            [
+                new("Early release wave", 115147.45m, "Initial launch burst including supporter allocation.", new LocalDate(2026, 1, 18), 10),
+                new("Main sale weekend", 152994.85m, "Primary public sales window after line-up announcement.", new LocalDate(2026, 3, 7), 10),
+                new("Final release", 173739.94m, "Late-phase sales including partner holds conversion.", new LocalDate(2026, 5, 29), 10)
+            ]),
+        new(
+            Name: "Processing Fees",
+            AllocatedAmount: -24664.81m,
+            ExpenditureType: ExpenditureType.OpEx,
+            LineItems:
+            [
+                new("Stripe variable fees", -9303.94m, "Percentage fees across card payments.", new LocalDate(2026, 1, 18), 21),
+                new("TicketTailor application fees", -13393.93m, "Vendor fees net of waived organizer promos.", new LocalDate(2026, 3, 7), 21),
+                new("Refund handling and chargebacks", -1966.94m, "Refund costs and disputed payment handling.", new LocalDate(2026, 6, 11), 0)
+            ])
+    ];
+
+    private readonly HumansDbContext _dbContext;
+    private readonly IBudgetService _budgetService;
+    private readonly IClock _clock;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<DevelopmentBudgetSeeder> _logger;
+
+    public DevelopmentBudgetSeeder(
+        HumansDbContext dbContext,
+        IBudgetService budgetService,
+        IClock clock,
+        IMemoryCache cache,
+        ILogger<DevelopmentBudgetSeeder> logger)
+    {
+        _dbContext = dbContext;
+        _budgetService = budgetService;
+        _clock = clock;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<DevelopmentBudgetSeedResult> SeedAsync(Guid actorUserId, CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+        var publicYear = await _dbContext.CampSettings
+            .AsNoTracking()
+            .Select(s => s.PublicYear)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (publicYear <= 0)
+        {
+            publicYear = now.InUtc().Year;
+        }
+
+        var budgetYearCode = $"DEMO-{publicYear}";
+        var budgetYearName = $"Demo Budget {publicYear}";
+
+        var teamsCreated = 0;
+        var teamsUpdated = 0;
+        foreach (var seed in TeamSeeds)
+        {
+            await EnsureBudgetTeamAsync(seed, now, cancellationToken, onCreated: () => teamsCreated++, onUpdated: () => teamsUpdated++);
+        }
+
+        if (teamsCreated > 0 || teamsUpdated > 0)
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            _cache.InvalidateActiveTeams();
+        }
+
+        var budgetYear = await _dbContext.BudgetYears
+            .AsNoTracking()
+            .FirstOrDefaultAsync(y => !y.IsDeleted && y.Year == budgetYearCode, cancellationToken);
+
+        if (budgetYear is null)
+        {
+            budgetYear = await _budgetService.CreateYearAsync(budgetYearCode, budgetYearName, actorUserId);
+        }
+
+        var departmentCategoriesSynced = await _budgetService.SyncDepartmentsAsync(budgetYear.Id, actorUserId);
+
+        var groupsCreated = 0;
+        if (await _budgetService.EnsureTicketingGroupAsync(budgetYear.Id, actorUserId))
+        {
+            groupsCreated++;
+        }
+
+        var activeYear = await _budgetService.GetActiveYearAsync();
+        var activatedBudgetYear = false;
+        if (activeYear is null)
+        {
+            await _budgetService.UpdateYearStatusAsync(budgetYear.Id, BudgetYearStatus.Active, actorUserId);
+            activatedBudgetYear = true;
+        }
+
+        var currentYear = await LoadBudgetYearAsync(budgetYear.Id, cancellationToken);
+        var departmentGroup = currentYear.Groups.Single(g => g.IsDepartmentGroup);
+        await _budgetService.UpdateGroupAsync(departmentGroup.Id, departmentGroup.Name, 0, departmentGroup.IsRestricted, actorUserId);
+
+        var sharedServicesGroup = await EnsureGroupAsync(
+            budgetYear.Id,
+            "Shared Services",
+            sortOrder: 1,
+            isRestricted: false,
+            actorUserId,
+            cancellationToken,
+            onCreated: () => groupsCreated++);
+
+        var ticketingGroup = currentYear.Groups.Single(g => g.IsTicketingGroup);
+        await _budgetService.UpdateGroupAsync(ticketingGroup.Id, ticketingGroup.Name, 2, ticketingGroup.IsRestricted, actorUserId);
+
+        var categoriesCreated = 0;
+        var lineItemsCreated = 0;
+
+        foreach (var teamSeed in TeamSeeds)
+        {
+            var category = await EnsureDepartmentCategoryAsync(
+                departmentGroup.Id,
+                teamSeed,
+                actorUserId,
+                cancellationToken,
+                onCategoryCreated: () => categoriesCreated++);
+
+            await ConfigureCategoryAsync(category.Id, teamSeed.Name, teamSeed.AllocatedAmount, teamSeed.ExpenditureType,
+                teamSeed.LineItems, actorUserId, cancellationToken, onLineItemCreated: () => lineItemsCreated++);
+        }
+
+        foreach (var sharedSeed in SharedServicesCategories)
+        {
+            var category = await EnsureCategoryAsync(
+                sharedServicesGroup.Id,
+                sharedSeed.Name,
+                sharedSeed.AllocatedAmount,
+                sharedSeed.ExpenditureType,
+                teamId: null,
+                actorUserId,
+                cancellationToken,
+                onCategoryCreated: () => categoriesCreated++);
+
+            await ConfigureCategoryAsync(category.Id, sharedSeed.Name, sharedSeed.AllocatedAmount, sharedSeed.ExpenditureType,
+                sharedSeed.LineItems, actorUserId, cancellationToken, onLineItemCreated: () => lineItemsCreated++);
+        }
+
+        foreach (var ticketSeed in TicketingCategories)
+        {
+            var category = await EnsureCategoryAsync(
+                ticketingGroup.Id,
+                ticketSeed.Name,
+                ticketSeed.AllocatedAmount,
+                ticketSeed.ExpenditureType,
+                teamId: null,
+                actorUserId,
+                cancellationToken,
+                onCategoryCreated: () => categoriesCreated++);
+
+            await ConfigureCategoryAsync(category.Id, ticketSeed.Name, ticketSeed.AllocatedAmount, ticketSeed.ExpenditureType,
+                ticketSeed.LineItems, actorUserId, cancellationToken, onLineItemCreated: () => lineItemsCreated++);
+        }
+
+        await _budgetService.UpdateTicketingProjectionAsync(
+            ticketingGroup.Id,
+            startDate: new LocalDate(publicYear, 1, 15),
+            eventDate: new LocalDate(publicYear, 8, 24),
+            initialSalesCount: 550,
+            dailySalesRate: 8.5m,
+            averageTicketPrice: 250m,
+            vatRate: 10,
+            stripeFeePercent: 1.50m,
+            stripeFeeFixed: 0.25m,
+            ticketTailorFeePercent: 3.00m,
+            actorUserId);
+
+        _logger.LogInformation(
+            "Development budget seed completed for {BudgetYearCode}: teamsCreated={TeamsCreated}, teamsUpdated={TeamsUpdated}, categoriesCreated={CategoriesCreated}, lineItemsCreated={LineItemsCreated}",
+            budgetYearCode, teamsCreated, teamsUpdated, categoriesCreated, lineItemsCreated);
+
+        return new DevelopmentBudgetSeedResult(
+            BudgetYearId: budgetYear.Id,
+            BudgetYearCode: budgetYearCode,
+            BudgetYearName: budgetYearName,
+            ActivatedBudgetYear: activatedBudgetYear,
+            TeamsCreated: teamsCreated,
+            TeamsUpdated: teamsUpdated,
+            DepartmentCategoriesSynced: departmentCategoriesSynced,
+            GroupsCreated: groupsCreated,
+            CategoriesCreated: categoriesCreated,
+            LineItemsCreated: lineItemsCreated);
+    }
+
+    private async Task EnsureBudgetTeamAsync(
+        BudgetTeamSeed seed,
+        Instant now,
+        CancellationToken cancellationToken,
+        Action onCreated,
+        Action onUpdated)
+    {
+        var existing = await _dbContext.Teams
+            .FirstOrDefaultAsync(t => t.Slug == seed.Slug, cancellationToken);
+
+        if (existing is null)
+        {
+            _dbContext.Teams.Add(new Team
+            {
+                Id = DeterministicGuid($"dev-budget-team:{seed.Slug}"),
+                Name = seed.Name,
+                Description = seed.Description,
+                Slug = seed.Slug,
+                IsActive = true,
+                RequiresApproval = true,
+                SystemTeamType = SystemTeamType.None,
+                CreatedAt = now,
+                UpdatedAt = now,
+                IsPublicPage = false,
+                ShowCoordinatorsOnPublicPage = true,
+                HasBudget = true,
+                IsHidden = false,
+                IsSensitive = false
+            });
+
+            onCreated();
+            return;
+        }
+
+        var updated = false;
+
+        if (!string.Equals(existing.Name, seed.Name, StringComparison.Ordinal))
+        {
+            existing.Name = seed.Name;
+            updated = true;
+        }
+
+        if (!string.Equals(existing.Description, seed.Description, StringComparison.Ordinal))
+        {
+            existing.Description = seed.Description;
+            updated = true;
+        }
+
+        if (!existing.IsActive)
+        {
+            existing.IsActive = true;
+            updated = true;
+        }
+
+        if (!existing.HasBudget)
+        {
+            existing.HasBudget = true;
+            updated = true;
+        }
+
+        if (existing.SystemTeamType != SystemTeamType.None)
+        {
+            existing.SystemTeamType = SystemTeamType.None;
+            updated = true;
+        }
+
+        if (existing.ParentTeamId is not null)
+        {
+            existing.ParentTeamId = null;
+            updated = true;
+        }
+
+        if (existing.IsHidden)
+        {
+            existing.IsHidden = false;
+            updated = true;
+        }
+
+        if (existing.IsSensitive)
+        {
+            existing.IsSensitive = false;
+            updated = true;
+        }
+
+        if (updated)
+        {
+            existing.UpdatedAt = now;
+            onUpdated();
+        }
+    }
+
+    private async Task<BudgetGroup> EnsureGroupAsync(
+        Guid budgetYearId,
+        string name,
+        int sortOrder,
+        bool isRestricted,
+        Guid actorUserId,
+        CancellationToken cancellationToken,
+        Action onCreated)
+    {
+        var existing = await _dbContext.BudgetGroups
+            .AsNoTracking()
+            .FirstOrDefaultAsync(g => g.BudgetYearId == budgetYearId && g.Name == name, cancellationToken);
+
+        if (existing is null)
+        {
+            var created = await _budgetService.CreateGroupAsync(budgetYearId, name, isRestricted, actorUserId);
+            onCreated();
+            existing = created;
+        }
+
+        await _budgetService.UpdateGroupAsync(existing.Id, name, sortOrder, isRestricted, actorUserId);
+
+        return existing;
+    }
+
+    private async Task<BudgetCategory> EnsureDepartmentCategoryAsync(
+        Guid budgetGroupId,
+        BudgetTeamSeed seed,
+        Guid actorUserId,
+        CancellationToken cancellationToken,
+        Action onCategoryCreated)
+    {
+        var team = await _dbContext.Teams
+            .AsNoTracking()
+            .FirstAsync(t => t.Slug == seed.Slug, cancellationToken);
+
+        var existing = await _dbContext.BudgetCategories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.BudgetGroupId == budgetGroupId && c.TeamId == team.Id, cancellationToken);
+
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        var created = await _budgetService.CreateCategoryAsync(
+            budgetGroupId,
+            seed.Name,
+            seed.AllocatedAmount,
+            seed.ExpenditureType,
+            team.Id,
+            actorUserId);
+
+        onCategoryCreated();
+        return created;
+    }
+
+    private async Task<BudgetCategory> EnsureCategoryAsync(
+        Guid budgetGroupId,
+        string name,
+        decimal allocatedAmount,
+        ExpenditureType expenditureType,
+        Guid? teamId,
+        Guid actorUserId,
+        CancellationToken cancellationToken,
+        Action onCategoryCreated)
+    {
+        var existing = await _dbContext.BudgetCategories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.BudgetGroupId == budgetGroupId && c.Name == name, cancellationToken);
+
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        var created = await _budgetService.CreateCategoryAsync(
+            budgetGroupId,
+            name,
+            allocatedAmount,
+            expenditureType,
+            teamId,
+            actorUserId);
+
+        onCategoryCreated();
+        return created;
+    }
+
+    private async Task ConfigureCategoryAsync(
+        Guid categoryId,
+        string name,
+        decimal allocatedAmount,
+        ExpenditureType expenditureType,
+        IReadOnlyList<BudgetLineItemSeed> lineItems,
+        Guid actorUserId,
+        CancellationToken cancellationToken,
+        Action onLineItemCreated)
+    {
+        var category = await _dbContext.BudgetCategories
+            .AsNoTracking()
+            .FirstAsync(c => c.Id == categoryId, cancellationToken);
+
+        await _budgetService.UpdateCategoryAsync(category.Id, name, allocatedAmount, expenditureType, actorUserId);
+
+        foreach (var lineItem in lineItems)
+        {
+            var existing = await _dbContext.BudgetLineItems
+                .AsNoTracking()
+                .FirstOrDefaultAsync(li => li.BudgetCategoryId == categoryId && li.Description == lineItem.Description, cancellationToken);
+
+            if (existing is null)
+            {
+                await _budgetService.CreateLineItemAsync(
+                    categoryId,
+                    lineItem.Description,
+                    lineItem.Amount,
+                    responsibleTeamId: category.TeamId,
+                    notes: lineItem.Notes,
+                    expectedDate: lineItem.ExpectedDate,
+                    vatRate: lineItem.VatRate,
+                    actorUserId);
+
+                onLineItemCreated();
+                continue;
+            }
+
+            await _budgetService.UpdateLineItemAsync(
+                existing.Id,
+                lineItem.Description,
+                lineItem.Amount,
+                responsibleTeamId: category.TeamId,
+                notes: lineItem.Notes,
+                expectedDate: lineItem.ExpectedDate,
+                vatRate: lineItem.VatRate,
+                actorUserId);
+        }
+    }
+
+    private async Task<BudgetYear> LoadBudgetYearAsync(Guid budgetYearId, CancellationToken cancellationToken)
+    {
+        return await _dbContext.BudgetYears
+            .Include(y => y.Groups)
+                .ThenInclude(g => g.Categories)
+                    .ThenInclude(c => c.LineItems)
+            .Include(y => y.Groups)
+                .ThenInclude(g => g.TicketingProjection)
+            .FirstAsync(y => y.Id == budgetYearId, cancellationToken);
+    }
+
+    private static Guid DeterministicGuid(string value)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var hash = sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(value));
+        return new Guid(hash.AsSpan(0, 16));
+    }
+
+    private sealed record BudgetTeamSeed(
+        string Slug,
+        string Name,
+        string Description,
+        decimal AllocatedAmount,
+        ExpenditureType ExpenditureType,
+        IReadOnlyList<BudgetLineItemSeed> LineItems);
+
+    private sealed record BudgetCategorySeed(
+        string Name,
+        decimal AllocatedAmount,
+        ExpenditureType ExpenditureType,
+        IReadOnlyList<BudgetLineItemSeed> LineItems);
+
+    private sealed record BudgetLineItemSeed(
+        string Description,
+        decimal Amount,
+        string Notes,
+        LocalDate ExpectedDate,
+        int VatRate);
+}

--- a/src/Humans.Web/Infrastructure/DevelopmentTicketSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentTicketSeeder.cs
@@ -1,0 +1,731 @@
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NodaTime;
+
+namespace Humans.Web.Infrastructure;
+
+public sealed record DevelopmentTicketSeedResult(
+    int PaidOrders,
+    int NonPaidOrders,
+    int OrdersCreated,
+    int AttendeesCreated,
+    int PaidTicketsSold,
+    decimal GrossRevenue,
+    decimal DonationRevenue,
+    decimal DiscountTotal,
+    int OrdersWithDonation,
+    int OrdersWithDiscountCode,
+    int MatchedOrders,
+    int MatchedAttendees,
+    int TwoTicketOrders);
+
+public sealed class DevelopmentTicketSeeder
+{
+    private const string DemoOrderPrefix = "dev-order-";
+    private const string DemoTicketPrefix = "dev-ticket-";
+    private const int TargetPaidTickets = 600;
+    private const int TargetPaidRevenueEuros = 200000;
+    private const int TwoTicketPaidOrders = 150;
+    private const int SingleTicketPaidOrders = 300;
+
+    private static readonly TicketTypeSeed[] PaidTicketMix =
+    [
+        new("Low income", 100m, 90),
+        new("Contributor", 250m, 150),
+        new("Standard", 275m, 210),
+        new("VIP", 400m, 150)
+    ];
+
+    private static readonly decimal[] VipDonationOptions = [50m, 75m, 100m, 150m, 200m, 250m, 300m, 500m];
+    private static readonly decimal[] ContributorDonationOptions = [25m, 35m, 50m, 75m, 100m, 150m, 200m, 250m];
+    private static readonly decimal[] StandardDonationOptions = [10m, 15m, 20m, 25m, 35m, 50m, 75m, 100m];
+    private static readonly decimal[] LowIncomeDonationOptions = [5m, 10m, 15m, 20m, 25m, 35m, 50m];
+
+    private static readonly string[] FirstNames =
+    [
+        "Ariadna", "Mateo", "Lucia", "Pau", "Ines", "Jules", "Nora", "Leo", "Clara", "Hugo",
+        "Noa", "Dario", "Marta", "Teo", "Sofia", "Bruno", "Laia", "Nico", "Mila", "Izan"
+    ];
+
+    private static readonly string[] LastNames =
+    [
+        "Soler", "Campos", "Navarro", "Torres", "Arias", "Costa", "Benet", "Ferrer", "Lopez", "Mora",
+        "Sala", "Vidal", "Roig", "Pons", "Santos", "Prats", "Valle", "Luna", "Guasch", "Casals"
+    ];
+
+    private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
+    private readonly TicketVendorSettings _settings;
+    private readonly ILogger<DevelopmentTicketSeeder> _logger;
+
+    public DevelopmentTicketSeeder(
+        HumansDbContext dbContext,
+        IClock clock,
+        IOptions<TicketVendorSettings> settings,
+        ILogger<DevelopmentTicketSeeder> logger)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    public async Task<DevelopmentTicketSeedResult> SeedAsync(CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+        var eventId = string.IsNullOrWhiteSpace(_settings.EventId) ? "dev-seeded-event" : _settings.EventId;
+        var knownUsers = await LoadKnownUsersAsync(cancellationToken);
+
+        await RemoveExistingDemoDataAsync(cancellationToken);
+
+        var paidOrders = BuildPaidOrders(knownUsers, eventId);
+        AdjustPaidRevenueToTarget(paidOrders, TargetPaidRevenueEuros);
+        AssignPaidPurchaseDates(paidOrders, now.InUtc().Date.Year);
+        var nonPaidOrders = BuildNonPaidOrders(knownUsers, eventId);
+
+        var orderEntities = new List<TicketOrder>();
+        var attendeeEntities = new List<TicketAttendee>();
+
+        foreach (var plan in paidOrders.Concat(nonPaidOrders))
+        {
+            var orderId = Guid.NewGuid();
+            var (stripeFee, applicationFee) = plan.PaymentStatus == TicketPaymentStatus.Paid
+                ? ComputeFees(plan.TotalAmount, plan.PaymentMethod, plan.PaymentMethodDetail)
+                : ((decimal?)null, (decimal?)null);
+
+            var order = new TicketOrder
+            {
+                Id = orderId,
+                VendorOrderId = plan.VendorOrderId,
+                BuyerName = plan.BuyerName,
+                BuyerEmail = plan.BuyerEmail,
+                MatchedUserId = plan.MatchedBuyerUserId,
+                TotalAmount = plan.TotalAmount,
+                Currency = "EUR",
+                DiscountCode = plan.DiscountCode,
+                PaymentStatus = plan.PaymentStatus,
+                VendorEventId = eventId,
+                VendorDashboardUrl = $"https://demo.tickettailor.local/orders/{plan.VendorOrderId}",
+                PurchasedAt = plan.PurchasedAt,
+                SyncedAt = now,
+                StripePaymentIntentId = plan.PaymentStatus == TicketPaymentStatus.Paid
+                    ? $"pi_demo_{plan.OrderNumber:D6}"
+                    : null,
+                PaymentMethod = plan.PaymentMethod,
+                PaymentMethodDetail = plan.PaymentMethodDetail,
+                StripeFee = stripeFee,
+                ApplicationFee = applicationFee,
+                DiscountAmount = plan.DiscountAmount > 0 ? plan.DiscountAmount : null,
+                DonationAmount = plan.DonationAmount,
+                VatAmount = ComputeOrderVat(plan)
+            };
+
+            orderEntities.Add(order);
+
+            for (var ticketIndex = 0; ticketIndex < plan.Attendees.Count; ticketIndex++)
+            {
+                var ticket = plan.Attendees[ticketIndex];
+                attendeeEntities.Add(new TicketAttendee
+                {
+                    Id = Guid.NewGuid(),
+                    VendorTicketId = $"{DemoTicketPrefix}{plan.OrderNumber:D4}-{ticketIndex + 1:D2}",
+                    TicketOrderId = orderId,
+                    AttendeeName = ticket.AttendeeName,
+                    AttendeeEmail = ticket.AttendeeEmail,
+                    MatchedUserId = ticket.MatchedUserId,
+                    TicketTypeName = ticket.TicketTypeName,
+                    Price = ticket.Price,
+                    Status = ticket.Status,
+                    VendorEventId = eventId,
+                    SyncedAt = now
+                });
+            }
+        }
+
+        _dbContext.TicketOrders.AddRange(orderEntities);
+        _dbContext.TicketAttendees.AddRange(attendeeEntities);
+
+        var syncState = await _dbContext.TicketSyncStates.FindAsync([1], cancellationToken);
+        if (syncState is not null)
+        {
+            syncState.VendorEventId = eventId;
+            syncState.SyncStatus = TicketSyncStatus.Idle;
+            syncState.LastError = null;
+            syncState.LastSyncAt = now;
+            syncState.StatusChangedAt = now;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var paidOrdersList = paidOrders.ToList();
+        var paidTicketsSold = paidOrdersList.Sum(o => o.Attendees.Count(a => a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn));
+        var grossRevenue = paidOrdersList.Sum(o => o.TotalAmount);
+        var donationRevenue = paidOrdersList.Sum(o => o.DonationAmount);
+        var discountTotal = paidOrdersList.Sum(o => o.DiscountAmount);
+        var matchedOrders = paidOrdersList.Count(o => o.MatchedBuyerUserId.HasValue);
+        var matchedAttendees = paidOrdersList.Sum(o => o.Attendees.Count(a => a.MatchedUserId.HasValue));
+
+        _logger.LogInformation(
+            "Development ticket seed completed: paidOrders={PaidOrders}, nonPaidOrders={NonPaidOrders}, ticketsSold={TicketsSold}, grossRevenue={GrossRevenue}",
+            paidOrdersList.Count, nonPaidOrders.Count, paidTicketsSold, grossRevenue);
+
+        return new DevelopmentTicketSeedResult(
+            PaidOrders: paidOrdersList.Count,
+            NonPaidOrders: nonPaidOrders.Count,
+            OrdersCreated: orderEntities.Count,
+            AttendeesCreated: attendeeEntities.Count,
+            PaidTicketsSold: paidTicketsSold,
+            GrossRevenue: grossRevenue,
+            DonationRevenue: donationRevenue,
+            DiscountTotal: discountTotal,
+            OrdersWithDonation: paidOrdersList.Count(o => o.DonationAmount > 0),
+            OrdersWithDiscountCode: paidOrdersList.Count(o => o.DiscountAmount > 0),
+            MatchedOrders: matchedOrders,
+            MatchedAttendees: matchedAttendees,
+            TwoTicketOrders: paidOrdersList.Count(o => o.Attendees.Count == 2));
+    }
+
+    private async Task<List<KnownUserSeed>> LoadKnownUsersAsync(CancellationToken cancellationToken)
+    {
+        return await _dbContext.UserEmails
+            .Where(e => e.IsVerified)
+            .OrderBy(e => e.Email)
+            .Select(e => new KnownUserSeed(
+                e.UserId,
+                e.Email,
+                e.User.DisplayName ?? e.User.Email ?? e.Email))
+            .ToListAsync(cancellationToken);
+    }
+
+    private async Task RemoveExistingDemoDataAsync(CancellationToken cancellationToken)
+    {
+        var existingAttendees = await _dbContext.TicketAttendees
+            .Where(a => EF.Functions.Like(a.VendorTicketId, $"{DemoTicketPrefix}%"))
+            .ToListAsync(cancellationToken);
+
+        if (existingAttendees.Count > 0)
+        {
+            _dbContext.TicketAttendees.RemoveRange(existingAttendees);
+        }
+
+        var existingOrders = await _dbContext.TicketOrders
+            .Where(o => EF.Functions.Like(o.VendorOrderId, $"{DemoOrderPrefix}%"))
+            .ToListAsync(cancellationToken);
+
+        if (existingOrders.Count > 0)
+        {
+            _dbContext.TicketOrders.RemoveRange(existingOrders);
+        }
+
+        if (existingAttendees.Count > 0 || existingOrders.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private static List<PlannedOrder> BuildPaidOrders(
+        IReadOnlyList<KnownUserSeed> knownUsers,
+        string eventId)
+    {
+        var paidTicketPool = BuildPaidTicketPool(knownUsers);
+        var orderSizes = Enumerable.Repeat(2, TwoTicketPaidOrders)
+            .Concat(Enumerable.Repeat(1, SingleTicketPaidOrders))
+            .Select((size, index) => new { size, SortKey = DeterministicGuid($"dev-paid-order-size:{index}:{size}") })
+            .OrderBy(x => x.SortKey)
+            .Select(x => x.size)
+            .ToList();
+
+        var orders = new List<PlannedOrder>(orderSizes.Count);
+        var ticketCursor = 0;
+
+        for (var orderIndex = 0; orderIndex < orderSizes.Count; orderIndex++)
+        {
+            var size = orderSizes[orderIndex];
+            var attendees = paidTicketPool.Skip(ticketCursor).Take(size).ToList();
+            ticketCursor += size;
+
+            var matchedBuyer = orderIndex % 57 == 0 && knownUsers.Count > 0
+                ? knownUsers[(orderIndex / 57) % knownUsers.Count]
+                : null;
+
+            var buyer = BuildBuyer(orderIndex, attendees, matchedBuyer);
+            var (paymentMethod, paymentMethodDetail) = GetPaymentMethod(orderIndex);
+
+            var order = new PlannedOrder
+            {
+                OrderNumber = orderIndex + 1,
+                VendorOrderId = $"{DemoOrderPrefix}{orderIndex + 1:D4}",
+                BuyerName = buyer.Name,
+                BuyerEmail = buyer.Email,
+                MatchedBuyerUserId = matchedBuyer?.UserId,
+                PaymentStatus = TicketPaymentStatus.Paid,
+                PurchasedAt = Instant.FromUtc(2026, 3, 14, 9, 0),
+                PaymentMethod = paymentMethod,
+                PaymentMethodDetail = paymentMethodDetail
+            };
+
+            order.Attendees.AddRange(attendees);
+
+            if (ShouldApplyDiscount(orderIndex))
+            {
+                order.DiscountCode = BuildDiscountCode(orderIndex, attendees[0].TicketTypeName);
+                order.DiscountAmount = GetDiscountAmount(attendees[0].TicketTypeName);
+            }
+
+            order.DonationAmount = GetInitialDonation(orderIndex, attendees);
+            order.TotalAmount = ComputeOrderTotal(order.Attendees, order.DiscountAmount, order.DonationAmount);
+            orders.Add(order);
+        }
+
+        return orders;
+    }
+
+    private static List<PlannedOrder> BuildNonPaidOrders(
+        IReadOnlyList<KnownUserSeed> knownUsers,
+        string eventId)
+    {
+        var templates = new (TicketPaymentStatus Status, string[] TicketTypes)[]
+        {
+            (TicketPaymentStatus.Pending, ["Standard"]),
+            (TicketPaymentStatus.Pending, ["Contributor", "Standard"]),
+            (TicketPaymentStatus.Pending, ["Low income"]),
+            (TicketPaymentStatus.Pending, ["VIP"]),
+            (TicketPaymentStatus.Refunded, ["Standard"]),
+            (TicketPaymentStatus.Refunded, ["VIP", "Contributor"]),
+            (TicketPaymentStatus.Refunded, ["Low income"]),
+            (TicketPaymentStatus.Cancelled, ["Standard"]),
+            (TicketPaymentStatus.Cancelled, ["Contributor"]),
+            (TicketPaymentStatus.Cancelled, ["VIP", "Standard"])
+        };
+
+        var orders = new List<PlannedOrder>(templates.Length);
+
+        for (var index = 0; index < templates.Length; index++)
+        {
+            var template = templates[index];
+            var attendees = template.TicketTypes
+                .Select((ticketType, ticketIndex) =>
+                {
+                    var price = GetTicketPrice(ticketType);
+                    var person = BuildSyntheticPerson(700 + (index * 3) + ticketIndex, "guest");
+                    return new PlannedTicket
+                    {
+                        TicketTypeName = ticketType,
+                        Price = price,
+                        SortKey = DeterministicGuid($"dev-nonpaid-ticket:{index}:{ticketIndex}:{ticketType}"),
+                        AttendeeName = person.Name,
+                        AttendeeEmail = person.Email,
+                        Status = TicketAttendeeStatus.Void
+                    };
+                })
+                .ToList();
+
+            var buyerSeed = BuildSyntheticPerson(900 + index, "buyer");
+            var buyer = index % 4 == 0 && knownUsers.Count > 0
+                ? new BuyerSeed(knownUsers[index % knownUsers.Count].DisplayName, knownUsers[index % knownUsers.Count].Email)
+                : new BuyerSeed(buyerSeed.Name, buyerSeed.Email);
+
+            var order = new PlannedOrder
+            {
+                OrderNumber = SingleTicketPaidOrders + TwoTicketPaidOrders + index + 1,
+                VendorOrderId = $"{DemoOrderPrefix}{SingleTicketPaidOrders + TwoTicketPaidOrders + index + 1:D4}",
+                BuyerName = buyer.Name,
+                BuyerEmail = buyer.Email,
+                MatchedBuyerUserId = index % 4 == 0 && knownUsers.Count > 0 ? knownUsers[index % knownUsers.Count].UserId : null,
+                PaymentStatus = template.Status,
+                PurchasedAt = GetNonPaidPurchaseInstant(index),
+                PaymentMethod = index % 2 == 0 ? "card" : null,
+                PaymentMethodDetail = index % 2 == 0 ? "visa" : null
+            };
+
+            order.Attendees.AddRange(attendees);
+            if (index % 3 == 0)
+            {
+                order.DiscountCode = BuildDiscountCode(800 + index, attendees[0].TicketTypeName);
+                order.DiscountAmount = GetDiscountAmount(attendees[0].TicketTypeName);
+            }
+
+            order.TotalAmount = ComputeOrderTotal(order.Attendees, order.DiscountAmount, 0m);
+            orders.Add(order);
+        }
+
+        return orders;
+    }
+
+    private static List<PlannedTicket> BuildPaidTicketPool(IReadOnlyList<KnownUserSeed> knownUsers)
+    {
+        var pool = new List<PlannedTicket>(TargetPaidTickets);
+
+        foreach (var seed in PaidTicketMix)
+        {
+            for (var i = 0; i < seed.Count; i++)
+            {
+                pool.Add(new PlannedTicket
+                {
+                    TicketTypeName = seed.Name,
+                    Price = seed.Price,
+                    Status = TicketAttendeeStatus.Valid,
+                    SortKey = DeterministicGuid($"dev-ticket-pool:{seed.Name}:{i}")
+                });
+            }
+        }
+
+        pool = pool
+            .OrderBy(t => t.SortKey)
+            .ToList();
+
+        var matchedAttendeeCount = Math.Min(4, knownUsers.Count);
+        for (var i = 0; i < matchedAttendeeCount; i++)
+        {
+            pool[i].AttendeeName = knownUsers[i].DisplayName;
+            pool[i].AttendeeEmail = knownUsers[i].Email;
+            pool[i].MatchedUserId = knownUsers[i].UserId;
+        }
+
+        for (var i = matchedAttendeeCount; i < pool.Count; i++)
+        {
+            var person = BuildSyntheticPerson(i + 1, i % 5 == 0 ? "crew" : "guest");
+            pool[i].AttendeeName = person.Name;
+            pool[i].AttendeeEmail = (i % 17 == 0 || i % 29 == 0) ? null : person.Email;
+        }
+
+        return pool;
+    }
+
+    private static BuyerSeed BuildBuyer(
+        int orderIndex,
+        IReadOnlyList<PlannedTicket> attendees,
+        KnownUserSeed? matchedBuyer)
+    {
+        if (matchedBuyer is not null)
+        {
+            return new BuyerSeed(matchedBuyer.DisplayName, matchedBuyer.Email);
+        }
+
+        if (attendees.Count == 1 && !string.IsNullOrWhiteSpace(attendees[0].AttendeeEmail))
+        {
+            return new BuyerSeed(attendees[0].AttendeeName, attendees[0].AttendeeEmail!);
+        }
+
+        if (attendees.Count > 1 && orderIndex % 4 != 0 && !string.IsNullOrWhiteSpace(attendees[0].AttendeeEmail))
+        {
+            return new BuyerSeed(attendees[0].AttendeeName, attendees[0].AttendeeEmail!);
+        }
+
+        var person = BuildSyntheticPerson(400 + orderIndex, "buyer");
+        return new BuyerSeed(person.Name, person.Email);
+    }
+
+    private static bool ShouldApplyDiscount(int orderIndex) => orderIndex % 11 == 0;
+
+    private static string BuildDiscountCode(int orderIndex, string ticketTypeName)
+    {
+        var prefix = ticketTypeName switch
+        {
+            "Low income" => "SOLIDARITY",
+            "Contributor" => "CREW",
+            "Standard" => "COMMUNITY",
+            "VIP" => "PATRON",
+            _ => "DEMO"
+        };
+
+        return $"{prefix}-2026-{orderIndex + 1:D3}";
+    }
+
+    private static decimal GetDiscountAmount(string ticketTypeName) => ticketTypeName switch
+    {
+        "Low income" => 15m,
+        "Contributor" => 30m,
+        "Standard" => 40m,
+        "VIP" => 50m,
+        _ => 20m
+    };
+
+    private static decimal GetInitialDonation(int orderIndex, IReadOnlyList<PlannedTicket> attendees)
+    {
+        var containsVip = attendees.Any(a => string.Equals(a.TicketTypeName, "VIP", StringComparison.Ordinal));
+        var containsContributor = attendees.Any(a => string.Equals(a.TicketTypeName, "Contributor", StringComparison.Ordinal));
+        var containsStandard = attendees.Any(a => string.Equals(a.TicketTypeName, "Standard", StringComparison.Ordinal));
+
+        if (containsVip && orderIndex % 2 == 0)
+        {
+            return VipDonationOptions[(orderIndex / 2) % VipDonationOptions.Length];
+        }
+
+        if (containsContributor && orderIndex % 3 == 0)
+        {
+            return ContributorDonationOptions[(orderIndex / 3) % ContributorDonationOptions.Length];
+        }
+
+        if (containsStandard && orderIndex % 4 == 0)
+        {
+            return StandardDonationOptions[(orderIndex / 4) % StandardDonationOptions.Length];
+        }
+
+        if (orderIndex % 7 == 0)
+        {
+            return LowIncomeDonationOptions[(orderIndex / 7) % LowIncomeDonationOptions.Length];
+        }
+
+        return 0m;
+    }
+
+    private static void AdjustPaidRevenueToTarget(List<PlannedOrder> orders, decimal targetGrossRevenue)
+    {
+        var currentRevenue = orders.Sum(o => o.TotalAmount);
+        var diff = targetGrossRevenue - currentRevenue;
+
+        if (diff < 0)
+        {
+            throw new InvalidOperationException(
+                $"Ticket seed overshot the gross revenue target by {Math.Abs(diff):N2}. Adjust the baseline mix first.");
+        }
+
+        var adjustableOrders = orders
+            .OrderByDescending(o => o.Attendees.Any(a => string.Equals(a.TicketTypeName, "VIP", StringComparison.Ordinal)))
+            .ThenByDescending(o => o.Attendees.Any(a => string.Equals(a.TicketTypeName, "Contributor", StringComparison.Ordinal)))
+            .ThenByDescending(o => o.Attendees.Count)
+            .ToList();
+
+        foreach (var order in adjustableOrders)
+        {
+            if (diff <= 0)
+            {
+                break;
+            }
+
+            var remainingHeadroom = 500m - order.DonationAmount;
+            if (remainingHeadroom <= 0)
+            {
+                continue;
+            }
+
+            var increment = Math.Min(remainingHeadroom, diff);
+            order.DonationAmount += increment;
+            order.TotalAmount = ComputeOrderTotal(order.Attendees, order.DiscountAmount, order.DonationAmount);
+            diff -= increment;
+        }
+
+        if (diff != 0)
+        {
+            throw new InvalidOperationException($"Unable to hit ticket gross revenue target exactly. Remaining diff: {diff:N2}");
+        }
+    }
+
+    private static decimal ComputeOrderTotal(
+        IReadOnlyList<PlannedTicket> attendees,
+        decimal discountAmount,
+        decimal donationAmount)
+    {
+        var ticketTotal = attendees.Sum(a => a.Price);
+        return Math.Round(ticketTotal - discountAmount + donationAmount, 2);
+    }
+
+    private static decimal ComputeOrderVat(PlannedOrder order)
+    {
+        if (order.PaymentStatus != TicketPaymentStatus.Paid)
+        {
+            return 0m;
+        }
+
+        var totalVat = order.Attendees
+            .Where(a => a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn)
+            .Sum(a => Math.Round(Math.Min(a.Price, TicketConstants.VipThresholdEuros) * TicketConstants.VatRate / (1 + TicketConstants.VatRate), 2));
+
+        return Math.Round(totalVat, 2);
+    }
+
+    private static void AssignPaidPurchaseDates(List<PlannedOrder> orders, int seasonYear)
+    {
+        var firstSaleDate = new LocalDate(seasonYear, 3, 14);
+        var finalSaleDate = new LocalDate(seasonYear, 4, 5);
+        var dailyTicketQuotas = BuildDailyTicketQuotas(firstSaleDate, finalSaleDate, TargetPaidTickets);
+
+        var cumulativeTickets = 0;
+        foreach (var order in orders)
+        {
+            var soldTickets = order.Attendees.Count(a => a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn);
+            var midpointTicket = cumulativeTickets + (soldTickets / 2m);
+            var day = ResolveTicketSaleDate(midpointTicket, dailyTicketQuotas);
+            order.PurchasedAt = CreatePurchaseInstant(day, order.OrderNumber);
+            cumulativeTickets += soldTickets;
+        }
+    }
+
+    private static List<DailyTicketQuota> BuildDailyTicketQuotas(
+        LocalDate firstSaleDate,
+        LocalDate finalSaleDate,
+        int totalTickets)
+    {
+        var firstBurstTickets = (int)Math.Round(totalTickets * 0.40m, MidpointRounding.AwayFromZero);
+        var secondBurstTickets = (int)Math.Round(totalTickets * 0.20m, MidpointRounding.AwayFromZero);
+        var remainingTickets = totalTickets - firstBurstTickets - secondBurstTickets;
+
+        var phaseOneDates = Enumerable.Range(0, 3).Select(offset => firstSaleDate.PlusDays(offset)).ToList();
+        var phaseTwoDates = Enumerable.Range(3, 4).Select(offset => firstSaleDate.PlusDays(offset)).ToList();
+        var phaseThreeDates = Enumerable.Range(7, Period.Between(firstSaleDate.PlusDays(7), finalSaleDate.PlusDays(1), PeriodUnits.Days).Days)
+            .Select(offset => firstSaleDate.PlusDays(offset))
+            .ToList();
+
+        var quotas = new List<DailyTicketQuota>();
+        quotas.AddRange(DistributeTicketsAcrossDates(firstBurstTickets, phaseOneDates));
+        quotas.AddRange(DistributeTicketsAcrossDates(secondBurstTickets, phaseTwoDates));
+        quotas.AddRange(DistributeTicketsAcrossDates(remainingTickets, phaseThreeDates));
+        return quotas;
+    }
+
+    private static IEnumerable<DailyTicketQuota> DistributeTicketsAcrossDates(
+        int totalTickets,
+        IReadOnlyList<LocalDate> dates)
+    {
+        if (dates.Count == 0)
+        {
+            yield break;
+        }
+
+        var baseTickets = totalTickets / dates.Count;
+        var remainder = totalTickets % dates.Count;
+
+        for (var i = 0; i < dates.Count; i++)
+        {
+            yield return new DailyTicketQuota(
+                dates[i],
+                baseTickets + (i < remainder ? 1 : 0));
+        }
+    }
+
+    private static LocalDate ResolveTicketSaleDate(decimal midpointTicket, IReadOnlyList<DailyTicketQuota> dailyTicketQuotas)
+    {
+        decimal runningTotal = 0;
+        foreach (var quota in dailyTicketQuotas)
+        {
+            runningTotal += quota.TicketCount;
+            if (midpointTicket < runningTotal)
+            {
+                return quota.Date;
+            }
+        }
+
+        return dailyTicketQuotas[^1].Date;
+    }
+
+    private static Instant CreatePurchaseInstant(LocalDate date, int orderNumber)
+    {
+        var localTime = new LocalTime(9 + (orderNumber % 9), (orderNumber * 11) % 60);
+        return date.At(localTime).InZoneStrictly(DateTimeZone.Utc).ToInstant();
+    }
+
+    private static (decimal StripeFee, decimal ApplicationFee) ComputeFees(
+        decimal totalAmount,
+        string? paymentMethod,
+        string? paymentMethodDetail)
+    {
+        if (string.IsNullOrWhiteSpace(paymentMethod))
+        {
+            return (0m, 0m);
+        }
+
+        var (variableRate, fixedFee) = paymentMethod switch
+        {
+            "card" when string.Equals(paymentMethodDetail, "visa", StringComparison.OrdinalIgnoreCase) => (0.0145m, 0.25m),
+            "card" when string.Equals(paymentMethodDetail, "mastercard", StringComparison.OrdinalIgnoreCase) => (0.0149m, 0.25m),
+            "link" => (0.0150m, 0.25m),
+            "ideal" => (0.0165m, 0.20m),
+            "bancontact" => (0.0170m, 0.20m),
+            "klarna" => (0.0240m, 0.35m),
+            _ => (0.0150m, 0.25m)
+        };
+
+        var stripeFee = Math.Round((totalAmount * variableRate) + fixedFee, 2);
+        var applicationFee = Math.Round(Math.Max(totalAmount * 0.03m, 0.30m), 2);
+        return (stripeFee, applicationFee);
+    }
+
+    private static (string PaymentMethod, string? PaymentMethodDetail) GetPaymentMethod(int orderIndex) => (orderIndex % 12) switch
+    {
+        0 or 1 or 2 or 3 => ("card", "visa"),
+        4 or 5 => ("card", "mastercard"),
+        6 => ("link", null),
+        7 => ("ideal", null),
+        8 => ("bancontact", null),
+        9 => ("klarna", null),
+        _ => ("card", "visa")
+    };
+
+    private static Instant GetNonPaidPurchaseInstant(int index)
+    {
+        var date = new LocalDate(2026, 4, 1).PlusDays(index / 3);
+        var time = new LocalTime(10 + (index % 6), (index * 13) % 60);
+        return date.At(time).InZoneStrictly(DateTimeZone.Utc).ToInstant();
+    }
+
+    private static decimal GetTicketPrice(string ticketTypeName) => ticketTypeName switch
+    {
+        "Low income" => 100m,
+        "Contributor" => 250m,
+        "Standard" => 275m,
+        "VIP" => 400m,
+        _ => 0m
+    };
+
+    private static BuyerSeed BuildSyntheticPerson(int seed, string role)
+    {
+        var first = FirstNames[(seed * 7) % FirstNames.Length];
+        var last = LastNames[(seed * 11) % LastNames.Length];
+        var name = $"{first} {last}";
+        var email = $"{Slugify(first)}.{Slugify(last)}.{role}.{seed:D4}@ticketseed.local";
+        return new BuyerSeed(name, email);
+    }
+
+    private static string Slugify(string value) =>
+        string.Concat(value
+            .ToLowerInvariant()
+            .Where(char.IsLetterOrDigit));
+
+    private static Guid DeterministicGuid(string value)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var hash = sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(value));
+        return new Guid(hash.AsSpan(0, 16));
+    }
+
+    private sealed record TicketTypeSeed(string Name, decimal Price, int Count);
+    private sealed record KnownUserSeed(Guid UserId, string Email, string DisplayName);
+    private sealed record BuyerSeed(string Name, string Email);
+
+    private sealed class PlannedOrder
+    {
+        public required int OrderNumber { get; init; }
+        public required string VendorOrderId { get; init; }
+        public required string BuyerName { get; init; }
+        public required string BuyerEmail { get; init; }
+        public Guid? MatchedBuyerUserId { get; init; }
+        public required TicketPaymentStatus PaymentStatus { get; init; }
+        public Instant PurchasedAt { get; set; }
+        public string? DiscountCode { get; set; }
+        public decimal DiscountAmount { get; set; }
+        public decimal DonationAmount { get; set; }
+        public decimal TotalAmount { get; set; }
+        public string? PaymentMethod { get; init; }
+        public string? PaymentMethodDetail { get; init; }
+        public List<PlannedTicket> Attendees { get; } = [];
+    }
+
+    private sealed class PlannedTicket
+    {
+        public required string TicketTypeName { get; init; }
+        public required decimal Price { get; init; }
+        public required Guid SortKey { get; init; }
+        public required TicketAttendeeStatus Status { get; init; }
+        public string AttendeeName { get; set; } = string.Empty;
+        public string? AttendeeEmail { get; set; }
+        public Guid? MatchedUserId { get; set; }
+    }
+
+    private sealed record DailyTicketQuota(LocalDate Date, int TicketCount);
+}

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -66,6 +66,8 @@ builder.Services.AddSingleton(configRegistry);
 
 // Configure NodaTime clock
 builder.Services.AddSingleton<IClock>(SystemClock.Instance);
+builder.Services.AddScoped<DevelopmentBudgetSeeder>();
+builder.Services.AddScoped<DevelopmentTicketSeeder>();
 
 // Configure JSON options with NodaTime support
 builder.Services.ConfigureHttpJsonOptions(options =>


### PR DESCRIPTION
## What changed

This PR adds a dev-only seeding workflow for richer local feature data.

- adds a budget demo seeder exposed via `/dev/seed/budget`
- adds a ticketing demo seeder exposed via `/dev/seed/tickets`
- adds a dev-only `StubTicketVendorService` path so local seeded ticket data can drive `/Tickets` without real TicketTailor credentials
- documents the seed-data approach in `docs/seed-data.md` and links it from the docs index
- keeps the TicketTailor registration path explicit so it is easy to see when the live client is used versus the dev stub

## Why

The repository already had bootstrap seed data and dev login personas, but it did not yet have a clear pattern for realistic operational demo data such as budgets and ticket sales.

That made local finance and ticketing development harder, because the screens could render but did not have believable data behind them unless a real external setup already existed.

## Impact

- local development can now seed budget and ticket data on demand
- the finance screens have realistic sample budget structure and totals
- the ticketing screens can be explored locally without real TicketTailor credentials when `DevAuth:Enabled=true`
- the seed-data strategy is now documented for future work

## Validation

- `dotnet build src/Humans.Web/Humans.Web.csproj -v minimal`
- manually ran the app locally and executed both seed endpoints
- verified `/Finance` renders the seeded budget totals and VAT summary data
- verified `/Tickets` renders from the dev stub with seeded ticket orders and attendees

## Notes

These seeders are intended for local and dev use only. They are explicit, on-demand, and separate from foundational `HasData` bootstrap rows and migration backfills.
