### PR TITLE
Fix: show Add Category form on non-empty budget groups

### DIFF
--- a/src/Humans.Web/Views/Finance/YearDetail.cshtml
+++ b/src/Humans.Web/Views/Finance/YearDetail.cshtml
@@ -360,7 +360,7 @@
                     }
                     </div>
                 }
-                else if (!group.IsTicketingGroup)
+                @if (!group.IsTicketingGroup)
                 {
                     <div class="p-3 border-top bg-light">
                         <form asp-action="CreateCategory" method="post" class="row g-2 align-items-end">


### PR DESCRIPTION
## Summary
- The "Add Category" form on `/Finance/YearDetail` was inside an `else if` branch, so it only rendered for groups with zero categories
- Changed to a separate `@if (!group.IsTicketingGroup)` block so it always shows for non-ticketing groups

Closes #399

## Test plan
- [ ] Navigate to `/Finance/YearDetail` for a year with groups that have categories → "Add Category" form visible
- [ ] Empty groups still show the form
- [ ] Ticketing groups still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)