### PR TITLE
Fix all communication preference review findings from PR #208

### DIFF
--- a/.github/workflows/label-db.yml
+++ b/.github/workflows/label-db.yml
@@ -1,0 +1,51 @@
+name: Label PRs with EF migrations
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for migration files in PR diff
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+
+            const hasMigration = files.some(f =>
+              f.filename.startsWith('src/Humans.Infrastructure/Migrations/') &&
+              f.status !== 'removed'
+            );
+
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const hasLabel = labels.includes('db');
+
+            if (hasMigration && !hasLabel) {
+              core.info('Migration files found — adding db label');
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ['db']
+              });
+            } else if (!hasMigration && hasLabel) {
+              core.info('No migration files — removing db label');
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'db'
+              });
+            } else {
+              core.info(`No change needed (migrations: ${hasMigration}, label: ${hasLabel})`);
+            }

--- a/docs/architecture/service-data-access-map.md
+++ b/docs/architecture/service-data-access-map.md
@@ -1,0 +1,1085 @@
+# Service Data Access Map
+
+Audit of which services access which database tables and cache keys, organized by section.
+The goal is to identify cross-section table overlap, duplicated caching, and cache configuration issues.
+
+**Generated:** 2026-04-10
+
+---
+
+## Table of Contents
+
+1. [Profiles & Accounts](#profiles--accounts)
+2. [Onboarding & Governance](#onboarding--governance)
+3. [Teams](#teams)
+4. [Google Integration](#google-integration)
+5. [Camps & City Planning](#camps--city-planning)
+6. [Shifts](#shifts)
+7. [Legal & Consent](#legal--consent)
+8. [Notifications](#notifications)
+9. [Tickets](#tickets)
+10. [Budget](#budget)
+11. [Campaigns](#campaigns)
+12. [Email](#email)
+13. [Feedback](#feedback)
+14. [Admin & Infrastructure](#admin--infrastructure)
+15. [Cross-Section Analysis](#cross-section-analysis)
+16. [Cache Inventory](#cache-inventory)
+17. [Appendix A: Out-of-Service Database Access](#appendix-a-out-of-service-database-access)
+18. [Appendix B: Out-of-Service Cache Access](#appendix-b-out-of-service-cache-access)
+
+---
+
+## Profiles & Accounts
+
+### ProfileService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Profiles | R/W |
+| Users | R/W |
+| Applications | R/W |
+| CampaignGrants | R |
+| EventSettings | R |
+| TicketSyncStates | R |
+| TicketOrders | R |
+| TicketAttendees | R |
+| TeamRoleAssignments | R/W |
+| TeamMembers | R |
+| VolunteerHistoryEntries | R |
+| ContactFields | R |
+| CommunicationPreferences | R |
+| ConsentRecords | R |
+| VolunteerEventProfiles | R/W |
+
+| Cache Key | TTL | Read | Write | Invalidate |
+|-----------|-----|------|-------|------------|
+| `UserProfile:{userId}` | 2 min | yes | yes | yes |
+| `ApprovedProfiles` | 10 min | yes | yes | yes |
+| `NavBadgeCounts` | 2 min | | | yes |
+| `NotificationMeters` | 2 min | | | yes |
+| `ActiveTeams` | 10 min | | | yes |
+| `claims:{userId}` | 60 sec | | | yes |
+
+### ContactFieldService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Profiles | R |
+| ContactFields | R/W |
+
+No distributed cache. Uses request-scoped in-memory fields for permission checks (board member, coordinator, team IDs) to avoid N+1.
+
+### ContactService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Users | R/W |
+| UserEmails | R/W |
+| CommunicationPreferences | R |
+
+No cache.
+
+### AccountProvisioningService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Users | R/W |
+| UserEmails | R/W |
+
+No cache.
+
+### AccountMergeService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| AccountMergeRequests | R/W |
+| Users | R/W |
+| RoleAssignments | R/W |
+| IdentityUserLogins | R/W |
+| UserEmails | R/W |
+| Profiles | R/W |
+| ContactFields | R/W |
+| VolunteerHistoryEntries | R/W |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `ApprovedProfiles` | yes |
+| `ActiveTeams` (via RemoveMemberFromAllTeamsCache) | yes |
+
+### DuplicateAccountService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Users | R |
+| UserEmails | R/W |
+| Profiles | R/W |
+| TeamMembers | R |
+| RoleAssignments | R |
+| IdentityUserLogins | R/W |
+| ContactFields | R/W |
+| VolunteerHistoryEntries | R/W |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `ApprovedProfiles` | yes |
+| `ActiveTeams` (via RemoveMemberFromAllTeamsCache) | yes |
+
+### MembershipCalculator (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Profiles | R |
+| TeamMembers | R |
+| RoleAssignments | R |
+| LegalDocuments | R |
+| DocumentVersions | R |
+| ConsentRecords | R |
+| Users | R |
+
+No cache. Pure computation.
+
+### VolunteerHistoryService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| VolunteerHistoryEntries | R/W |
+| Profiles | R |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `ApprovedProfiles` | yes (updates entry in bulk cache) |
+
+---
+
+## Onboarding & Governance
+
+### OnboardingService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Profiles | R/W |
+| Users | R |
+| Applications | R |
+| BoardVotes | R/W |
+| RoleAssignments | R |
+| TeamMembers | R |
+| UserEmails | R/W |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `NavBadgeCounts` | yes |
+| `NotificationMeters` | yes |
+| `UserProfile:{userId}` | yes |
+| `ApprovedProfiles` | yes (add/remove) |
+| `NavBadge:Voting:{userId}` | yes |
+| `UserAccess:{userId}` (composite) | yes |
+
+### ApplicationDecisionService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Applications | R/W |
+| BoardVotes | R/W (removed for GDPR after decision) |
+| Profiles | R/W (MembershipTier update) |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `NavBadgeCounts` | yes |
+| `NotificationMeters` | yes |
+| `NavBadge:Voting:{userId}` | yes (per voter) |
+
+### RoleAssignmentService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| RoleAssignments | R/W |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `NavBadgeCounts` | yes |
+| `claims:{userId}` | yes |
+
+---
+
+## Teams
+
+### TeamService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Teams | R/W |
+| TeamMembers | R/W |
+| TeamJoinRequests | R/W |
+| TeamRoleDefinitions | R/W |
+| TeamRoleAssignments | R/W |
+| Users | R |
+
+| Cache Key | TTL | Read | Write | Invalidate |
+|-----------|-----|------|-------|------------|
+| `ActiveTeams` | 10 min | yes | yes | yes |
+| `shift-auth:{userId}` | 60 sec | | | yes |
+| `NotificationMeters` | 2 min | | | yes |
+
+### TeamPageService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Users | R |
+| Teams | R |
+| Rotas | R |
+
+No direct cache. Delegates to other services.
+
+### TeamResourceService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| GoogleResources | R/W |
+
+No cache.
+
+### TeamResourcePersistence (static helper, not DI-registered)
+
+| Table | R/W |
+|-------|-----|
+| GoogleResources | R/W |
+
+No cache.
+
+---
+
+## Google Integration
+
+### GoogleWorkspaceSyncService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| GoogleResources | R/W |
+| TeamMembers | R |
+| Teams | R |
+| Users | R/W |
+| GoogleSyncOutboxEvents | R/W |
+| SyncServiceSettings | R |
+
+No direct cache. Uses `IDbContextFactory` + `SemaphoreSlim(5)` for parallel safe DB access.
+
+### GoogleAdminService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| UserEmails | R/W |
+| Users | R/W |
+| Teams | R |
+| TeamMembers | R |
+| GoogleResources | R |
+
+No cache.
+
+### GoogleWorkspaceUserService (Scoped)
+
+No database access. Pure Google Directory API wrapper.
+
+### EmailProvisioningService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Users | R/W |
+
+No cache. Delegates to UserEmailService for email record creation.
+
+### SyncSettingsService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| SyncServiceSettings | R/W |
+
+No cache.
+
+### DriveActivityMonitorService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| GoogleResources | R |
+| SystemSettings | R/W |
+| IdentityUserLogins | R |
+| Users | R |
+
+Per-invocation in-memory dictionary for people ID resolution (not IMemoryCache).
+
+---
+
+## Camps & City Planning
+
+### CampService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Camps | R/W |
+| CampSeasons | R/W |
+| CampLeads | R/W |
+| CampHistoricalNames | R/W |
+| CampImages | R/W |
+| CampSettings | R/W |
+| AuditLogEntries | W |
+
+| Cache Key | TTL | Read | Write | Invalidate |
+|-----------|-----|------|-------|------------|
+| `camps_year_{year}` | 5 min | yes | yes | yes |
+| `CampSettings` | 5 min | yes | yes | yes |
+
+### CampContactService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| AuditLogEntries | W |
+
+| Cache Key | TTL | Type |
+|-----------|-----|------|
+| `CampContactRateLimit:{userId}:{campId}` | 10 min | Rate limit |
+
+### CityPlanningService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| CampPolygons | R/W |
+| CampSeasons | R/W |
+| Camps | R |
+| CampPolygonHistories | R/W |
+| Profiles | R |
+| Teams | R |
+| TeamMembers | R |
+| CampLeads | R |
+| CityPlanningSettings | R/W |
+| CampSettings | R |
+
+No cache.
+
+---
+
+## Shifts
+
+### ShiftManagementService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Teams | R |
+| TeamRoleAssignments | R |
+| TeamMembers | R |
+| RoleAssignments | R |
+| EventSettings | R/W |
+| Rotas | R/W |
+| Shifts | R/W |
+| ShiftSignups | R |
+| ShiftTags | R/W |
+| VolunteerTagPreferences | R/W |
+
+| Cache Key | TTL | Read | Write |
+|-----------|-----|------|-------|
+| `shift-auth:{userId}` | 60 sec | yes | yes |
+
+### ShiftSignupService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| ShiftSignups | R/W |
+| Shifts | R |
+| Rotas | R/W |
+| EventSettings | R |
+| Teams | R |
+| AuditLogEntries | W |
+| Users | R |
+
+No cache.
+
+### GeneralAvailabilityService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| GeneralAvailability | R/W |
+| Users | R |
+
+No cache.
+
+---
+
+## Legal & Consent
+
+### LegalDocumentService (Scoped)
+
+No database access. Fetches documents from GitHub.
+
+| Cache Key | TTL | Read | Write |
+|-----------|-----|------|-------|
+| `Legal:{slug}` | 1 hr (30 sec on failure) | yes | yes |
+
+### LegalDocumentSyncService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| LegalDocuments | R/W |
+| DocumentVersions | R/W |
+| Profiles | R |
+
+No cache.
+
+### AdminLegalDocumentService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| LegalDocuments | R/W |
+| Teams | R |
+| DocumentVersions | R/W |
+
+No cache.
+
+### ConsentService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| LegalDocuments | R |
+| DocumentVersions | R |
+| ConsentRecords | R/W |
+| Profiles | R |
+
+No cache.
+
+---
+
+## Notifications
+
+### NotificationService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| CommunicationPreferences | R |
+| Teams | R |
+| TeamMembers | R |
+| RoleAssignments | R |
+| Notifications | W |
+| NotificationRecipients | W |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `NotificationBadge:{userId}` | yes (per affected user) |
+
+### NotificationInboxService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| NotificationRecipients | R/W |
+| Notifications | R/W |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `NotificationBadge:{userId}` | yes |
+
+### NotificationMeterProvider (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Profiles | R |
+| Users | R |
+| GoogleSyncOutboxEvents | R |
+| TeamJoinRequests | R |
+| TicketSyncStates | R |
+| Applications | R |
+
+| Cache Key | TTL | Read | Write |
+|-----------|-----|------|-------|
+| `NotificationMeters` | 2 min | yes | yes |
+| `NavBadge:Voting:{userId}` | 2 min | yes | yes |
+
+### CommunicationPreferenceService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| CommunicationPreferences | R/W |
+
+No cache.
+
+---
+
+## Tickets
+
+### TicketQueryService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| TicketAttendees | R |
+| TicketOrders | R |
+| UserEmails | R |
+| TeamMembers | R |
+| Campaigns | R |
+| TicketSyncStates | R |
+
+| Cache Key | TTL | Read | Write |
+|-----------|-----|------|-------|
+| `UserTicketCount:{userId}` | 5 min | yes | yes |
+| `UserIdsWithTickets` | 5 min | yes | yes |
+
+### TicketSyncService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| TicketSyncStates | R/W |
+| UserEmails | R |
+| TicketOrders | R/W |
+| TicketAttendees | R/W |
+| CampaignGrants | R/W |
+| Campaigns | R |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `TicketEventSummary:{eventId}` | yes |
+| `TicketDashboardStats` | yes |
+| `UserIdsWithTickets` | yes |
+
+### TicketTailorService (Transient via HttpClient factory)
+
+No database access. External API client.
+
+| Cache Key | TTL | Read | Write |
+|-----------|-----|------|-------|
+| `TicketEventSummary:{eventId}` | 15 min | yes | yes |
+
+### TicketingBudgetService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| TicketOrders | R |
+| BudgetGroups | R |
+| BudgetCategories | R |
+| BudgetLineItems | R/W |
+| TicketingProjections | R/W |
+
+No cache.
+
+---
+
+## Budget
+
+### BudgetService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| BudgetYears | R/W |
+| BudgetGroups | R/W |
+| BudgetCategories | R/W |
+| BudgetLineItems | R/W |
+| TicketingProjections | R/W |
+| BudgetAuditLogs | R/W |
+| Teams | R |
+| TeamMembers | R |
+| TeamRoleAssignments | R |
+
+No cache.
+
+---
+
+## Campaigns
+
+### CampaignService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| Campaigns | R/W |
+| CampaignGrants | R/W |
+| CampaignCodes | R/W |
+| Teams | R |
+| Users | R |
+| TeamMembers | R |
+| EmailOutboxMessages | R/W |
+
+No cache.
+
+---
+
+## Email
+
+### OutboxEmailService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| UserEmails | R |
+| EmailOutboxMessages | W |
+
+No cache.
+
+### EmailOutboxService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| EmailOutboxMessages | R/W |
+
+No cache.
+
+### UserEmailService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| UserEmails | R/W |
+| AccountMergeRequests | R/W |
+| Users | R/W |
+
+No cache.
+
+### SmtpEmailService / SmtpEmailTransport / EmailRenderer (Scoped)
+
+No database access. No cache. Pure transport and rendering.
+
+---
+
+## Feedback
+
+### FeedbackService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| FeedbackReports | R/W |
+| FeedbackMessages | R/W |
+| Users | R |
+| Teams | R |
+
+| Cache Key | Invalidate |
+|-----------|------------|
+| `NavBadgeCounts` | yes |
+
+---
+
+## Admin & Infrastructure
+
+### AuditLogService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| AuditLogEntries | R/W |
+| GoogleResources | R (Include for sync logs) |
+
+No cache. Entries are added but not saved; caller controls atomicity.
+
+### MagicLinkService (Scoped)
+
+| Table | R/W |
+|-------|-----|
+| UserEmails | R |
+| Users | R/W |
+
+| Cache Key | TTL | Type |
+|-----------|-----|------|
+| `magic_link_used:{tokenPrefix}` | 15 min | Rate limit / replay prevention |
+| `magic_link_signup:{email}` | 60 sec | Rate limit |
+
+### HumansMetricsService (Singleton)
+
+| Table | R/W |
+|-------|-----|
+| Users | R |
+| Profiles | R |
+| Applications | R |
+| RoleAssignments | R |
+| Teams | R |
+| TeamJoinRequests | R |
+| GoogleResources | R |
+| LegalDocuments | R |
+| GoogleSyncOutboxEvents | R |
+
+Uses `IDbContextFactory` (correct for singleton). Auto-refreshes snapshot every 60 seconds.
+No IMemoryCache usage; maintains internal volatile snapshot for OpenTelemetry gauges.
+
+### TrackingMemoryCache (Singleton)
+
+No database access. Decorator around IMemoryCache that tracks hit/miss statistics and active entry counts per key prefix. ConcurrentDictionary for stats.
+
+---
+
+## Cross-Section Analysis
+
+### Tables Accessed by Multiple Sections
+
+This is the core finding. Tables listed are accessed by 3+ sections (excluding AuditLogEntries which is write-only from many services).
+
+| Table | Sections |
+|-------|----------|
+| **Users** | Profiles, Onboarding, Teams, Google, Camps (City Planning), Shifts, Notifications, Tickets, Email, Feedback, Admin/Metrics |
+| **Profiles** | Profiles, Onboarding, Camps (City Planning), Legal (Sync), Notifications (Meters), Admin/Metrics |
+| **TeamMembers** | Profiles, Teams, Google (Sync, Admin), Camps (City Planning), Shifts, Notifications, Tickets, Budget, Campaigns, Admin/Metrics |
+| **Teams** | Teams, Camps (City Planning), Shifts, Legal (Admin), Notifications, Budget, Campaigns, Feedback, Admin/Metrics |
+| **RoleAssignments** | Onboarding (Governance), Shifts, Notifications, Profiles (MembershipCalc), Admin/Metrics |
+| **Applications** | Profiles, Onboarding, Governance, Notifications (Meters), Admin/Metrics |
+| **UserEmails** | Profiles (Accounts), Email, Google (Admin), Tickets (Sync), Magic Link |
+| **GoogleResources** | Teams (Resources), Google (Sync, Admin, Activity), Notifications (Meters), Admin/Metrics |
+| **CommunicationPreferences** | Notifications, Profiles (export), Contact |
+| **TicketOrders** | Tickets (Query, Sync), Ticketing Budget, Profiles (hold date) |
+| **LegalDocuments / DocumentVersions** | Legal (all 3 services), Consent, MembershipCalculator |
+| **ConsentRecords** | Consent, MembershipCalculator, Profiles (export) |
+| **CampaignGrants** | Campaigns, Tickets (Sync), Profiles |
+| **EmailOutboxMessages** | Email (Outbox, OutboxService), Campaigns |
+
+### Notable Cross-Section Overlaps
+
+1. **TeamMembers is the most cross-cut table** (11 sections). Nearly every section needs to check team membership for authorization or filtering. This is somewhat mitigated by the `ActiveTeams` cache which includes member lists.
+
+2. **ProfileService reaches into Tickets and Events** to compute hold dates (`TicketOrders`, `TicketAttendees`, `EventSettings`, `TicketSyncStates`). This creates a dependency from Profiles into Tickets that could be extracted into a method on TicketQueryService.
+
+3. **TicketingBudgetService reads TicketOrders and writes BudgetLineItems** — bridging Tickets and Budget. This is the intended design (sync actuals from tickets into budget).
+
+4. **CampaignGrants are written by CampaignService but also updated by TicketSyncService** (marking redemption). Two different sections mutate the same table for different reasons.
+
+5. **MembershipCalculator reads across Legal, Consent, Teams, and Profiles** to compute membership status. This is inherently cross-cutting but is read-only.
+
+6. **NotificationMeterProvider is a wide reader** — reads from Profiles, Users, GoogleSyncOutboxEvents, TeamJoinRequests, TicketSyncStates, and Applications. This is expected for an aggregation service.
+
+---
+
+## Cache Inventory
+
+### All Cache Keys
+
+| Key | TTL | Type | Populated By | Invalidated By |
+|-----|-----|------|-------------|----------------|
+| `NavBadgeCounts` | 2 min | Static | **NavBadgesViewComponent** | ProfileService, OnboardingService, FeedbackService, ApplicationDecisionService, RoleAssignmentService |
+| `NotificationBadge:{userId}` | 2 min | Per-User | **NotificationBellViewComponent** | NotificationService, NotificationInboxService |
+| `NotificationMeters` | 2 min | Static | NotificationMeterProvider | ProfileService, OnboardingService, ApplicationDecisionService, TeamService |
+| `ApprovedProfiles` | 10 min | Static | ProfileService | ProfileService, OnboardingService, VolunteerHistoryService, AccountMergeService, DuplicateAccountService |
+| `ActiveTeams` | 10 min | Static | TeamService | TeamService, ProfileService, AccountMergeService, DuplicateAccountService |
+| `UserProfile:{userId}` | 2 min | Per-User | ProfileService | ProfileService, OnboardingService |
+| `NavBadge:Voting:{userId}` | 2 min | Per-User | NotificationMeterProvider | OnboardingService, ApplicationDecisionService |
+| `claims:{userId}` | 60 sec | Per-User | (unknown populator) | RoleAssignmentService, ProfileService |
+| `shift-auth:{userId}` | 60 sec | Per-User | ShiftManagementService | TeamService |
+| `camps_year_{year}` | 5 min | Per-Entity | CampService | CampService |
+| `CampSettings` | 5 min | Static | CampService | CampService |
+| `Legal:{slug}` | 1 hr | Per-Entity | LegalDocumentService | LegalDocumentService |
+| `UserTicketCount:{userId}` | 5 min | Per-User | TicketQueryService | (TTL-based only) |
+| `UserIdsWithTickets` | 5 min | Static | TicketQueryService | TicketSyncService |
+| `TicketEventSummary:{eventId}` | 15 min | Per-Entity | TicketTailorService | TicketSyncService |
+| `TicketDashboardStats` | 5 min | Static | (unknown populator) | TicketSyncService |
+| `NobodiesTeamEmails_All` | 2 min | Static | **NobodiesEmailBadgeViewComponent** | GoogleController |
+| `CampContactRateLimit:{userId}:{campId}` | 10 min | Rate Limit | CampContactService | CampContactService |
+| `magic_link_used:{tokenPrefix}` | 15 min | Rate Limit | MagicLinkService | MagicLinkService |
+| `magic_link_signup:{email}` | 60 sec | Rate Limit | MagicLinkService | MagicLinkService |
+
+### Cache Issues Found
+
+**1. View components populate caches that services invalidate**
+
+`NavBadgeCounts` is populated by `NavBadgesViewComponent` (which does direct DB queries) but invalidated by 5 different services. `NotificationBadge:{userId}` is the same pattern with `NotificationBellViewComponent`. `NobodiesTeamEmails_All` is populated by `NobodiesEmailBadgeViewComponent` but invalidated by `GoogleController`.
+
+This means the DB queries that compute these values live in view components, not services. The services only know how to remove the key, not recompute it. This is backwards — the computation should be in a service, and the view component should call the service.
+
+**2. ApprovedProfiles is a shared mutable ConcurrentDictionary**
+
+Multiple services add to or remove from the `ApprovedProfiles` bulk cache entry. On a cache miss, ProfileService loads all approved profiles and rebuilds the dictionary. Between a miss and the rebuild, individual add/remove operations from other services (OnboardingService, VolunteerHistoryService, etc.) could race. At current scale (~500 users) this is low-risk but architecturally fragile.
+
+**3. UserTicketCount has no explicit invalidation**
+
+Per-user ticket counts are cached for 5 minutes with TTL-based expiry only. After a ticket sync, `UserIdsWithTickets` is invalidated but individual `UserTicketCount:{userId}` entries are not. A user could see stale ticket counts for up to 5 minutes after sync.
+
+**4. TicketDashboardStats invalidated but populator unclear**
+
+`TicketSyncService` invalidates `TicketDashboardStats` but the code that populates it wasn't found in the service layer audit. It may be populated in a controller or view component (see Appendix A).
+
+**5. NobodiesTeamEmails_All is entirely outside the service layer**
+
+The cache is populated by a view component and invalidated by a controller. No service is involved. The DB query (via `IUserEmailService`) and cache management should both move to a service.
+
+---
+
+## Table Ownership Map
+
+The principle: **each table has one owning service, and all other access goes through that service's API.**
+Read access through the owning service lets it serve from cache. Write access through the owning service lets it invalidate correctly.
+
+### Proposed Ownership
+
+| Table(s) | Owner | Current Violations (services accessing directly) |
+|----------|-------|--------------------------------------------------|
+| **Profiles**, ContactFields, VolunteerHistoryEntries, ProfileLanguages, VolunteerEventProfiles | ProfileService | ApplicationDecisionService (writes MembershipTier), OnboardingService (R/W approval/suspension), AccountMergeService (R/W anonymize), DuplicateAccountService (R/W anonymize), NotificationMeterProvider (R counts), CityPlanningService (R display name), HumansMetricsService (R counts) |
+| **Users** | (Identity — UserManager) | Touched by nearly every section. Most reads are for display names or email. Google services write GoogleEmail/GoogleEmailStatus. |
+| **UserEmails** | UserEmailService | AccountMergeService (R/W), AccountProvisioningService (R/W), GoogleAdminService (R/W), OnboardingService (R/W purge), TicketSyncService (R match), MagicLinkService (R), OutboxEmailService (R) |
+| **Teams**, TeamMembers, TeamJoinRequests, TeamRoleDefinitions, TeamRoleAssignments | TeamService | Read by 11 sections for auth/membership checks. SystemTeamSyncJob writes TeamMembers and TeamRoleAssignments directly. BudgetService reads TeamRoleAssignments for auth. |
+| **Applications**, BoardVotes | OnboardingService / ApplicationDecisionService | ProfileService (R/W — creates applications on profile save), NotificationMeterProvider (R), HumansMetricsService (R) |
+| **RoleAssignments** | RoleAssignmentService | MembershipCalculator (R), NotificationService (R), ShiftManagementService (R), AccountMergeService (R/W end roles), HumansMetricsService (R) |
+| **GoogleResources** | TeamResourceService | GoogleWorkspaceSyncService (R/W provision), GoogleAdminService (R), DriveActivityMonitorService (R), NotificationMeterProvider (R), HumansMetricsService (R) |
+| **GoogleSyncOutboxEvents** | GoogleWorkspaceSyncService | NotificationMeterProvider (R), HumansMetricsService (R) |
+| **SyncServiceSettings** | SyncSettingsService | Clean — no violations |
+| **LegalDocuments**, DocumentVersions | LegalDocumentSyncService / AdminLegalDocumentService | MembershipCalculator (R), ConsentService (R) |
+| **ConsentRecords** | ConsentService | MembershipCalculator (R) |
+| **Notifications**, NotificationRecipients | NotificationService / NotificationInboxService | Clean — no violations |
+| **CommunicationPreferences** | CommunicationPreferenceService | NotificationService (R), ContactService (R) |
+| **Camps**, CampSeasons, CampLeads, CampHistoricalNames, CampImages, CampSettings | CampService | CityPlanningService (R/W CampSeasons, R others) |
+| **CampPolygons**, CampPolygonHistories, CityPlanningSettings | CityPlanningService | Clean — no violations |
+| **EventSettings**, Rotas, Shifts, ShiftSignups, ShiftTags, VolunteerTagPreferences | ShiftManagementService / ShiftSignupService | Clean internally (ShiftSignup reads Shifts/Rotas but they're same section) |
+| **GeneralAvailability** | GeneralAvailabilityService | Clean — no violations |
+| **TicketOrders**, TicketAttendees, TicketSyncStates | TicketSyncService / TicketQueryService | ProfileService (R for hold dates), TicketingBudgetService (R orders for actuals) |
+| **BudgetYears**, BudgetGroups, BudgetCategories, BudgetLineItems, BudgetAuditLogs, TicketingProjections | BudgetService | TicketingBudgetService (R/W line items and projections) |
+| **Campaigns**, CampaignGrants, CampaignCodes | CampaignService | TicketSyncService (R/W CampaignGrants — marks redemption), ProfileService (R CampaignGrants) |
+| **FeedbackReports**, FeedbackMessages | FeedbackService | Clean — no violations |
+| **EmailOutboxMessages** | OutboxEmailService / EmailOutboxService | CampaignService (R/W — creates outbox entries) |
+| **AuditLogEntries** | AuditLogService | Clean — write-only, always called through the service |
+| **AccountMergeRequests** | AccountMergeService | UserEmailService (R/W — creates merge requests on email conflict) |
+| **SystemSettings** | (no owner — shared key-value store) | DriveActivityMonitorService (R/W), ProcessEmailOutboxJob (R/W), EmailController (R/W) |
+
+### Violations Summary
+
+**Write violations (most critical — break cache invalidation):**
+
+| Violator | Table Written | Owner |
+|----------|--------------|-------|
+| ApplicationDecisionService | Profiles (MembershipTier) | ProfileService |
+| OnboardingService | Profiles (approval/suspension fields) | ProfileService |
+| AccountMergeService | Profiles, ContactFields, VolunteerHistoryEntries | ProfileService |
+| DuplicateAccountService | Profiles, ContactFields, VolunteerHistoryEntries | ProfileService |
+| ProfileService | Applications | OnboardingService |
+| SystemTeamSyncJob | TeamMembers, TeamRoleAssignments | TeamService |
+| ProcessAccountDeletionsJob | TeamRoleAssignments, ContactFields, VolunteerHistoryEntries | TeamService, ProfileService |
+| TicketSyncService | CampaignGrants | CampaignService |
+| TicketingBudgetService | BudgetLineItems, TicketingProjections | BudgetService |
+| CityPlanningService | CampSeasons | CampService |
+| CampaignService | EmailOutboxMessages | OutboxEmailService |
+| AccountMergeService | RoleAssignments | RoleAssignmentService |
+| GoogleWorkspaceSyncService | Users (GoogleEmailStatus) | Identity/UserManager |
+
+**Read violations (less critical but prevent caching):**
+
+Too many to list individually. The pattern is: services query tables they don't own to get display names, check membership, count records, or verify authorization. The most common reads across boundaries are:
+- TeamMembers (11 sections check membership)
+- Users (display names, email)
+- Profiles (status checks, counts)
+- RoleAssignments (authorization checks)
+
+---
+
+## Prioritized Fix Plan
+
+Strategy: start from the **least-intertwined services** (island sections) and work toward the heavily cross-cut core. Each phase makes the next one easier because it reduces the number of cross-boundary accesses.
+
+### Phase 1 — Island Services (no inbound violations)
+
+These services own their tables cleanly and no other service writes to them. The work is purely moving the *read* queries from other services into these services' APIs, then calling the service instead.
+
+**1a. FeedbackService**
+- Currently reads Users (display name) and Teams (name) directly
+- Add lookup methods or accept display names from callers
+- Effort: trivial
+
+**1b. GeneralAvailabilityService**
+- Reads Users for display names
+- Same pattern as above
+- Effort: trivial
+
+**1c. CommunicationPreferenceService**
+- NotificationService and ContactService read CommunicationPreferences directly
+- Add `GetPreferencesForUserAsync(userId)` / `IsOptedOutAsync(userId, category)` if not already present
+- Effort: small
+
+**1d. SyncSettingsService**
+- Already clean. No work needed.
+
+**1e. ConsentService**
+- MembershipCalculator reads ConsentRecords directly
+- Add a method like `GetConsentedVersionIdsAsync(userId)` or `GetConsentMapForUsersAsync(userIds)`
+- Effort: small
+
+### Phase 2 — Self-Contained Sections with Minor Boundary Reads
+
+**2a. Legal (LegalDocumentSyncService / AdminLegalDocumentService)**
+- MembershipCalculator reads LegalDocuments/DocumentVersions for required doc lists
+- Add `GetRequiredDocumentVersionsAsync(teamId?)` to the legal service
+- Effort: small
+
+**2b. CampService ← CityPlanningService**
+- CityPlanningService reads AND writes CampSeasons
+- CityPlanningService should call CampService methods for season data and mutations (e.g., `GetSeasonAsync`, `UpdateSeasonPlacementDatesAsync`)
+- Effort: moderate — CityPlanning has several CampSeason write paths
+
+**2c. Shifts (ShiftManagementService / ShiftSignupService)**
+- Reads Teams/TeamMembers for authorization
+- Reads RoleAssignments for coordinator checks
+- Wire through TeamService and RoleAssignmentService APIs instead of direct queries
+- Effort: moderate (shift-auth cache already helps, but the underlying queries still bypass)
+
+### Phase 3 — Ticket/Budget/Campaign Triangle
+
+These three sections have write violations across each other.
+
+**3a. TicketSyncService → CampaignService**
+- TicketSyncService writes CampaignGrants (marks RedeemedAt)
+- Add `MarkGrantRedeemedAsync(code, redeemedAt)` to CampaignService
+- Effort: small
+
+**3b. TicketingBudgetService → BudgetService**
+- Writes BudgetLineItems and TicketingProjections directly
+- Add methods to BudgetService: `UpsertAutoLineItemsAsync(categoryId, items)`, `UpdateProjectionAsync(groupId, actuals)`
+- Effort: moderate — the weekly line-item upsert logic is non-trivial
+
+**3c. CampaignService → OutboxEmailService**
+- Creates EmailOutboxMessages directly
+- Should call OutboxEmailService to enqueue
+- Effort: small
+
+**3d. ProfileService → TicketQueryService**
+- ProfileService reads TicketOrders/TicketAttendees/TicketSyncStates for hold date
+- Add `GetEventHoldStatusAsync(userId)` to TicketQueryService
+- Effort: small
+
+### Phase 4 — Google Integration
+
+**4a. GoogleWorkspaceSyncService**
+- Reads TeamMembers, Teams directly → call TeamService
+- Writes Users.GoogleEmailStatus → call a method on an identity/account service
+- Effort: moderate — sync service is complex and uses IDbContextFactory for parallelism
+
+**4b. GoogleAdminService**
+- Reads/writes UserEmails → call UserEmailService
+- Reads TeamMembers → call TeamService
+- Effort: moderate
+
+### Phase 5 — Governance and Onboarding
+
+**5a. ApplicationDecisionService → ProfileService**
+- Writes `profile.MembershipTier` directly on approval
+- ProfileService should expose `UpdateMembershipTierAsync(userId, tier)`
+- Effort: small code change but important for cache correctness
+
+**5b. ProfileService → OnboardingService**
+- ProfileService creates/updates Applications on profile save
+- This is a write violation in the wrong direction (Profiles writing to Governance)
+- Move application creation to ApplicationDecisionService, call it from ProfileService
+- Effort: moderate — tangled in the profile save flow
+
+**5c. OnboardingService → ProfileService**
+- Writes approval/suspension/consent-check fields on Profiles directly
+- Should call ProfileService methods for these mutations
+- This is the single biggest source of cache-busting for ApprovedProfiles
+- Effort: moderate-large — OnboardingService has many paths that mutate profile state
+
+### Phase 6 — Core Cross-Cutting (TeamMembers, Users, Profiles)
+
+**6a. TeamMembers read access**
+- 11 sections read TeamMembers for authorization checks
+- TeamService already has `ActiveTeams` cache with member lists
+- Add/expose `IsUserMemberOfTeamAsync`, `GetUserTeamIdsAsync`, `GetTeamMemberUserIdsAsync` methods that serve from cache
+- Many callers can switch to these without touching the DB
+- Effort: moderate — many call sites to update, but each one is mechanical
+
+**6b. Users read access (display names, email)**
+- Nearly universal. Many services just need `DisplayName` or `Email`
+- Consider a lightweight `IUserLookupService` (or methods on an existing service) that serves from a cached dictionary
+- Effort: moderate — mechanical but widespread
+
+**6c. Profiles read access**
+- ProfileService's `ApprovedProfiles` cache already holds what most callers need
+- Expose read methods that serve from cache: `GetApprovedProfileAsync(userId)`, `GetProfileCountsAsync()`
+- Redirect NotificationMeterProvider, HumansMetricsService, etc. to use ProfileService instead of querying the table
+- Effort: moderate
+
+### Phase 7 — Jobs and Account Operations
+
+**7a. SystemTeamSyncJob → TeamService**
+- Writes TeamMembers and TeamRoleAssignments directly
+- Needs `AddMemberToTeamAsync` / `RemoveMemberFromTeamAsync` methods on TeamService
+- Effort: large — this is the most complex job in the system
+
+**7b. ProcessAccountDeletionsJob → ProfileService, TeamService**
+- Anonymizes profiles, removes contact fields, volunteer history, role assignments directly
+- Should orchestrate through the owning services
+- Effort: large — touches many tables across sections
+
+**7c. AccountMergeService / DuplicateAccountService → ProfileService, RoleAssignmentService**
+- Write to Profiles (anonymize), RoleAssignments (end), ContactFields, VolunteerHistoryEntries
+- Should call owning services for each mutation
+- Effort: moderate-large
+
+### Phase 8 — View Components and Controllers
+
+After services own their data properly, move the view component DB queries and cache population into the owning services:
+
+- NavBadgesViewComponent → new method on a service (or NotificationMeterProvider)
+- NotificationBellViewComponent → NotificationInboxService
+- NobodiesEmailBadgeViewComponent → a Google/Email service
+- ProfileCardViewComponent → ProfileService
+- AuditLogViewComponent → AuditLogService
+- MyGoogleResourcesViewComponent → TeamResourceService
+
+Controller DB access should follow the same pattern — each controller call goes through a service.
+
+### Summary
+
+| Phase | Scope | Effort | Impact |
+|-------|-------|--------|--------|
+| 1 | Island services (Feedback, GA, CommPrefs, Consent) | Small | Low risk, establishes pattern |
+| 2 | Self-contained sections (Legal, Camps←CityPlanning, Shifts) | Small-Moderate | Removes first write violations |
+| 3 | Ticket/Budget/Campaign triangle | Moderate | Fixes cross-section writes |
+| 4 | Google integration | Moderate | Reduces sync complexity |
+| 5 | Governance/Onboarding ↔ Profiles | Moderate-Large | Fixes ApprovedProfiles cache reliability |
+| 6 | Core cross-cutting (TeamMembers, Users, Profiles reads) | Moderate | Enables proper caching everywhere |
+| 7 | Jobs and account operations | Large | Removes last direct DB mutations |
+| 8 | View components and controllers | Moderate | Completes the service layer boundary |
+
+---
+
+## Appendix A: Out-of-Service Database Access
+
+Controllers and view components that inject `HumansDbContext` or `IMemoryCache` directly, bypassing the service layer.
+
+### Controllers
+
+| Controller | Tables Read | Tables Written |
+|------------|------------|----------------|
+| **AdminController** | Users, Profiles, TicketOrders, TicketAttendees, database metadata (migrations) | Hangfire lock table (ExecuteSqlRaw) |
+| **ProfileController** | ProfileLanguages, UserEmails, EmailOutboxMessages, TeamMembers, CampaignGrants, GoogleSyncOutboxEvents, TicketOrders | ProfileLanguages, UserEmails |
+| **BoardController** | Users, Teams | |
+| **BudgetController** | BudgetLineItems | |
+| **EmailController** | EmailOutboxMessages, SystemSettings | SystemSettings |
+| **GuestController** | TicketOrders, TicketAttendees, Users | |
+| **CampAdminController** | Camps | |
+| **DevLoginController** | Camps, CampSeasons, CampLeads | Camps, CampSeasons, CampLeads |
+| **UnsubscribeController** | (via injected DbContext) | |
+| **GoogleController** | | |
+
+### View Components
+
+| Component | Tables Read | Cache Keys |
+|-----------|------------|------------|
+| **NavBadgesViewComponent** | Profiles, Applications | `NavBadgeCounts` (read/write) |
+| **NotificationBellViewComponent** | NotificationRecipients | `NotificationBadge:{userId}` (read/write) |
+| **AuditLogViewComponent** | Users, Teams | |
+| **MyGoogleResourcesViewComponent** | TeamMembers | |
+| **ProfileCardViewComponent** | Users, Profiles, ProfileLanguages | |
+| **NobodiesEmailBadgeViewComponent** | | `NobodiesTeamEmails_All` (read/write) |
+
+### Background Jobs
+
+Jobs are in Infrastructure so this is a softer violation, but complex mutation logic should live in services.
+
+| Job | Tables Read | Tables Written | Cache |
+|-----|------------|----------------|-------|
+| **SystemTeamSyncJob** | TeamMembers, Teams, Profiles, Applications, Users, RoleAssignments, GoogleResources | TeamMembers, TeamRoleAssignments | ActiveTeams, ApprovedProfiles |
+| **ProcessAccountDeletionsJob** | Users, ContactFields, VolunteerHistoryEntries | Users (anonymize), ContactFields, VolunteerHistoryEntries, TeamRoleAssignments, ShiftSignups, VolunteerEventProfiles | ApprovedProfiles |
+| **SendAdminDailyDigestJob** | Users, Profiles, TeamMembers, TeamJoinRequests, Applications, GoogleSyncOutboxEvents, TicketSyncStates, RoleAssignments | | |
+| **SendBoardDailyDigestJob** | AuditLogEntries, Users, Applications, Profiles, TeamJoinRequests, TeamMembers, RoleAssignments, BoardVotes | | |
+| **SuspendNonCompliantMembersJob** | Users | | UserProfile invalidation |
+| **ProcessGoogleSyncOutboxJob** | GoogleSyncOutboxEvents, Users, Teams, GoogleResources | GoogleSyncOutboxEvents | |
+| **CleanupNotificationsJob** | Notifications | Notifications | |
+| **CleanupEmailOutboxJob** | EmailOutboxMessages | EmailOutboxMessages | |
+| **ProcessEmailOutboxJob** | SystemSettings, EmailOutboxMessages, CampaignGrants | SystemSettings, EmailOutboxMessages | |
+| **TermRenewalReminderJob** | Applications | Applications | |
+| **SendReConsentReminderJob** | Users | Users | |
+| **SyncLegalDocumentsJob** | TeamMembers, ConsentRecords, Users | | |
+
+---
+
+## Appendix B: Out-of-Service Cache Access
+
+Controllers that directly manipulate cache keys.
+
+| Controller/Component | Cache Operation | Key |
+|---------------------|-----------------|-----|
+| **GoogleController** | Remove | `NobodiesTeamEmails_All` |
+| **ProfileController** | Remove | (various profile-related keys) |
+| **TeamAdminController** | Remove | (team-related keys) |
+| **DevLoginController** | Invalidate | `ApprovedProfiles`, `UserAccess` |
+| **NavBadgesViewComponent** | GetOrCreate | `NavBadgeCounts` |
+| **NotificationBellViewComponent** | GetOrCreate | `NotificationBadge:{userId}` |
+| **NobodiesEmailBadgeViewComponent** | TryGetValue/Set | `NobodiesTeamEmails_All` |

--- a/docs/features/communication-preferences.md
+++ b/docs/features/communication-preferences.md
@@ -23,7 +23,7 @@ System and Campaign Codes are always locked on — users cannot opt out. These c
 
 ### Ticketing Locking
 
-When a user has a matched `TicketOrder` (auto-matched by email), their Ticketing preference is locked on. Purchase confirmations and event information are mandatory for ticket holders. Users without ticket orders can opt in/out freely.
+When a user has a matched `TicketAttendee` record (auto-matched by email), their Ticketing preference is locked on. Purchase confirmations and event information are mandatory for ticket attendees. Users without a ticket attendee match can opt in/out freely.
 
 ### Facilitated Messages Opt-Out
 

--- a/docs/features/event-participation.md
+++ b/docs/features/event-participation.md
@@ -1,0 +1,64 @@
+# Event Participation Tracking
+
+## Business Context
+
+Track yearly event participation status for each human, enabling self-service opt-out for those not attending and providing admin visibility into participation breakdown.
+
+## User Stories
+
+### As a human, I want to declare I'm not attending this year
+- Dashboard ticket widget shows "Not attending this year" button when no ticket linked
+- Clicking sets participation status to NotAttending
+- Can undo the declaration to return to default state
+
+### As a ticket holder, my participation is auto-tracked
+- Ticket sync creates/updates participation records automatically
+- Valid ticket -> Ticketed status
+- Checked in -> Attended status (permanent, cannot revert)
+- Ticket purchase overrides a previous NotAttending declaration
+- Ticket void/transfer with no remaining tickets removes Ticketed record
+
+### As an admin, I can see participation breakdown
+- Donut chart on ticket dashboard: Has Ticket / No Ticket / Not Coming
+- "Who Hasn't Bought" excludes humans who declared not attending
+
+### As an admin, I can backfill historical data
+- CSV import of UserId,Status pairs for a given year
+- Available via Tickets > Backfill tab (admin only)
+
+## Data Model
+
+### EventParticipation
+| Property | Type | Notes |
+|----------|------|-------|
+| Id | Guid | PK |
+| UserId | Guid | FK to User (Cascade) |
+| Year | int | Event year |
+| Status | ParticipationStatus | NotAttending, Ticketed, Attended, NoShow |
+| DeclaredAt | Instant? | When user self-declared NotAttending |
+| Source | ParticipationSource | UserDeclared, TicketSync, AdminBackfill |
+
+**Unique constraint:** (UserId, Year)
+
+### EventSettings.Year
+Added `Year` (int) to EventSettings so participation records can be linked to the correct event year.
+
+## Status Lifecycle
+
+| Transition | Trigger |
+|---|---|
+| (none) -> NotAttending | User clicks "Not attending this year" |
+| (none) -> Ticketed | Ticket sync matches valid ticket |
+| NotAttending -> Ticketed | Ticket purchase overrides |
+| Ticketed -> Attended | Ticket sync sees CheckedIn |
+| Ticketed -> NoShow | Post-event derivation |
+| Ticketed -> (removed) | All valid tickets voided/transferred |
+
+Attended is permanent -- cannot be reverted by any mechanism.
+
+## Related Features
+
+- Ticket sync (TicketSyncService)
+- Dashboard ticket widget
+- Ticket admin dashboard
+- "Who Hasn't Bought" metrics

--- a/docs/plans/spec-audit-2026-04-09.md
+++ b/docs/plans/spec-audit-2026-04-09.md
@@ -1,0 +1,76 @@
+# Open Issue Spec Quality Audit — 2026-04-09
+
+## Summary
+
+| Category | Count |
+|----------|-------|
+| UNDERSPECIFIED | 5 |
+| NEEDS REFINEMENT | 22 |
+| READY | 27 |
+| SKIP | 6 |
+
+## UNDERSPECIFIED — Too vague to code against
+
+### #468 — Make "Verify Email Address" more visible
+- Body is a screenshot and "Button or larger text pls". No labels, no acceptance criteria, no spec of where/how.
+- Missing: exact UI change, which page, target element.
+
+### #464 — Explain Barrio requirements when signing up
+- User request with ideas but no labels, no AC, no data model, no content source.
+- Missing: who writes the content, admin-editable or hardcoded, which page, no AC.
+
+### #83 — Add other OAuth options, additional to Google
+- Two sentences. Largely duplicated by #99 and #98.
+- Missing: which providers, UI spec, data model implications.
+
+### #86 — Voting system: bylaw-compliant member voting
+- Has requirements sections but 6 major open questions unanswered (anonymity, bylaw text, electronic voting legality, proxy voting, MVP scope).
+- Cannot be coded without resolving these.
+
+### #77 — Reasons why an Asociado is accepted (or applying)
+- Informal request, no structured spec. On hold waiting for Pablo.
+
+## NEEDS REFINEMENT — Has a spec but key details missing
+
+### High priority (likely to be worked soon):
+
+- **#452** — Shift period filter bug. Root cause unknown, spec lists 3 "likely causes." Needs investigation first.
+- **#454** — Google Groups 403 handling. "Mark email as rejected" approach unspecified — new field? New table?
+- **#453** — Google Group email delivery preferences. Lists 4 options without committing to one.
+- **#200** — MailerLite sync. Spec fragmented across 4 comments. Heavy overlap with #450.
+- **#206** — Ticketing contact merge. Body vs comment describe two different scopes.
+
+### Medium priority (larger features):
+
+- **#382** — Ticket transfer. Presents 3 options, says to research first. Research task disguised as implementation.
+- **#253** — On-site date tracking. Two data model alternatives without choosing.
+- **#254** — Multi-language campaign templates. Missing migration strategy for existing data.
+- **#162** — Shift notifications. Comments add 4+ triggers beyond the original 8. Scope boundary unclear.
+- **#161** — Shift exports, iCal feed, stats. Several sub-features underspecified (cantina CSV, stats dashboard).
+- **#159** — Invoice generation. No Invoice entity schema, no legal format details.
+- **#158** — Barrio services store. Very thin spec for XL issue. No entity definitions.
+- **#157** — Bus ticket sales. References external spec doc. Phase/threshold logic vague.
+- **#150** — Event guide. POC feedback not incorporated into AC.
+- **#110** — Inbound bounce parsing. Inbox connection method unspecified.
+- **#450** — MailerLite bidirectional sync. Blocked on #433-436. Overlap with #200 confusing.
+- **#446** — Human-link tag helper. Depends on #447. Line numbers may be stale.
+- **#244** — Notification inbox. Group resolution model has no data model. Digest frequency in comment not in AC.
+- **#218** — Event audience segmentation. Depends on underspecified #206/#205. Segment builder vague.
+- **#149** — Figma design integration. Meta-issue, design analysis required first.
+- **#99** — Local username/password auth. Missing login page UI flow, account linking details.
+- **#98** — Magic-link auth. IP binding unusable on mobile. Account lifecycle unclear.
+- **#100** — SSO/JWT issuance. No concrete client app to test against. Claims/key management unspecified.
+- **#205** — Marketing-only contacts. Data model option not confirmed.
+
+## READY — Clear enough to hand to a coding agent
+
+#467, #466, #463, #459, #458, #457, #455, #449, #445, #444, #436, #435, #434, #432, #429, #428, #427, #426, #425, #422, #420, #419, #418, #416, #403, #402, #401, #127, #187
+
+## SKIP — Blocked, placeholders, or duplicates
+
+- **#163** — Placeholder for feedback gathering, not implementable.
+- **#279** — Explicitly blocked:spec-incomplete.
+- **#198** — Paused, code being replaced.
+- **#204** — Blocked on legal review.
+- **#33** — Duplicate of #82.
+- **#82** — Open questions need resolving first.

--- a/docs/sections/Tickets.md
+++ b/docs/sections/Tickets.md
@@ -33,9 +33,14 @@
 
 - When ticket sync runs, new orders and attendees are imported and existing ones are updated.
 - Auto-matching runs during sync: orders and attendees are matched to humans by email.
+- Ticket sync derives EventParticipation records: valid ticket -> Ticketed, checked-in -> Attended (permanent).
+- When a user's last valid ticket is voided/transferred, their TicketSync-sourced participation record is removed.
+- Ticket purchase overrides a NotAttending declaration.
+- "Who Hasn't Bought" excludes humans who declared not attending.
 
 ## Cross-Section Dependencies
 
 - **Campaigns**: TicketAdmin can generate discount codes for campaigns via the ticket vendor integration.
 - **Profiles**: Ticket orders and attendees are auto-matched against human email addresses.
 - **Admin**: Sync configuration and manual vendor operations are Admin-only.
+- **Event Participation**: Ticket sync auto-creates/updates EventParticipation records. Admin can backfill historical data via Tickets > Backfill.

--- a/src/Humans.Application/Interfaces/IAuditLogService.cs
+++ b/src/Humans.Application/Interfaces/IAuditLogService.cs
@@ -70,4 +70,31 @@ public interface IAuditLogService
         IReadOnlyList<AuditAction>? actions = null,
         int limit = 20,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a full audit log page with display name lookups for users and teams.
+    /// Used by Board/Admin audit log views to avoid direct DbContext access in controllers.
+    /// </summary>
+    Task<AuditLogPageResult> GetAuditLogPageAsync(
+        string? actionFilter, int page, int pageSize, CancellationToken ct = default);
+
+    /// <summary>
+    /// Batch-loads user display names for a set of user IDs.
+    /// </summary>
+    Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(IReadOnlyList<Guid> userIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Batch-loads team names and slugs for a set of team IDs.
+    /// </summary>
+    Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Full audit log page with display name dictionaries for rendering.
+/// </summary>
+public record AuditLogPageResult(
+    IReadOnlyList<AuditLogEntry> Items,
+    int TotalCount,
+    int AnomalyCount,
+    Dictionary<Guid, string> UserDisplayNames,
+    Dictionary<Guid, (string Name, string Slug)> TeamNames);

--- a/src/Humans.Application/Interfaces/IBudgetService.cs
+++ b/src/Humans.Application/Interfaces/IBudgetService.cs
@@ -41,6 +41,7 @@ public interface IBudgetService
     Task DeleteCategoryAsync(Guid categoryId, Guid actorUserId);
 
     // Budget Line Items
+    Task<BudgetLineItem?> GetLineItemByIdAsync(Guid id);
     Task<BudgetLineItem> CreateLineItemAsync(Guid budgetCategoryId, string description, decimal amount, Guid? responsibleTeamId, string? notes, LocalDate? expectedDate, int vatRate, Guid actorUserId);
     Task UpdateLineItemAsync(Guid lineItemId, string description, decimal amount, Guid? responsibleTeamId, string? notes, LocalDate? expectedDate, int vatRate, Guid actorUserId);
     Task DeleteLineItemAsync(Guid lineItemId, Guid actorUserId);

--- a/src/Humans.Application/Interfaces/ICampService.cs
+++ b/src/Humans.Application/Interfaces/ICampService.cs
@@ -43,6 +43,11 @@ public interface ICampService
     Task<IReadOnlyList<CampPublicSummary>> GetCampPublicSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampPlacementSummary>> GetCampPlacementSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<CampSettings> GetSettingsAsync(CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Gets camps with their active leads (and lead user data) for a given year.
+    /// Optionally filters to specific season statuses.
+    /// </summary>
+    Task<List<Camp>> GetCampsWithLeadsForYearAsync(int year, IReadOnlyList<CampSeasonStatus>? statusFilter = null, CancellationToken cancellationToken = default);
     Task<List<Camp>> GetCampsByLeadUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<List<CampSeason>> GetPendingSeasonsAsync(CancellationToken cancellationToken = default);
 

--- a/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
+++ b/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
@@ -4,6 +4,23 @@ using Humans.Domain.Enums;
 namespace Humans.Application.Interfaces;
 
 /// <summary>
+/// Status of a CommunicationPreference token validation attempt.
+/// Distinct from <see cref="UnsubscribeTokenResult"/> which is the high-level
+/// result returned by <see cref="IUnsubscribeService"/>.
+/// </summary>
+public enum TokenValidationStatus
+{
+    /// <summary>Token is valid and decoded successfully.</summary>
+    Valid,
+
+    /// <summary>Token was a valid new-format token but has expired.</summary>
+    Expired,
+
+    /// <summary>Token is not a valid new-format token (tampered, corrupted, or different format).</summary>
+    Invalid,
+}
+
+/// <summary>
 /// Manages per-user communication preferences and unsubscribe tokens.
 /// </summary>
 public interface ICommunicationPreferenceService
@@ -51,9 +68,9 @@ public interface ICommunicationPreferenceService
 
     /// <summary>
     /// Validates and decodes an unsubscribe token.
-    /// Returns null if the token is invalid or expired.
+    /// Returns status (Valid/Expired/Invalid) with decoded UserId and Category when valid.
     /// </summary>
-    (Guid UserId, MessageCategory Category)? ValidateUnsubscribeToken(string token);
+    (TokenValidationStatus Status, Guid UserId, MessageCategory Category) ValidateUnsubscribeToken(string token);
 
     /// <summary>
     /// Generates RFC 8058 List-Unsubscribe headers for a given user and category.
@@ -80,4 +97,11 @@ public interface ICommunicationPreferenceService
     /// </summary>
     Task<IReadOnlySet<Guid>> GetUsersWithAnyPreferencesAsync(
         IReadOnlyList<Guid> userIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates a browser-friendly unsubscribe URL for use in email footers.
+    /// Unlike <see cref="GenerateUnsubscribeHeaders"/>, this returns a plain URL string
+    /// suitable for direct use in anchor tags.
+    /// </summary>
+    string GenerateBrowserUnsubscribeUrl(Guid userId, MessageCategory category);
 }

--- a/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
+++ b/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
@@ -60,4 +60,24 @@ public interface ICommunicationPreferenceService
     /// Returns a dictionary of header name → value pairs.
     /// </summary>
     Dictionary<string, string> GenerateUnsubscribeHeaders(Guid userId, MessageCategory category);
+
+    /// <summary>
+    /// Returns a set of user IDs (from the input list) whose inbox is disabled
+    /// for the given category. Users with no preference row are considered inbox-enabled.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetUsersWithInboxDisabledAsync(
+        IReadOnlyList<Guid> userIds, MessageCategory category,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns whether any communication preferences exist for the given user.
+    /// </summary>
+    Task<bool> HasAnyPreferencesAsync(
+        Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the set of user IDs (from the input list) that have any communication preferences.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetUsersWithAnyPreferencesAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Interfaces/IConsentService.cs
+++ b/src/Humans.Application/Interfaces/IConsentService.cs
@@ -16,4 +16,30 @@ public interface IConsentService
     Task<ConsentSubmitResult> SubmitConsentAsync(
         Guid userId, Guid documentVersionId, bool explicitConsent,
         string ipAddress, string userAgent, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets all consent records for a user, ordered by most recent first,
+    /// with DocumentVersion and LegalDocument navigation properties loaded.
+    /// </summary>
+    Task<IReadOnlyList<ConsentRecord>> GetUserConsentRecordsAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the count of consent records for a user.
+    /// </summary>
+    Task<int> GetConsentRecordCountAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the set of document version IDs that a user has explicitly consented to.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetConsentedVersionIdsAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a map of user ID → consented document version IDs for a batch of users.
+    /// Every input user ID appears in the result (with an empty set if no consents).
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetConsentMapForUsersAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/IEmailOutboxService.cs
+++ b/src/Humans.Application/Interfaces/IEmailOutboxService.cs
@@ -1,7 +1,9 @@
+using Humans.Domain.Entities;
+
 namespace Humans.Application.Interfaces;
 
 /// <summary>
-/// Service for managing email outbox messages (retry, discard).
+/// Service for managing email outbox messages (retry, discard, stats, pause/resume).
 /// </summary>
 public interface IEmailOutboxService
 {
@@ -16,4 +18,30 @@ public interface IEmailOutboxService
     /// Returns the recipient email if found, or null if the message does not exist.
     /// </summary>
     Task<string?> DiscardMessageAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets aggregate statistics and recent messages for the email outbox dashboard.
+    /// </summary>
+    Task<EmailOutboxStats> GetOutboxStatsAsync(int recentMessageCount = 50, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets whether email sending is currently paused.
+    /// </summary>
+    Task<bool> IsEmailPausedAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the email sending paused state.
+    /// </summary>
+    Task SetEmailPausedAsync(bool paused, CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Aggregate statistics for the email outbox dashboard.
+/// </summary>
+public record EmailOutboxStats(
+    int TotalCount,
+    int QueuedCount,
+    int SentLast24HoursCount,
+    int FailedCount,
+    bool IsPaused,
+    IReadOnlyList<EmailOutboxMessage> RecentMessages);

--- a/src/Humans.Application/Interfaces/ILegalDocumentSyncService.cs
+++ b/src/Humans.Application/Interfaces/ILegalDocumentSyncService.cs
@@ -50,4 +50,12 @@ public interface ILegalDocumentSyncService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The document version if found.</returns>
     Task<DocumentVersion?> GetVersionByIdAsync(Guid versionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the current required document versions for a specific team.
+    /// Returns the latest effective version per required+active document scoped to the team.
+    /// Each returned DocumentVersion has its LegalDocument navigation loaded.
+    /// </summary>
+    Task<IReadOnlyList<DocumentVersion>> GetRequiredDocumentVersionsForTeamAsync(
+        Guid teamId, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Interfaces/INotificationInboxService.cs
+++ b/src/Humans.Application/Interfaces/INotificationInboxService.cs
@@ -83,6 +83,13 @@ public interface INotificationInboxService
     Task ResolveBySourceAsync(
         Guid userId, NotificationSource source,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets unread notification badge counts for a user (actionable + informational).
+    /// Used by the notification bell ViewComponent.
+    /// </summary>
+    Task<(int Actionable, int Informational)> GetUnreadBadgeCountsAsync(
+        Guid userId, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/IOnboardingService.cs
+++ b/src/Humans.Application/Interfaces/IOnboardingService.cs
@@ -42,6 +42,17 @@ public interface IOnboardingService
     // --- Shared: consent-check pending (used by ConsentController + ProfileController) ---
     Task<bool> SetConsentCheckPendingIfEligibleAsync(Guid userId, CancellationToken ct = default);
 
+    // --- Badge counts ---
+    /// <summary>
+    /// Gets the count of profiles pending consent review (not yet approved, not rejected).
+    /// </summary>
+    Task<int> GetPendingReviewCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the count of submitted applications that the given board member has not yet voted on.
+    /// </summary>
+    Task<int> GetUnvotedApplicationCountAsync(Guid boardMemberUserId, CancellationToken ct = default);
+
     // --- Admin ---
     Task<DTOs.AdminDashboardData> GetAdminDashboardAsync(CancellationToken ct = default);
     Task<OnboardingResult> PurgeHumanAsync(Guid userId, CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -72,6 +72,13 @@ public record MyTeamMembershipSummary(
     bool CanLeave,
     int PendingRequestCount);
 
+public record UserTeamGoogleResource(
+    string TeamName,
+    string TeamSlug,
+    string ResourceName,
+    GoogleResourceType ResourceType,
+    string? Url);
+
 public record TeamRosterSlotSummary(
     string TeamName,
     string TeamSlug,
@@ -163,6 +170,12 @@ public interface ITeamService
     /// Gets all teams the user is a member of.
     /// </summary>
     Task<IReadOnlyList<TeamMember>> GetUserTeamsAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets active Google resources grouped by team for a user's active team memberships.
+    /// Used by the MyGoogleResources view component on the dashboard.
+    /// </summary>
+    Task<IReadOnlyList<UserTeamGoogleResource>> GetUserTeamGoogleResourcesAsync(Guid userId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the current user's team memberships with viewer-specific pending-request counts.

--- a/src/Humans.Application/Interfaces/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/ITicketQueryService.cs
@@ -1,4 +1,5 @@
 using Humans.Application.DTOs;
+using NodaTime;
 
 namespace Humans.Application.Interfaces;
 
@@ -104,4 +105,25 @@ public interface ITicketQueryService
     /// Get all orders for CSV export, ordered by purchase date descending.
     /// </summary>
     Task<List<OrderExportRow>> GetOrderExportDataAsync();
+
+    /// <summary>
+    /// Checks whether a user has a matched ticket attendee record.
+    /// Used for guest dashboard and communication preferences ticketing lock.
+    /// </summary>
+    Task<bool> HasTicketAttendeeMatchAsync(Guid userId);
+
+    /// <summary>
+    /// Gets ticket order summaries for a specific user (as buyer), ordered by most recent first.
+    /// </summary>
+    Task<List<UserTicketOrderSummary>> GetUserTicketOrderSummariesAsync(Guid userId);
 }
+
+/// <summary>
+/// Summary of a ticket order for display on user-facing pages.
+/// </summary>
+public record UserTicketOrderSummary(
+    string BuyerName,
+    Instant PurchasedAt,
+    int AttendeeCount,
+    decimal TotalAmount,
+    string Currency);

--- a/src/Humans.Application/Interfaces/IUnsubscribeService.cs
+++ b/src/Humans.Application/Interfaces/IUnsubscribeService.cs
@@ -1,0 +1,47 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Handles token validation, user lookup, and unsubscribe actions
+/// for both new category-aware tokens and legacy campaign-only tokens.
+/// </summary>
+public interface IUnsubscribeService
+{
+    /// <summary>
+    /// Validates an unsubscribe token (new or legacy) and returns the resolved result.
+    /// </summary>
+    Task<UnsubscribeTokenResult> ValidateTokenAsync(string token, CancellationToken ct = default);
+
+    /// <summary>
+    /// Performs the unsubscribe action for a validated token.
+    /// </summary>
+    Task<UnsubscribeTokenResult> ConfirmUnsubscribeAsync(string token, string source, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result of validating an unsubscribe token.
+/// </summary>
+public record UnsubscribeTokenResult
+{
+    public bool IsValid { get; init; }
+    public bool IsExpired { get; init; }
+    public bool IsLegacy { get; init; }
+    public Guid? UserId { get; init; }
+    public string? DisplayName { get; init; }
+    public MessageCategory? Category { get; init; }
+
+    public static UnsubscribeTokenResult Invalid() => new() { IsValid = false };
+    public static UnsubscribeTokenResult Expired() => new() { IsValid = false, IsExpired = true };
+
+    public static UnsubscribeTokenResult Valid(
+        Guid userId, string displayName, MessageCategory category, bool isLegacy = false) =>
+        new()
+        {
+            IsValid = true,
+            UserId = userId,
+            DisplayName = displayName,
+            Category = category,
+            IsLegacy = isLegacy
+        };
+}

--- a/src/Humans.Application/Interfaces/IUserService.cs
+++ b/src/Humans.Application/Interfaces/IUserService.cs
@@ -1,0 +1,51 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Service owning user-level concerns. Currently focused on event participation.
+/// </summary>
+public interface IUserService
+{
+    /// <summary>
+    /// Get the participation record for a user in a given year. Returns null if no record exists.
+    /// </summary>
+    Task<EventParticipation?> GetParticipationAsync(Guid userId, int year);
+
+    /// <summary>
+    /// Get all participation records for a given year.
+    /// </summary>
+    Task<List<EventParticipation>> GetAllParticipationsForYearAsync(int year);
+
+    /// <summary>
+    /// Declare that the user is not attending this year's event.
+    /// </summary>
+    Task<EventParticipation> DeclareNotAttendingAsync(Guid userId, int year);
+
+    /// <summary>
+    /// Undo a "not attending" declaration. Removes the record.
+    /// Only works if the current status is NotAttending with Source=UserDeclared.
+    /// </summary>
+    Task<bool> UndoNotAttendingAsync(Guid userId, int year);
+
+    /// <summary>
+    /// Set participation status from ticket sync. Handles the lifecycle rules:
+    /// - Valid ticket → Ticketed
+    /// - Checked in → Attended (permanent)
+    /// - Ticket purchase overrides NotAttending
+    /// </summary>
+    Task SetParticipationFromTicketSyncAsync(Guid userId, int year, ParticipationStatus status);
+
+    /// <summary>
+    /// Remove a TicketSync-sourced participation record when a user no longer has valid tickets.
+    /// Does not remove UserDeclared or AdminBackfill records.
+    /// Does not remove Attended records (permanent).
+    /// </summary>
+    Task RemoveTicketSyncParticipationAsync(Guid userId, int year);
+
+    /// <summary>
+    /// Bulk import historical participation data (admin backfill).
+    /// </summary>
+    Task<int> BackfillParticipationsAsync(int year, List<(Guid UserId, ParticipationStatus Status)> entries);
+}

--- a/src/Humans.Domain/Constants/SystemSettingKeys.cs
+++ b/src/Humans.Domain/Constants/SystemSettingKeys.cs
@@ -1,0 +1,9 @@
+namespace Humans.Domain.Constants;
+
+/// <summary>
+/// Well-known keys for the SystemSettings table.
+/// </summary>
+public static class SystemSettingKeys
+{
+    public const string IsEmailSendingPaused = "IsEmailSendingPaused";
+}

--- a/src/Humans.Domain/Entities/EventParticipation.cs
+++ b/src/Humans.Domain/Entities/EventParticipation.cs
@@ -1,0 +1,43 @@
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+/// <summary>
+/// Per-user, per-year record tracking event participation status.
+/// No record = unknown/no response yet (default state, not stored).
+/// </summary>
+public class EventParticipation
+{
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// The user this participation record belongs to.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// The event year (e.g. 2026).
+    /// </summary>
+    public int Year { get; set; }
+
+    /// <summary>
+    /// Current participation status.
+    /// </summary>
+    public ParticipationStatus Status { get; set; }
+
+    /// <summary>
+    /// When the user self-declared NotAttending (null for other sources).
+    /// </summary>
+    public Instant? DeclaredAt { get; set; }
+
+    /// <summary>
+    /// How the status was set.
+    /// </summary>
+    public ParticipationSource Source { get; set; }
+
+    /// <summary>
+    /// Navigation property to the user.
+    /// </summary>
+    public User User { get; set; } = null!;
+}

--- a/src/Humans.Domain/Entities/EventSettings.cs
+++ b/src/Humans.Domain/Entities/EventSettings.cs
@@ -19,6 +19,11 @@ public class EventSettings
     public string EventName { get; set; } = string.Empty;
 
     /// <summary>
+    /// The year of this event (e.g., 2026).
+    /// </summary>
+    public int Year { get; set; }
+
+    /// <summary>
     /// IANA timezone ID (e.g., "Europe/Madrid").
     /// </summary>
     public string TimeZoneId { get; set; } = string.Empty;

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -163,4 +163,9 @@ public class User : IdentityUser<Guid>
     /// Navigation property to communication preferences.
     /// </summary>
     public ICollection<CommunicationPreference> CommunicationPreferences { get; } = new List<CommunicationPreference>();
+
+    /// <summary>
+    /// Navigation property to event participation records.
+    /// </summary>
+    public ICollection<EventParticipation> EventParticipations { get; } = new List<EventParticipation>();
 }

--- a/src/Humans.Domain/Enums/ParticipationSource.cs
+++ b/src/Humans.Domain/Enums/ParticipationSource.cs
@@ -1,0 +1,22 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// How an EventParticipation status was set.
+/// </summary>
+public enum ParticipationSource
+{
+    /// <summary>
+    /// User self-declared (e.g. "Not attending this year").
+    /// </summary>
+    UserDeclared = 0,
+
+    /// <summary>
+    /// Automatically set by ticket sync.
+    /// </summary>
+    TicketSync = 1,
+
+    /// <summary>
+    /// Manually backfilled by an admin.
+    /// </summary>
+    AdminBackfill = 2,
+}

--- a/src/Humans.Domain/Enums/ParticipationStatus.cs
+++ b/src/Humans.Domain/Enums/ParticipationStatus.cs
@@ -1,0 +1,27 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// Status of a user's participation in a yearly event.
+/// </summary>
+public enum ParticipationStatus
+{
+    /// <summary>
+    /// User has declared they are not attending this year.
+    /// </summary>
+    NotAttending = 0,
+
+    /// <summary>
+    /// User has a valid ticket for the event.
+    /// </summary>
+    Ticketed = 1,
+
+    /// <summary>
+    /// User attended the event (checked in).
+    /// </summary>
+    Attended = 2,
+
+    /// <summary>
+    /// User had a ticket but did not attend (post-event derivation).
+    /// </summary>
+    NoShow = 3,
+}

--- a/src/Humans.Infrastructure/Data/Configurations/EventParticipationConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/EventParticipationConfiguration.cs
@@ -1,0 +1,40 @@
+using Humans.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Humans.Infrastructure.Data.Configurations;
+
+public class EventParticipationConfiguration : IEntityTypeConfiguration<EventParticipation>
+{
+    public void Configure(EntityTypeBuilder<EventParticipation> builder)
+    {
+        builder.ToTable("event_participations");
+
+        builder.HasKey(ep => ep.Id);
+
+        builder.Property(ep => ep.UserId)
+            .IsRequired();
+
+        builder.Property(ep => ep.Year)
+            .IsRequired();
+
+        builder.Property(ep => ep.Status)
+            .HasConversion<string>()
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(ep => ep.Source)
+            .HasConversion<string>()
+            .HasMaxLength(50)
+            .IsRequired();
+
+        // Unique constraint on (UserId, Year)
+        builder.HasIndex(ep => new { ep.UserId, ep.Year })
+            .IsUnique();
+
+        builder.HasOne(ep => ep.User)
+            .WithMany(u => u.EventParticipations)
+            .HasForeignKey(ep => ep.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Humans.Infrastructure/Data/HumansDbContext.cs
+++ b/src/Humans.Infrastructure/Data/HumansDbContext.cs
@@ -78,6 +78,7 @@ public class HumansDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
     public DbSet<Notification> Notifications => Set<Notification>();
     public DbSet<NotificationRecipient> NotificationRecipients => Set<NotificationRecipient>();
     public DbSet<ProfileLanguage> ProfileLanguages => Set<ProfileLanguage>();
+    public DbSet<EventParticipation> EventParticipations => Set<EventParticipation>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Humans.Infrastructure/Jobs/CleanupEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/CleanupEmailOutboxJob.cs
@@ -37,23 +37,32 @@ public class CleanupEmailOutboxJob : IRecurringJob
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        var cutoff = _clock.GetCurrentInstant() - Duration.FromDays(_settings.OutboxRetentionDays);
-
-        var toDelete = await _dbContext.EmailOutboxMessages
-            .Where(m => m.Status == EmailOutboxStatus.Sent && m.SentAt < cutoff)
-            .ToListAsync(cancellationToken);
-
-        if (toDelete.Count > 0)
+        try
         {
-            _dbContext.EmailOutboxMessages.RemoveRange(toDelete);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            var cutoff = _clock.GetCurrentInstant() - Duration.FromDays(_settings.OutboxRetentionDays);
+
+            var toDelete = await _dbContext.EmailOutboxMessages
+                .Where(m => m.Status == EmailOutboxStatus.Sent && m.SentAt < cutoff)
+                .ToListAsync(cancellationToken);
+
+            if (toDelete.Count > 0)
+            {
+                _dbContext.EmailOutboxMessages.RemoveRange(toDelete);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            _logger.LogInformation(
+                "CleanupEmailOutboxJob deleted {Count} sent messages older than {Cutoff}",
+                toDelete.Count,
+                cutoff);
+
+            _metrics.RecordJobRun("cleanup_email_outbox", "success");
         }
-
-        _logger.LogInformation(
-            "CleanupEmailOutboxJob deleted {Count} sent messages older than {Cutoff}",
-            toDelete.Count,
-            cutoff);
-
-        _metrics.RecordJobRun("cleanup_email_outbox", "success");
+        catch (Exception ex)
+        {
+            _metrics.RecordJobRun("cleanup_email_outbox", "failure");
+            _logger.LogError(ex, "Error cleaning up email outbox");
+            throw;
+        }
     }
 }

--- a/src/Humans.Infrastructure/Jobs/CleanupNotificationsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/CleanupNotificationsJob.cs
@@ -37,39 +37,48 @@ public class CleanupNotificationsJob : IRecurringJob
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        var now = _clock.GetCurrentInstant();
-        var resolvedCutoff = now - ResolvedRetentionPeriod;
-        var informationalCutoff = now - InformationalRetentionPeriod;
-
-        // Pass 1: resolved notifications older than 7 days
-        var resolvedToDelete = await _dbContext.Notifications
-            .Where(n => n.ResolvedAt != null && n.ResolvedAt < resolvedCutoff)
-            .ToListAsync(cancellationToken);
-
-        if (resolvedToDelete.Count > 0)
+        try
         {
-            _dbContext.Notifications.RemoveRange(resolvedToDelete);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            var now = _clock.GetCurrentInstant();
+            var resolvedCutoff = now - ResolvedRetentionPeriod;
+            var informationalCutoff = now - InformationalRetentionPeriod;
+
+            // Pass 1: resolved notifications older than 7 days
+            var resolvedToDelete = await _dbContext.Notifications
+                .Where(n => n.ResolvedAt != null && n.ResolvedAt < resolvedCutoff)
+                .ToListAsync(cancellationToken);
+
+            if (resolvedToDelete.Count > 0)
+            {
+                _dbContext.Notifications.RemoveRange(resolvedToDelete);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            // Pass 2: unresolved informational notifications older than 30 days
+            var staleToDelete = await _dbContext.Notifications
+                .Where(n => n.ResolvedAt == null &&
+                            n.Class == NotificationClass.Informational &&
+                            n.CreatedAt < informationalCutoff)
+                .ToListAsync(cancellationToken);
+
+            if (staleToDelete.Count > 0)
+            {
+                _dbContext.Notifications.RemoveRange(staleToDelete);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            _logger.LogInformation(
+                "CleanupNotificationsJob: deleted {ResolvedCount} resolved (>{ResolvedDays}d) and {StaleCount} stale informational (>{StaleDays}d) notifications",
+                resolvedToDelete.Count, ResolvedRetentionPeriod.Days,
+                staleToDelete.Count, InformationalRetentionPeriod.Days);
+
+            _metrics.RecordJobRun("cleanup_notifications", "success");
         }
-
-        // Pass 2: unresolved informational notifications older than 30 days
-        var staleToDelete = await _dbContext.Notifications
-            .Where(n => n.ResolvedAt == null &&
-                        n.Class == NotificationClass.Informational &&
-                        n.CreatedAt < informationalCutoff)
-            .ToListAsync(cancellationToken);
-
-        if (staleToDelete.Count > 0)
+        catch (Exception ex)
         {
-            _dbContext.Notifications.RemoveRange(staleToDelete);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            _metrics.RecordJobRun("cleanup_notifications", "failure");
+            _logger.LogError(ex, "Error cleaning up notifications");
+            throw;
         }
-
-        _logger.LogInformation(
-            "CleanupNotificationsJob: deleted {ResolvedCount} resolved (>{ResolvedDays}d) and {StaleCount} stale informational (>{StaleDays}d) notifications",
-            resolvedToDelete.Count, ResolvedRetentionPeriod.Days,
-            staleToDelete.Count, InformationalRetentionPeriod.Days);
-
-        _metrics.RecordJobRun("cleanup_notifications", "success");
     }
 }

--- a/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
@@ -138,6 +138,7 @@ public class ProcessAccountDeletionsJob : IRecurringJob
             foreach (var userId in processedUserIds)
             {
                 _profileService.UpdateProfileCache(userId, null);
+                _cache.InvalidateUserProfile(userId);
                 _teamService.RemoveMemberFromAllTeamsCache(userId);
                 _cache.InvalidateRoleAssignmentClaims(userId);
                 _cache.InvalidateShiftAuthorization(userId);

--- a/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Data;
@@ -43,7 +44,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
     {
         // 1. Check global pause flag
         var pauseSetting = await _dbContext.SystemSettings
-            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused", cancellationToken);
+            .FirstOrDefaultAsync(s => s.Key == SystemSettingKeys.IsEmailSendingPaused, cancellationToken);
 
         if (pauseSetting is { Value: "true" })
         {

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -49,146 +49,156 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        var pendingEvents = await _dbContext.GoogleSyncOutboxEvents
-            .Where(e => e.ProcessedAt == null && !e.FailedPermanently && e.RetryCount < MaxRetryCount)
-            .OrderBy(e => e.OccurredAt)
-            .Take(BatchSize)
-            .ToListAsync(cancellationToken);
-
-        if (pendingEvents.Count == 0)
+        try
         {
-            return;
-        }
+            var pendingEvents = await _dbContext.GoogleSyncOutboxEvents
+                .Where(e => e.ProcessedAt == null && !e.FailedPermanently && e.RetryCount < MaxRetryCount)
+                .OrderBy(e => e.OccurredAt)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken);
 
-        // Pre-load contextual info for richer error messages
-        var userIds = pendingEvents.Select(e => e.UserId).Distinct().ToList();
-        var teamIds = pendingEvents.Select(e => e.TeamId).Distinct().ToList();
-        var userEmailLookup = await _dbContext.Users
-            .Where(u => userIds.Contains(u.Id))
-            .ToDictionaryAsync(u => u.Id, u => u.Email ?? "unknown", cancellationToken);
-        var teamNameLookup = await _dbContext.Teams
-            .Where(t => teamIds.Contains(t.Id))
-            .ToDictionaryAsync(t => t.Id, t => t.Name, cancellationToken);
-
-        foreach (var outboxEvent in pendingEvents)
-        {
-            try
+            if (pendingEvents.Count == 0)
             {
-                switch (outboxEvent.EventType)
+                return;
+            }
+
+            // Pre-load contextual info for richer error messages
+            var userIds = pendingEvents.Select(e => e.UserId).Distinct().ToList();
+            var teamIds = pendingEvents.Select(e => e.TeamId).Distinct().ToList();
+            var userEmailLookup = await _dbContext.Users
+                .Where(u => userIds.Contains(u.Id))
+                .ToDictionaryAsync(u => u.Id, u => u.Email ?? "unknown", cancellationToken);
+            var teamNameLookup = await _dbContext.Teams
+                .Where(t => teamIds.Contains(t.Id))
+                .ToDictionaryAsync(t => t.Id, t => t.Name, cancellationToken);
+
+            foreach (var outboxEvent in pendingEvents)
+            {
+                try
                 {
-                    case GoogleSyncOutboxEventTypes.AddUserToTeamResources:
-                        await _googleSyncService.AddUserToTeamResourcesAsync(
-                            outboxEvent.TeamId,
-                            outboxEvent.UserId,
-                            cancellationToken);
-                        break;
-
-                    case GoogleSyncOutboxEventTypes.RemoveUserFromTeamResources:
-                        await _googleSyncService.RemoveUserFromTeamResourcesAsync(
-                            outboxEvent.TeamId,
-                            outboxEvent.UserId,
-                            cancellationToken);
-                        break;
-
-                    default:
-                        throw new InvalidOperationException($"Unknown outbox event type '{outboxEvent.EventType}'.");
-                }
-
-                outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
-                outboxEvent.LastError = null;
-                _metrics.RecordSyncOperation("success");
-
-                // Only mark user as Valid when the event actually touched Google APIs
-                // (AddUserToTeamResources with linked resources). RemoveUserFromTeamResources
-                // is a no-op, and Add with zero resources doesn't validate the email.
-                if (string.Equals(outboxEvent.EventType, GoogleSyncOutboxEventTypes.AddUserToTeamResources, StringComparison.Ordinal))
-                {
-                    var hasResources = await _dbContext.GoogleResources
-                        .AnyAsync(r => r.TeamId == outboxEvent.TeamId && r.IsActive, cancellationToken);
-                    if (hasResources)
+                    switch (outboxEvent.EventType)
                     {
-                        await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Valid, cancellationToken);
+                        case GoogleSyncOutboxEventTypes.AddUserToTeamResources:
+                            await _googleSyncService.AddUserToTeamResourcesAsync(
+                                outboxEvent.TeamId,
+                                outboxEvent.UserId,
+                                cancellationToken);
+                            break;
+
+                        case GoogleSyncOutboxEventTypes.RemoveUserFromTeamResources:
+                            await _googleSyncService.RemoveUserFromTeamResourcesAsync(
+                                outboxEvent.TeamId,
+                                outboxEvent.UserId,
+                                cancellationToken);
+                            break;
+
+                        default:
+                            throw new InvalidOperationException($"Unknown outbox event type '{outboxEvent.EventType}'.");
                     }
+
+                    outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
+                    outboxEvent.LastError = null;
+                    _metrics.RecordSyncOperation("success");
+
+                    // Only mark user as Valid when the event actually touched Google APIs
+                    // (AddUserToTeamResources with linked resources). RemoveUserFromTeamResources
+                    // is a no-op, and Add with zero resources doesn't validate the email.
+                    if (string.Equals(outboxEvent.EventType, GoogleSyncOutboxEventTypes.AddUserToTeamResources, StringComparison.Ordinal))
+                    {
+                        var hasResources = await _dbContext.GoogleResources
+                            .AnyAsync(r => r.TeamId == outboxEvent.TeamId && r.IsActive, cancellationToken);
+                        if (hasResources)
+                        {
+                            await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Valid, cancellationToken);
+                        }
+                    }
+
+                    await _dbContext.SaveChangesAsync(cancellationToken);
                 }
-
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
-            catch (Google.GoogleApiException ex) when (IsPermanentError(ex))
-            {
-                _metrics.RecordSyncOperation("permanent_failure");
-                outboxEvent.FailedPermanently = true;
-                outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
-                outboxEvent.LastError = ex.Message.Length > 4000
-                    ? ex.Message[..4000]
-                    : ex.Message;
-
-                _logger.LogWarning(
-                    ex,
-                    "Permanent failure processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — HTTP {StatusCode}, not retrying",
-                    outboxEvent.Id,
-                    outboxEvent.EventType,
-                    userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
-                    teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
-                    ex.Error?.Code);
-
-                // Mark user's Google email as Rejected
-                await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Rejected, cancellationToken);
-
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _metrics.RecordSyncOperation("failure");
-                outboxEvent.RetryCount += 1;
-                outboxEvent.LastError = ex.Message.Length > 4000
-                    ? ex.Message[..4000]
-                    : ex.Message;
-
-                _logger.LogError(
-                    ex,
-                    "Failed processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — attempt {Attempt}/{MaxRetries}",
-                    outboxEvent.Id,
-                    outboxEvent.EventType,
-                    userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
-                    teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
-                    outboxEvent.RetryCount,
-                    MaxRetryCount);
-
-                // Mark as permanently failed when retries are exhausted
-                if (outboxEvent.RetryCount >= MaxRetryCount)
+                catch (Google.GoogleApiException ex) when (IsPermanentError(ex))
                 {
+                    _metrics.RecordSyncOperation("permanent_failure");
                     outboxEvent.FailedPermanently = true;
                     outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
+                    outboxEvent.LastError = ex.Message.Length > 4000
+                        ? ex.Message[..4000]
+                        : ex.Message;
+
+                    _logger.LogWarning(
+                        ex,
+                        "Permanent failure processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — HTTP {StatusCode}, not retrying",
+                        outboxEvent.Id,
+                        outboxEvent.EventType,
+                        userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
+                        teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
+                        ex.Error?.Code);
+
+                    // Mark user's Google email as Rejected
+                    await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Rejected, cancellationToken);
+
+                    await _dbContext.SaveChangesAsync(cancellationToken);
                 }
-
-                await _dbContext.SaveChangesAsync(cancellationToken);
-
-                // Notify admins on final failure (exhausted retries)
-                if (outboxEvent.RetryCount >= MaxRetryCount)
+                catch (Exception ex)
                 {
-                    try
+                    _metrics.RecordSyncOperation("failure");
+                    outboxEvent.RetryCount += 1;
+                    outboxEvent.LastError = ex.Message.Length > 4000
+                        ? ex.Message[..4000]
+                        : ex.Message;
+
+                    _logger.LogError(
+                        ex,
+                        "Failed processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — attempt {Attempt}/{MaxRetries}",
+                        outboxEvent.Id,
+                        outboxEvent.EventType,
+                        userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
+                        teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
+                        outboxEvent.RetryCount,
+                        MaxRetryCount);
+
+                    // Mark as permanently failed when retries are exhausted
+                    if (outboxEvent.RetryCount >= MaxRetryCount)
                     {
-                        await _notificationService.SendToRoleAsync(
-                            NotificationSource.SyncError,
-                            NotificationClass.Actionable,
-                            NotificationPriority.High,
-                            "Google sync event failed after all retries",
-                            RoleNames.Admin,
-                            body: $"Event {outboxEvent.EventType} for team {outboxEvent.TeamId} failed: {outboxEvent.LastError?[..Math.Min(200, outboxEvent.LastError.Length)]}",
-                            actionUrl: "/Google/SyncOutbox",
-                            actionLabel: "View \u2192",
-                            cancellationToken: cancellationToken);
+                        outboxEvent.FailedPermanently = true;
+                        outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
                     }
-                    catch (Exception notifEx)
+
+                    await _dbContext.SaveChangesAsync(cancellationToken);
+
+                    // Notify admins on final failure (exhausted retries)
+                    if (outboxEvent.RetryCount >= MaxRetryCount)
                     {
-                        _logger.LogError(notifEx,
-                            "Failed to dispatch SyncError notification for outbox event {OutboxId}",
-                            outboxEvent.Id);
+                        try
+                        {
+                            await _notificationService.SendToRoleAsync(
+                                NotificationSource.SyncError,
+                                NotificationClass.Actionable,
+                                NotificationPriority.High,
+                                "Google sync event failed after all retries",
+                                RoleNames.Admin,
+                                body: $"Event {outboxEvent.EventType} for team {outboxEvent.TeamId} failed: {outboxEvent.LastError?[..Math.Min(200, outboxEvent.LastError.Length)]}",
+                                actionUrl: "/Google/SyncOutbox",
+                                actionLabel: "View \u2192",
+                                cancellationToken: cancellationToken);
+                        }
+                        catch (Exception notifEx)
+                        {
+                            _logger.LogError(notifEx,
+                                "Failed to dispatch SyncError notification for outbox event {OutboxId}",
+                                outboxEvent.Id);
+                        }
                     }
                 }
             }
+
+            _metrics.RecordJobRun("process_google_sync_outbox", "success");
         }
-        _metrics.RecordJobRun("process_google_sync_outbox", "success");
+        catch (Exception ex)
+        {
+            _metrics.RecordJobRun("process_google_sync_outbox", "failure");
+            _logger.LogError(ex, "Error processing Google sync outbox");
+            throw;
+        }
     }
 
     private static bool IsPermanentError(Google.GoogleApiException ex)

--- a/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
@@ -177,6 +177,8 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
                 {
                     _profileService.UpdateProfileCache(userId, null);
                     _cache.InvalidateUserProfile(userId);
+                    _cache.InvalidateRoleAssignmentClaims(userId);
+                    _cache.InvalidateShiftAuthorization(userId);
                     _teamService.RemoveMemberFromAllTeamsCache(userId);
                 }
             }

--- a/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410151810_AddEventParticipationAndEventSettingsYear")]
+    partial class AddEventParticipationAndEventSettingsYear
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.cs
+++ b/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEventParticipationAndEventSettingsYear : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Year",
+                table: "event_settings",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            // Backfill Year from GateOpeningDate so the feature isn't inert after deploy
+            migrationBuilder.Sql(
+                @"UPDATE event_settings SET ""Year"" = EXTRACT(YEAR FROM ""GateOpeningDate"")::integer WHERE ""GateOpeningDate"" IS NOT NULL;");
+
+            migrationBuilder.CreateTable(
+                name: "event_participations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Year = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    DeclaredAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
+                    Source = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_event_participations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_event_participations_users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_event_participations_UserId_Year",
+                table: "event_participations",
+                columns: new[] { "UserId", "Year" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "event_participations");
+
+            migrationBuilder.DropColumn(
+                name: "Year",
+                table: "event_settings");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
+++ b/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
@@ -100,6 +100,7 @@ public class ApplicationDecisionService : IApplicationDecisionService
 
         _cache.InvalidateNavBadgeCounts();
         _cache.InvalidateNotificationMeters();
+        _cache.InvalidateUserProfile(application.UserId);
         foreach (var id in voterIds)
             _cache.InvalidateVotingBadge(id);
         _metrics.RecordApplicationProcessed("approved");

--- a/src/Humans.Infrastructure/Services/AuditLogService.cs
+++ b/src/Humans.Infrastructure/Services/AuditLogService.cs
@@ -186,6 +186,40 @@ public class AuditLogService : IAuditLogService
     }
 
     /// <inheritdoc />
+    public async Task<AuditLogPageResult> GetAuditLogPageAsync(
+        string? actionFilter, int page, int pageSize, CancellationToken ct = default)
+    {
+        var (items, totalCount, anomalyCount) = await GetFilteredAsync(actionFilter, page, pageSize, ct);
+
+        // Collect all user IDs that might appear as actors or subjects
+        var userIds = new HashSet<Guid>();
+        var teamIds = new HashSet<Guid>();
+
+        foreach (var e in items)
+        {
+            if (e.ActorUserId.HasValue)
+                userIds.Add(e.ActorUserId.Value);
+
+            // Subject user ID: User/Profile/WorkspaceAccount entity types, or related User
+            if (e.EntityType is "User" or "Profile" or "WorkspaceAccount")
+                userIds.Add(e.EntityId);
+            else if (string.Equals(e.RelatedEntityType, "User", StringComparison.Ordinal) && e.RelatedEntityId.HasValue)
+                userIds.Add(e.RelatedEntityId.Value);
+
+            // Target team ID
+            if (string.Equals(e.EntityType, "Team", StringComparison.Ordinal))
+                teamIds.Add(e.EntityId);
+            else if (string.Equals(e.RelatedEntityType, "Team", StringComparison.Ordinal) && e.RelatedEntityId.HasValue)
+                teamIds.Add(e.RelatedEntityId.Value);
+        }
+
+        var userDisplayNames = await GetUserDisplayNamesAsync(userIds.ToList(), ct);
+        var teamNameLookup = await GetTeamNamesAsync(teamIds.ToList(), ct);
+
+        return new AuditLogPageResult(items, totalCount, anomalyCount, userDisplayNames, teamNameLookup);
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<AuditLogEntry>> GetFilteredEntriesAsync(
         string? entityType = null,
         Guid? entityId = null,
@@ -215,5 +249,27 @@ public class AuditLogService : IAuditLogService
             .OrderByDescending(e => e.OccurredAt)
             .Take(limit)
             .ToListAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(IReadOnlyList<Guid> userIds, CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+            return new Dictionary<Guid, string>();
+
+        return await _dbContext.Users.AsNoTracking()
+            .Where(u => userIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => u.DisplayName, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default)
+    {
+        if (teamIds.Count == 0)
+            return new Dictionary<Guid, (string Name, string Slug)>();
+
+        return await _dbContext.Teams.AsNoTracking()
+            .Where(t => teamIds.Contains(t.Id))
+            .ToDictionaryAsync(t => t.Id, t => (t.Name, t.Slug), ct);
     }
 }

--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -654,6 +654,11 @@ public class BudgetService : IBudgetService
 
     // ───────────────────────── Budget Line Items ─────────────────────────
 
+    public async Task<BudgetLineItem?> GetLineItemByIdAsync(Guid id)
+    {
+        return await _dbContext.BudgetLineItems.FindAsync(id);
+    }
+
     public async Task<BudgetLineItem> CreateLineItemAsync(
         Guid budgetCategoryId, string description, decimal amount,
         Guid? responsibleTeamId, string? notes, LocalDate? expectedDate,

--- a/src/Humans.Infrastructure/Services/CampService.cs
+++ b/src/Humans.Infrastructure/Services/CampService.cs
@@ -319,6 +319,25 @@ public class CampService : ICampService
             .ToList();
     }
 
+    /// <inheritdoc />
+    public async Task<List<Camp>> GetCampsWithLeadsForYearAsync(int year, IReadOnlyList<CampSeasonStatus>? statusFilter = null, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Camps
+            .Include(c => c.Seasons.Where(s => s.Year == year))
+            .Include(c => c.Leads.Where(l => l.LeftAt == null))
+                .ThenInclude(l => l.User)
+            .Where(c => c.Seasons.Any(s => s.Year == year));
+
+        if (statusFilter is { Count: > 0 })
+        {
+            query = query.Where(c => c.Seasons.Any(s => s.Year == year && statusFilter.Contains(s.Status)));
+        }
+
+        return await query
+            .OrderBy(c => c.Seasons.Where(s => s.Year == year).Select(s => s.Name).FirstOrDefault())
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<List<Camp>> GetCampsByLeadUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
     {
         return await _dbContext.Camps

--- a/src/Humans.Infrastructure/Services/CampaignService.cs
+++ b/src/Humans.Infrastructure/Services/CampaignService.cs
@@ -314,18 +314,27 @@ public class CampaignService : ICampaignService
 
         var alreadyGrantedSet = alreadyGrantedUserIds.ToHashSet();
 
-        var eligible = activeTeamUserIds
+        var notGranted = activeTeamUserIds
             .Where(id => !alreadyGrantedSet.Contains(id))
             .ToList();
 
+        // Count users who have opted out of Marketing
+        var optedOutCount = 0;
+        foreach (var userId in notGranted)
+        {
+            if (await _commPrefService.IsOptedOutAsync(userId, MessageCategory.Marketing, ct))
+                optedOutCount++;
+        }
+
+        var eligibleCount = notGranted.Count - optedOutCount;
         var availableCodes = await CountAvailableCodesAsync(campaignId, ct);
 
         return new WaveSendPreview(
-            EligibleCount: eligible.Count,
+            EligibleCount: eligibleCount,
             AlreadyGrantedExcluded: activeTeamUserIds.Count(id => alreadyGrantedSet.Contains(id)),
-            UnsubscribedExcluded: 0,
+            UnsubscribedExcluded: optedOutCount,
             CodesAvailable: availableCodes,
-            CodesRemainingAfterSend: availableCodes - eligible.Count);
+            CodesRemainingAfterSend: availableCodes - eligibleCount);
     }
 
     public async Task<int> SendWaveAsync(Guid campaignId, Guid teamId, CancellationToken ct = default)
@@ -348,11 +357,19 @@ public class CampaignService : ICampaignService
             .ToListAsync(ct);
         var alreadyGrantedSet = alreadyGrantedUserIds.ToHashSet();
 
-        var eligibleUsers = await _dbContext.Users
+        var candidateUsers = await _dbContext.Users
             .Include(u => u.UserEmails)
             .Where(u => activeTeamUserIds.Contains(u.Id)
                         && !alreadyGrantedSet.Contains(u.Id))
             .ToListAsync(ct);
+
+        // Filter out users who have opted out of Marketing emails
+        var eligibleUsers = new List<User>(candidateUsers.Count);
+        foreach (var user in candidateUsers)
+        {
+            if (!await _commPrefService.IsOptedOutAsync(user.Id, MessageCategory.Marketing, ct))
+                eligibleUsers.Add(user);
+        }
 
         if (eligibleUsers.Count == 0)
             return 0;
@@ -516,14 +533,12 @@ public class CampaignService : ICampaignService
 
         // Generate unsubscribe headers and footer link for Marketing category
         var unsubHeaders = _commPrefService.GenerateUnsubscribeHeaders(user.Id, MessageCategory.Marketing);
-        string? unsubscribeUrl = null;
         string? extraHeadersJson = null;
         if (unsubHeaders is not null)
         {
-            if (unsubHeaders.TryGetValue("List-Unsubscribe", out var listUnsub))
-                unsubscribeUrl = listUnsub.Trim('<', '>');
             extraHeadersJson = JsonSerializer.Serialize(unsubHeaders);
         }
+        var unsubscribeUrl = _commPrefService.GenerateBrowserUnsubscribeUrl(user.Id, MessageCategory.Marketing);
 
         // Wrap in email template
         var (wrappedHtml, plainText) = EmailBodyComposer.Compose(

--- a/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
+++ b/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
@@ -83,7 +83,20 @@ public class CommunicationPreferenceService : ICommunicationPreferenceService
         }
 
         if (created)
-            await _db.SaveChangesAsync(cancellationToken);
+        {
+            try
+            {
+                await _db.SaveChangesAsync(cancellationToken);
+            }
+            catch (DbUpdateException)
+            {
+                // Another request already created the defaults — reload
+                _db.ChangeTracker.Clear();
+                existing = await _db.CommunicationPreferences
+                    .Where(cp => cp.UserId == userId)
+                    .ToListAsync(cancellationToken);
+            }
+        }
 
         return existing
             .OrderBy(cp => cp.Category)

--- a/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
+++ b/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
@@ -257,6 +257,47 @@ public class CommunicationPreferenceService : ICommunicationPreferenceService
         return !await IsOptedOutAsync(userId, MessageCategory.FacilitatedMessages, cancellationToken);
     }
 
+    public async Task<IReadOnlySet<Guid>> GetUsersWithInboxDisabledAsync(
+        IReadOnlyList<Guid> userIds, MessageCategory category,
+        CancellationToken cancellationToken = default)
+    {
+        if (userIds.Count == 0)
+        {
+            return new HashSet<Guid>();
+        }
+
+        var disabledUserIds = await _db.CommunicationPreferences
+            .Where(cp => userIds.Contains(cp.UserId) && cp.Category == category && !cp.InboxEnabled)
+            .Select(cp => cp.UserId)
+            .ToListAsync(cancellationToken);
+
+        return disabledUserIds.ToHashSet();
+    }
+
+    public async Task<bool> HasAnyPreferencesAsync(
+        Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _db.CommunicationPreferences
+            .AnyAsync(cp => cp.UserId == userId, cancellationToken);
+    }
+
+    public async Task<IReadOnlySet<Guid>> GetUsersWithAnyPreferencesAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken cancellationToken = default)
+    {
+        if (userIds.Count == 0)
+        {
+            return new HashSet<Guid>();
+        }
+
+        var usersWithPrefs = await _db.CommunicationPreferences
+            .Where(cp => userIds.Contains(cp.UserId))
+            .Select(cp => cp.UserId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        return usersWithPrefs.ToHashSet();
+    }
+
     public Dictionary<string, string> GenerateUnsubscribeHeaders(Guid userId, MessageCategory category)
     {
         var token = GenerateUnsubscribeToken(userId, category);

--- a/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
+++ b/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
@@ -227,27 +227,35 @@ public class CommunicationPreferenceService : ICommunicationPreferenceService
         return _protector.Protect(payload, TokenLifetime);
     }
 
-    public (Guid UserId, MessageCategory Category)? ValidateUnsubscribeToken(string token)
+    public (TokenValidationStatus Status, Guid UserId, MessageCategory Category) ValidateUnsubscribeToken(string token)
     {
         try
         {
             var payload = _protector.Unprotect(token);
             var parts = payload.Split('|');
             if (parts.Length != 2)
-                return null;
+                return (TokenValidationStatus.Invalid, default, default);
 
             if (!Guid.TryParse(parts[0], out var userId))
-                return null;
+                return (TokenValidationStatus.Invalid, default, default);
 
             if (!Enum.TryParse<MessageCategory>(parts[1], out var category))
-                return null;
+                return (TokenValidationStatus.Invalid, default, default);
 
-            return (userId, category);
+            return (TokenValidationStatus.Valid, userId, category);
         }
         catch (CryptographicException ex)
         {
+            // DataProtection throws CryptographicException for both expired and tampered tokens.
+            // Expired tokens include "expired" in the message; tampered tokens do not.
+            if (ex.Message.Contains("expired", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(ex, "Expired unsubscribe token");
+                return (TokenValidationStatus.Expired, default, default);
+            }
+
             _logger.LogWarning(ex, "Failed to validate unsubscribe token");
-            return null;
+            return (TokenValidationStatus.Invalid, default, default);
         }
     }
 
@@ -309,5 +317,11 @@ public class CommunicationPreferenceService : ICommunicationPreferenceService
             ["List-Unsubscribe"] = $"<{oneClickUrl}>, <{browserUrl}>",
             ["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click",
         };
+    }
+
+    public string GenerateBrowserUnsubscribeUrl(Guid userId, MessageCategory category)
+    {
+        var token = GenerateUnsubscribeToken(userId, category);
+        return $"{_baseUrl}/Unsubscribe/{token}";
     }
 }

--- a/src/Humans.Infrastructure/Services/ConsentService.cs
+++ b/src/Humans.Infrastructure/Services/ConsentService.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces;
@@ -14,7 +15,8 @@ public class ConsentService : IConsentService
 {
     private readonly HumansDbContext _dbContext;
     private readonly IOnboardingService _onboardingService;
-    private readonly IMembershipCalculator _membershipCalculator;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService;
     private readonly INotificationInboxService _notificationInboxService;
     private readonly ISystemTeamSync _syncJob;
     private readonly IHumansMetrics _metrics;
@@ -24,7 +26,8 @@ public class ConsentService : IConsentService
     public ConsentService(
         HumansDbContext dbContext,
         IOnboardingService onboardingService,
-        IMembershipCalculator membershipCalculator,
+        IServiceProvider serviceProvider,
+        ILegalDocumentSyncService legalDocumentSyncService,
         INotificationInboxService notificationInboxService,
         ISystemTeamSync syncJob,
         IHumansMetrics metrics,
@@ -33,7 +36,8 @@ public class ConsentService : IConsentService
     {
         _dbContext = dbContext;
         _onboardingService = onboardingService;
-        _membershipCalculator = membershipCalculator;
+        _serviceProvider = serviceProvider;
+        _legalDocumentSyncService = legalDocumentSyncService;
         _notificationInboxService = notificationInboxService;
         _syncJob = syncJob;
         _metrics = metrics;
@@ -47,7 +51,8 @@ public class ConsentService : IConsentService
     {
         var now = _clock.GetCurrentInstant();
 
-        var userTeamIds = await _membershipCalculator.GetRequiredTeamIdsForUserAsync(userId, ct);
+        var membershipCalculator = _serviceProvider.GetRequiredService<IMembershipCalculator>();
+        var userTeamIds = await membershipCalculator.GetRequiredTeamIdsForUserAsync(userId, ct);
 
         var documents = await _dbContext.LegalDocuments
             .Where(d => d.IsActive && d.IsRequired && userTeamIds.Contains(d.TeamId))
@@ -92,9 +97,7 @@ public class ConsentService : IConsentService
     public async Task<(DocumentVersion? Version, ConsentRecord? ExistingConsent, string? UserFullName)>
         GetConsentReviewDetailAsync(Guid documentVersionId, Guid userId, CancellationToken ct = default)
     {
-        var version = await _dbContext.DocumentVersions
-            .Include(v => v.LegalDocument)
-            .FirstOrDefaultAsync(v => v.Id == documentVersionId, ct);
+        var version = await _legalDocumentSyncService.GetVersionByIdAsync(documentVersionId, ct);
 
         if (version is null)
             return (null, null, null);
@@ -113,9 +116,7 @@ public class ConsentService : IConsentService
         Guid userId, Guid documentVersionId, bool explicitConsent,
         string ipAddress, string userAgent, CancellationToken ct = default)
     {
-        var version = await _dbContext.DocumentVersions
-            .Include(v => v.LegalDocument)
-            .FirstOrDefaultAsync(v => v.Id == documentVersionId, ct);
+        var version = await _legalDocumentSyncService.GetVersionByIdAsync(documentVersionId, ct);
 
         if (version is null)
             return new ConsentSubmitResult(false, ErrorKey: "NotFound");
@@ -158,7 +159,8 @@ public class ConsentService : IConsentService
         // Auto-resolve AccessSuspended notifications only once ALL required consents are complete
         try
         {
-            if (await _membershipCalculator.HasAllRequiredConsentsAsync(userId, ct))
+            var membershipCalc = _serviceProvider.GetRequiredService<IMembershipCalculator>();
+            if (await membershipCalc.HasAllRequiredConsentsAsync(userId, ct))
             {
                 await _notificationInboxService.ResolveBySourceAsync(userId, NotificationSource.AccessSuspended, ct);
             }
@@ -169,6 +171,63 @@ public class ConsentService : IConsentService
         }
 
         return new ConsentSubmitResult(true, DocumentName: version.LegalDocument.Name);
+    }
+
+    public async Task<IReadOnlyList<ConsentRecord>> GetUserConsentRecordsAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        return await _dbContext.ConsentRecords
+            .AsNoTracking()
+            .Include(c => c.DocumentVersion)
+                .ThenInclude(v => v.LegalDocument)
+            .Where(c => c.UserId == userId)
+            .OrderByDescending(c => c.ConsentedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<int> GetConsentRecordCountAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        return await _dbContext.ConsentRecords
+            .CountAsync(cr => cr.UserId == userId, ct);
+    }
+
+    public async Task<IReadOnlySet<Guid>> GetConsentedVersionIdsAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        var ids = await _dbContext.ConsentRecords
+            .AsNoTracking()
+            .Where(cr => cr.UserId == userId && cr.ExplicitConsent)
+            .Select(cr => cr.DocumentVersionId)
+            .ToListAsync(ct);
+
+        return ids.ToHashSet();
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetConsentMapForUsersAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+        {
+            return new Dictionary<Guid, IReadOnlySet<Guid>>();
+        }
+
+        var consents = await _dbContext.ConsentRecords
+            .AsNoTracking()
+            .Where(cr => userIds.Contains(cr.UserId) && cr.ExplicitConsent)
+            .Select(cr => new { cr.UserId, cr.DocumentVersionId })
+            .ToListAsync(ct);
+
+        var result = userIds.ToDictionary(
+            id => id,
+            _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
+
+        foreach (var consent in consents)
+        {
+            ((HashSet<Guid>)result[consent.UserId]).Add(consent.DocumentVersionId);
+        }
+
+        return result;
     }
 
     private static string ComputeContentHash(string content)

--- a/src/Humans.Infrastructure/Services/ContactService.cs
+++ b/src/Humans.Infrastructure/Services/ContactService.cs
@@ -19,6 +19,7 @@ public class ContactService : IContactService
 {
     private readonly HumansDbContext _dbContext;
     private readonly UserManager<User> _userManager;
+    private readonly ICommunicationPreferenceService _preferenceService;
     private readonly IAuditLogService _auditLogService;
     private readonly IClock _clock;
     private readonly ILogger<ContactService> _logger;
@@ -26,12 +27,14 @@ public class ContactService : IContactService
     public ContactService(
         HumansDbContext dbContext,
         UserManager<User> userManager,
+        ICommunicationPreferenceService preferenceService,
         IAuditLogService auditLogService,
         IClock clock,
         ILogger<ContactService> logger)
     {
         _dbContext = dbContext;
         _userManager = userManager;
+        _preferenceService = preferenceService;
         _auditLogService = auditLogService;
         _clock = clock;
         _logger = logger;
@@ -181,23 +184,36 @@ public class ContactService : IContactService
                 (u.Email != null && EF.Functions.ILike(u.Email, pattern)));
         }
 
-        return await query
+        var contacts = await query
             .OrderByDescending(u => u.CreatedAt)
-            .Select(u => new AdminContactRow(
+            .Select(u => new
+            {
                 u.Id,
-                u.Email ?? string.Empty,
+                Email = u.Email ?? string.Empty,
                 u.DisplayName,
                 u.ContactSource,
                 u.ExternalSourceId,
                 u.CreatedAt,
-                u.CommunicationPreferences.Any()))
+            })
             .ToListAsync(ct);
+
+        var contactIds = contacts.Select(c => c.Id).ToList();
+        var usersWithPrefs = await _preferenceService.GetUsersWithAnyPreferencesAsync(contactIds, ct);
+
+        var results = new List<AdminContactRow>(contacts.Count);
+        foreach (var c in contacts)
+        {
+            results.Add(new AdminContactRow(
+                c.Id, c.Email, c.DisplayName, c.ContactSource,
+                c.ExternalSourceId, c.CreatedAt, usersWithPrefs.Contains(c.Id)));
+        }
+
+        return results;
     }
 
     public async Task<User?> GetContactDetailAsync(Guid userId, CancellationToken ct = default)
     {
         return await _dbContext.Users
-            .Include(u => u.CommunicationPreferences)
             .Include(u => u.UserEmails)
             .FirstOrDefaultAsync(u =>
                 u.Id == userId &&

--- a/src/Humans.Infrastructure/Services/EmailOutboxService.cs
+++ b/src/Humans.Infrastructure/Services/EmailOutboxService.cs
@@ -1,4 +1,8 @@
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
 using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 
@@ -7,10 +11,12 @@ namespace Humans.Infrastructure.Services;
 public class EmailOutboxService : IEmailOutboxService
 {
     private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
 
-    public EmailOutboxService(HumansDbContext dbContext)
+    public EmailOutboxService(HumansDbContext dbContext, IClock clock)
     {
         _dbContext = dbContext;
+        _clock = clock;
     }
 
     public async Task<string?> RetryMessageAsync(Guid id, CancellationToken cancellationToken = default)
@@ -38,5 +44,52 @@ public class EmailOutboxService : IEmailOutboxService
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         return recipient;
+    }
+
+    public async Task<EmailOutboxStats> GetOutboxStatsAsync(int recentMessageCount = 50, CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+        var cutoff24H = now - Duration.FromHours(24);
+
+        var totalCount = await _dbContext.EmailOutboxMessages.CountAsync(cancellationToken);
+        var queuedCount = await _dbContext.EmailOutboxMessages
+            .CountAsync(m => m.Status == EmailOutboxStatus.Queued, cancellationToken);
+        var sentLast24H = await _dbContext.EmailOutboxMessages
+            .CountAsync(m => m.Status == EmailOutboxStatus.Sent && m.SentAt > cutoff24H, cancellationToken);
+        var failedCount = await _dbContext.EmailOutboxMessages
+            .CountAsync(m => m.Status == EmailOutboxStatus.Failed, cancellationToken);
+
+        var isPaused = await IsEmailPausedAsync(cancellationToken);
+
+        var messages = await _dbContext.EmailOutboxMessages
+            .Include(m => m.User)
+            .OrderByDescending(m => m.CreatedAt)
+            .Take(recentMessageCount)
+            .ToListAsync(cancellationToken);
+
+        return new EmailOutboxStats(totalCount, queuedCount, sentLast24H, failedCount, isPaused, messages);
+    }
+
+    public async Task<bool> IsEmailPausedAsync(CancellationToken cancellationToken = default)
+    {
+        var setting = await _dbContext.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == SystemSettingKeys.IsEmailSendingPaused, cancellationToken);
+        return string.Equals(setting?.Value, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async Task SetEmailPausedAsync(bool paused, CancellationToken cancellationToken = default)
+    {
+        var setting = await _dbContext.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == SystemSettingKeys.IsEmailSendingPaused, cancellationToken);
+        if (setting is null)
+        {
+            setting = new SystemSetting { Key = SystemSettingKeys.IsEmailSendingPaused, Value = paused ? "true" : "false" };
+            _dbContext.SystemSettings.Add(setting);
+        }
+        else
+        {
+            setting.Value = paused ? "true" : "false";
+        }
+        await _dbContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/Humans.Infrastructure/Services/FeedbackService.cs
+++ b/src/Humans.Infrastructure/Services/FeedbackService.cs
@@ -324,8 +324,8 @@ public class FeedbackService : IFeedbackService
             string newName = "Unassigned";
             if (assignedToUserId.HasValue)
             {
-                var user = await _dbContext.Users.FindAsync(new object[] { assignedToUserId.Value }, cancellationToken);
-                newName = user?.DisplayName ?? assignedToUserId.Value.ToString();
+                await _dbContext.Entry(report).Reference(r => r.AssignedToUser!).LoadAsync(cancellationToken);
+                newName = report.AssignedToUser?.DisplayName ?? assignedToUserId.Value.ToString();
             }
             changes.Add($"Assignee: {oldName} → {newName}");
         }
@@ -339,8 +339,8 @@ public class FeedbackService : IFeedbackService
             string newTeamName = "Unassigned";
             if (assignedToTeamId.HasValue)
             {
-                var team = await _dbContext.Teams.FindAsync(new object[] { assignedToTeamId.Value }, cancellationToken);
-                newTeamName = team?.Name ?? assignedToTeamId.Value.ToString();
+                await _dbContext.Entry(report).Reference(r => r.AssignedToTeam!).LoadAsync(cancellationToken);
+                newTeamName = report.AssignedToTeam?.Name ?? assignedToTeamId.Value.ToString();
             }
             changes.Add($"Team: {oldTeamName} → {newTeamName}");
         }

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1349,7 +1349,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 {
                     var permToRemove = permissions.FirstOrDefault(p =>
                         IsDirectManagedPermission(p) &&
-                        string.Equals(p.EmailAddress, member.Email, StringComparison.OrdinalIgnoreCase));
+                        NormalizingEmailComparer.Instance.Equals(p.EmailAddress, member.Email));
 
                     if (permToRemove is null)
                     {
@@ -1565,7 +1565,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                         // Find the direct managed permission for this user
                         var permToRemove = permissions.FirstOrDefault(p =>
                             IsDirectManagedPermission(p) &&
-                            string.Equals(p.EmailAddress, member.Email, StringComparison.OrdinalIgnoreCase));
+                            NormalizingEmailComparer.Instance.Equals(p.EmailAddress, member.Email));
 
                         if (permToRemove is null)
                         {

--- a/src/Humans.Infrastructure/Services/LegalDocumentSyncService.cs
+++ b/src/Humans.Infrastructure/Services/LegalDocumentSyncService.cs
@@ -187,6 +187,23 @@ public class LegalDocumentSyncService : ILegalDocumentSyncService
             .FirstOrDefaultAsync(v => v.Id == versionId, cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DocumentVersion>> GetRequiredDocumentVersionsForTeamAsync(
+        Guid teamId, CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+
+        return await _dbContext.LegalDocuments
+            .AsNoTracking()
+            .Where(d => d.IsRequired && d.IsActive && d.TeamId == teamId)
+            .SelectMany(d => d.Versions)
+            .Where(v => v.EffectiveFrom <= now)
+            .Include(v => v.LegalDocument)
+            .GroupBy(v => v.LegalDocumentId)
+            .Select(g => g.OrderByDescending(v => v.EffectiveFrom).First())
+            .ToListAsync(cancellationToken);
+    }
+
     /// <summary>
     /// Syncs a single document from GitHub using folder-based discovery.
     /// </summary>

--- a/src/Humans.Infrastructure/Services/MembershipCalculator.cs
+++ b/src/Humans.Infrastructure/Services/MembershipCalculator.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
@@ -14,15 +15,23 @@ namespace Humans.Infrastructure.Services;
 public class MembershipCalculator : IMembershipCalculator
 {
     private readonly HumansDbContext _dbContext;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService;
     private readonly IClock _clock;
 
     public MembershipCalculator(
         HumansDbContext dbContext,
+        IServiceProvider serviceProvider,
+        ILegalDocumentSyncService legalDocumentSyncService,
         IClock clock)
     {
         _dbContext = dbContext;
+        _serviceProvider = serviceProvider;
+        _legalDocumentSyncService = legalDocumentSyncService;
         _clock = clock;
     }
+
+    private IConsentService ConsentService => _serviceProvider.GetRequiredService<IConsentService>();
 
     public async Task<MembershipStatus> ComputeStatusAsync(
         Guid userId,
@@ -84,14 +93,14 @@ public class MembershipCalculator : IMembershipCalculator
 
         foreach (var teamId in eligibleTeamIds)
         {
-            var versions = await GetRequiredDocumentVersionsForTeamAsync(teamId, cancellationToken);
+            var versions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, cancellationToken);
             allRequiredVersionIds.AddRange(versions.Select(v => v.Id));
         }
 
         // Deduplicate in case a doc is shared across teams
         var requiredVersionIds = allRequiredVersionIds.Distinct().ToList();
 
-        var consentedVersionIds = await GetConsentedVersionIdsAsync(userId, cancellationToken);
+        var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, cancellationToken);
         var missingVersionIds = requiredVersionIds
             .Where(id => !consentedVersionIds.Contains(id))
             .ToList();
@@ -124,13 +133,13 @@ public class MembershipCalculator : IMembershipCalculator
         Guid teamId,
         CancellationToken ct = default)
     {
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
         if (requiredVersions.Count == 0)
         {
             return true;
         }
 
-        var consentedVersionIds = await GetConsentedVersionIdsAsync(userId, ct);
+        var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, ct);
         return requiredVersions.All(v => consentedVersionIds.Contains(v.Id));
     }
 
@@ -147,8 +156,8 @@ public class MembershipCalculator : IMembershipCalculator
         CancellationToken ct = default)
     {
         var now = _clock.GetCurrentInstant();
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
-        var consentedVersionIds = await GetConsentedVersionIdsAsync(userId, ct);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
+        var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, ct);
 
         return requiredVersions
             .Where(v => !consentedVersionIds.Contains(v.Id))
@@ -164,11 +173,11 @@ public class MembershipCalculator : IMembershipCalculator
         CancellationToken cancellationToken = default)
     {
         // Get current versions of all required documents (Volunteers team = global)
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
         var requiredVersionIds = requiredVersions.Select(v => v.Id).ToList();
 
         // Get versions the user has consented to
-        var consentedVersionIds = await GetConsentedVersionIdsAsync(userId, cancellationToken);
+        var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, cancellationToken);
 
         // Find missing consents
         return requiredVersionIds
@@ -227,7 +236,7 @@ public class MembershipCalculator : IMembershipCalculator
             return new HashSet<Guid>();
         }
 
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
         var requiredVersionIds = requiredVersions.Select(v => v.Id).ToList();
 
         if (requiredVersionIds.Count == 0)
@@ -235,7 +244,7 @@ public class MembershipCalculator : IMembershipCalculator
             return userIdList.ToHashSet();
         }
 
-        var consentsByUser = await GetConsentMapForUsersAsync(userIdList, ct);
+        var consentsByUser = await ConsentService.GetConsentMapForUsersAsync(userIdList, ct);
 
         var requiredSet = requiredVersionIds.ToHashSet();
         var result = new HashSet<Guid>();
@@ -264,7 +273,7 @@ public class MembershipCalculator : IMembershipCalculator
 
         var now = _clock.GetCurrentInstant();
 
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
         var expiredVersions = requiredVersions
             .Where(v =>
             {
@@ -281,7 +290,7 @@ public class MembershipCalculator : IMembershipCalculator
         var expiredVersionIds = expiredVersions.Select(v => v.Id).ToHashSet();
 
         // Get consented version IDs for all users in batch
-        var consentsByUser = await GetConsentMapForUsersAsync(userIdList, cancellationToken);
+        var consentsByUser = await ConsentService.GetConsentMapForUsersAsync(userIdList, cancellationToken);
 
         var result = new HashSet<Guid>();
         foreach (var userId in userIdList)
@@ -419,60 +428,4 @@ public class MembershipCalculator : IMembershipCalculator
             pendingDeletion);
     }
 
-    private async Task<List<Domain.Entities.DocumentVersion>> GetRequiredDocumentVersionsForTeamAsync(
-        Guid teamId,
-        CancellationToken cancellationToken)
-    {
-        var now = _clock.GetCurrentInstant();
-
-        return await _dbContext.LegalDocuments
-            .AsNoTracking()
-            .Where(d => d.IsRequired && d.IsActive && d.TeamId == teamId)
-            .SelectMany(d => d.Versions)
-            .Where(v => v.EffectiveFrom <= now)
-            .Include(v => v.LegalDocument)
-            .GroupBy(v => v.LegalDocumentId)
-            .Select(g => g.OrderByDescending(v => v.EffectiveFrom).First())
-            .ToListAsync(cancellationToken);
-    }
-
-    private async Task<IReadOnlySet<Guid>> GetConsentedVersionIdsAsync(
-        Guid userId,
-        CancellationToken cancellationToken)
-    {
-        var ids = await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Where(cr => cr.UserId == userId && cr.ExplicitConsent)
-            .Select(cr => cr.DocumentVersionId)
-            .ToListAsync(cancellationToken);
-
-        return ids.ToHashSet();
-    }
-
-    private async Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetConsentMapForUsersAsync(
-        List<Guid> userIds,
-        CancellationToken cancellationToken)
-    {
-        if (userIds.Count == 0)
-        {
-            return new Dictionary<Guid, IReadOnlySet<Guid>>();
-        }
-
-        var consents = await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Where(cr => userIds.Contains(cr.UserId) && cr.ExplicitConsent)
-            .Select(cr => new { cr.UserId, cr.DocumentVersionId })
-            .ToListAsync(cancellationToken);
-
-        var result = userIds.ToDictionary(
-            id => id,
-            _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
-
-        foreach (var consent in consents)
-        {
-            ((HashSet<Guid>)result[consent.UserId]).Add(consent.DocumentVersionId);
-        }
-
-        return result;
-    }
 }

--- a/src/Humans.Infrastructure/Services/NotificationInboxService.cs
+++ b/src/Humans.Infrastructure/Services/NotificationInboxService.cs
@@ -369,6 +369,25 @@ public class NotificationInboxService : INotificationInboxService
         InvalidateBadgeCaches([userId]);
     }
 
+    /// <inheritdoc />
+    public async Task<(int Actionable, int Informational)> GetUnreadBadgeCountsAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        var actionableCount = await _dbContext.NotificationRecipients
+            .CountAsync(nr => nr.UserId == userId &&
+                              nr.ReadAt == null &&
+                              nr.Notification.ResolvedAt == null &&
+                              nr.Notification.Class == NotificationClass.Actionable, ct);
+
+        var informationalCount = await _dbContext.NotificationRecipients
+            .CountAsync(nr => nr.UserId == userId &&
+                              nr.ReadAt == null &&
+                              nr.Notification.ResolvedAt == null &&
+                              nr.Notification.Class == NotificationClass.Informational, ct);
+
+        return (actionableCount, informationalCount);
+    }
+
     private static NotificationRowDto MapToRow(NotificationRecipient nr)
     {
         var n = nr.Notification;

--- a/src/Humans.Infrastructure/Services/NotificationService.cs
+++ b/src/Humans.Infrastructure/Services/NotificationService.cs
@@ -17,17 +17,20 @@ namespace Humans.Infrastructure.Services;
 public class NotificationService : INotificationService
 {
     private readonly HumansDbContext _dbContext;
+    private readonly ICommunicationPreferenceService _preferenceService;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
     private readonly ILogger<NotificationService> _logger;
 
     public NotificationService(
         HumansDbContext dbContext,
+        ICommunicationPreferenceService preferenceService,
         IClock clock,
         IMemoryCache cache,
         ILogger<NotificationService> logger)
     {
         _dbContext = dbContext;
+        _preferenceService = preferenceService;
         _clock = clock;
         _cache = cache;
         _logger = logger;
@@ -55,12 +58,9 @@ public class NotificationService : INotificationService
         var now = _clock.GetCurrentInstant();
         var category = source.ToMessageCategory();
 
-        // Load preferences for all recipients at once
-        var preferences = await _dbContext.CommunicationPreferences
-            .Where(cp => recipientUserIds.Contains(cp.UserId) && cp.Category == category)
-            .ToListAsync(cancellationToken);
-
-        var prefByUser = preferences.ToDictionary(p => p.UserId);
+        // Load inbox-disabled users for the category via the preference service
+        var inboxDisabled = await _preferenceService.GetUsersWithInboxDisabledAsync(
+            recipientUserIds, category, cancellationToken);
 
         // For individual target, create one notification per user
         foreach (var userId in recipientUserIds)
@@ -68,7 +68,7 @@ public class NotificationService : INotificationService
             // Check InboxEnabled preference — informational can be suppressed
             if (notificationClass == NotificationClass.Informational)
             {
-                if (prefByUser.TryGetValue(userId, out var pref) && !pref.InboxEnabled)
+                if (inboxDisabled.Contains(userId))
                 {
                     _logger.LogDebug(
                         "Skipping informational notification for user {UserId} — InboxEnabled=false for {Category}",
@@ -145,12 +145,9 @@ public class NotificationService : INotificationService
         var now = _clock.GetCurrentInstant();
         var category = source.ToMessageCategory();
 
-        // Load preferences for all team members
-        var preferences = await _dbContext.CommunicationPreferences
-            .Where(cp => memberUserIds.Contains(cp.UserId) && cp.Category == category)
-            .ToListAsync(cancellationToken);
-
-        var prefByUser = preferences.ToDictionary(p => p.UserId);
+        // Load inbox-disabled users for the category via the preference service
+        var inboxDisabled = await _preferenceService.GetUsersWithInboxDisabledAsync(
+            memberUserIds, category, cancellationToken);
 
         // Group target: one shared notification
         var notification = new Notification
@@ -171,7 +168,7 @@ public class NotificationService : INotificationService
         {
             // Check InboxEnabled preference — informational can be suppressed
             if (notificationClass == NotificationClass.Informational &&
-                prefByUser.TryGetValue(userId, out var pref) && !pref.InboxEnabled)
+                inboxDisabled.Contains(userId))
             {
                 continue;
             }
@@ -229,12 +226,9 @@ public class NotificationService : INotificationService
 
         var category = source.ToMessageCategory();
 
-        // Load preferences
-        var preferences = await _dbContext.CommunicationPreferences
-            .Where(cp => roleUserIds.Contains(cp.UserId) && cp.Category == category)
-            .ToListAsync(cancellationToken);
-
-        var prefByUser = preferences.ToDictionary(p => p.UserId);
+        // Load inbox-disabled users for the category via the preference service
+        var inboxDisabled = await _preferenceService.GetUsersWithInboxDisabledAsync(
+            roleUserIds, category, cancellationToken);
 
         // Group target: one shared notification
         var notification = new Notification
@@ -254,7 +248,7 @@ public class NotificationService : INotificationService
         foreach (var userId in roleUserIds)
         {
             if (notificationClass == NotificationClass.Informational &&
-                prefByUser.TryGetValue(userId, out var pref) && !pref.InboxEnabled)
+                inboxDisabled.Contains(userId))
             {
                 continue;
             }

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -581,6 +581,21 @@ public class OnboardingService : IOnboardingService
         await _syncJob.SyncAsociadosMembershipForUserAsync(userId, CancellationToken.None);
     }
 
+    /// <inheritdoc />
+    public async Task<int> GetPendingReviewCountAsync(CancellationToken ct = default)
+    {
+        return await _dbContext.Profiles
+            .CountAsync(p => !p.IsApproved && p.RejectedAt == null, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetUnvotedApplicationCountAsync(Guid boardMemberUserId, CancellationToken ct = default)
+    {
+        return await _dbContext.Applications
+            .CountAsync(a => a.Status == ApplicationStatus.Submitted
+                && !a.BoardVotes.Any(v => v.BoardMemberUserId == boardMemberUserId), ct);
+    }
+
     public async Task<Application.DTOs.AdminDashboardData> GetAdminDashboardAsync(CancellationToken ct = default)
     {
         var allUserIds = await _dbContext.Users.Select(u => u.Id).ToListAsync(ct);

--- a/src/Humans.Infrastructure/Services/OutboxEmailService.cs
+++ b/src/Humans.Infrastructure/Services/OutboxEmailService.cs
@@ -203,7 +203,8 @@ public class OutboxEmailService : IEmailService
         CancellationToken cancellationToken = default)
     {
         var content = _renderer.RenderSignupRejected(userName, reason, culture);
-        await EnqueueAsync(userEmail, userName, content, "signup_rejected", cancellationToken);
+        await EnqueueAsync(userEmail, userName, content, "signup_rejected", cancellationToken,
+            category: MessageCategory.System);
     }
 
     /// <inheritdoc />
@@ -216,7 +217,8 @@ public class OutboxEmailService : IEmailService
         CancellationToken cancellationToken = default)
     {
         var content = _renderer.RenderTermRenewalReminder(userName, tierName, expiresAt, culture);
-        await EnqueueAsync(userEmail, userName, content, "term_renewal_reminder", cancellationToken);
+        await EnqueueAsync(userEmail, userName, content, "term_renewal_reminder", cancellationToken,
+            category: MessageCategory.Governance);
     }
 
     /// <inheritdoc />
@@ -230,7 +232,8 @@ public class OutboxEmailService : IEmailService
         CancellationToken cancellationToken = default)
     {
         var content = _renderer.RenderBoardDailyDigest(name, date, groups, outstandingCounts, culture);
-        await EnqueueAsync(email, name, content, "board_daily_digest", cancellationToken);
+        await EnqueueAsync(email, name, content, "board_daily_digest", cancellationToken,
+            category: MessageCategory.Governance);
     }
 
     /// <inheritdoc />
@@ -253,7 +256,8 @@ public class OutboxEmailService : IEmailService
         CancellationToken cancellationToken = default)
     {
         var content = _renderer.RenderFeedbackResponse(userName, originalDescription, responseMessage, reportLink, culture);
-        await EnqueueAsync(userEmail, userName, content, "feedback_response", cancellationToken);
+        await EnqueueAsync(userEmail, userName, content, "feedback_response", cancellationToken,
+            category: MessageCategory.System);
     }
 
     /// <inheritdoc />

--- a/src/Humans.Infrastructure/Services/OutboxEmailService.cs
+++ b/src/Humans.Infrastructure/Services/OutboxEmailService.cs
@@ -348,10 +348,7 @@ public class OutboxEmailService : IEmailService
         {
             var headers = _commPrefService.GenerateUnsubscribeHeaders(userId.Value, category.Value);
             extraHeadersJson = System.Text.Json.JsonSerializer.Serialize(headers);
-
-            // Extract URL for footer link (strip angle brackets from List-Unsubscribe header)
-            if (headers.TryGetValue("List-Unsubscribe", out var listUnsub))
-                unsubscribeUrl = listUnsub.Trim('<', '>');
+            unsubscribeUrl = _commPrefService.GenerateBrowserUnsubscribeUrl(userId.Value, category.Value);
         }
 
         var (wrappedHtml, plainText) = EmailBodyComposer.Compose(

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -21,6 +21,7 @@ public class ProfileService : IProfileService
     private readonly IEmailService _emailService;
     private readonly IAuditLogService _auditLogService;
     private readonly IMembershipCalculator _membershipCalculator;
+    private readonly IConsentService _consentService;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
     private readonly ILogger<ProfileService> _logger;
@@ -31,6 +32,7 @@ public class ProfileService : IProfileService
         IEmailService emailService,
         IAuditLogService auditLogService,
         IMembershipCalculator membershipCalculator,
+        IConsentService consentService,
         IClock clock,
         IMemoryCache cache,
         ILogger<ProfileService> logger)
@@ -40,6 +42,7 @@ public class ProfileService : IProfileService
         _emailService = emailService;
         _auditLogService = auditLogService;
         _membershipCalculator = membershipCalculator;
+        _consentService = consentService;
         _clock = clock;
         _cache = cache;
         _logger = logger;
@@ -452,13 +455,7 @@ public class ProfileService : IProfileService
             .OrderByDescending(a => a.SubmittedAt)
             .ToListAsync(ct);
 
-        var consents = await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Include(c => c.DocumentVersion)
-                .ThenInclude(v => v.LegalDocument)
-            .Where(c => c.UserId == userId)
-            .OrderByDescending(c => c.ConsentedAt)
-            .ToListAsync(ct);
+        var consents = await _consentService.GetUserConsentRecordsAsync(userId, ct);
 
         var teamMemberships = await _dbContext.TeamMembers
             .AsNoTracking()
@@ -698,12 +695,13 @@ public class ProfileService : IProfileService
         var user = await _dbContext.Users
             .Include(u => u.Profile)
             .Include(u => u.Applications)
-            .Include(u => u.ConsentRecords)
             .Include(u => u.UserEmails)
             .FirstOrDefaultAsync(u => u.Id == userId, ct);
 
         if (user is null)
             return null;
+
+        var consentCount = await _consentService.GetConsentRecordCountAsync(userId, ct);
 
         var roleAssignments = await _dbContext.RoleAssignments
             .AsNoTracking()
@@ -725,7 +723,7 @@ public class ProfileService : IProfileService
             user,
             user.Profile,
             user.Applications.OrderByDescending(a => a.SubmittedAt).ToList(),
-            user.ConsentRecords.Count,
+            consentCount,
             roleAssignments,
             rejectedByName);
     }

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -451,6 +451,7 @@ public class ProfileService : IProfileService
 
         var applications = await _dbContext.Applications
             .AsNoTracking()
+            .Include(a => a.StateHistory)
             .Where(a => a.UserId == userId)
             .OrderByDescending(a => a.SubmittedAt)
             .ToListAsync(ct);
@@ -460,6 +461,8 @@ public class ProfileService : IProfileService
         var teamMemberships = await _dbContext.TeamMembers
             .AsNoTracking()
             .Include(tm => tm.Team)
+            .Include(tm => tm.RoleAssignments)
+                .ThenInclude(tra => tra.TeamRoleDefinition)
             .Where(tm => tm.UserId == userId)
             .OrderByDescending(tm => tm.JoinedAt)
             .ToListAsync(ct);
@@ -483,6 +486,120 @@ public class ProfileService : IProfileService
             .OrderBy(e => e.DisplayOrder)
             .ToListAsync(ct);
 
+        var volunteerHistory = profile is not null
+            ? await _dbContext.VolunteerHistoryEntries
+                .AsNoTracking()
+                .Where(vh => vh.ProfileId == profile.Id)
+                .OrderByDescending(vh => vh.Date)
+                .ToListAsync(ct)
+            : [];
+
+        var profileLanguages = profile is not null
+            ? await _dbContext.ProfileLanguages
+                .AsNoTracking()
+                .Where(pl => pl.ProfileId == profile.Id)
+                .ToListAsync(ct)
+            : [];
+
+        var communicationPreferences = await _dbContext.CommunicationPreferences
+            .AsNoTracking()
+            .Where(cp => cp.UserId == userId)
+            .ToListAsync(ct);
+
+        var shiftSignups = await _dbContext.ShiftSignups
+            .AsNoTracking()
+            .Include(ss => ss.Shift)
+                .ThenInclude(s => s.Rota)
+                    .ThenInclude(r => r.Team)
+            .Include(ss => ss.Shift)
+                .ThenInclude(s => s.Rota)
+                    .ThenInclude(r => r.EventSettings)
+            .Where(ss => ss.UserId == userId)
+            .OrderByDescending(ss => ss.CreatedAt)
+            .ToListAsync(ct);
+
+        var volunteerEventProfiles = await _dbContext.VolunteerEventProfiles
+            .AsNoTracking()
+            .Where(vep => vep.UserId == userId)
+            .ToListAsync(ct);
+
+        var generalAvailability = await _dbContext.GeneralAvailability
+            .AsNoTracking()
+            .Include(ga => ga.EventSettings)
+            .Where(ga => ga.UserId == userId)
+            .ToListAsync(ct);
+
+        var tagPreferences = await _dbContext.VolunteerTagPreferences
+            .AsNoTracking()
+            .Include(vtp => vtp.ShiftTag)
+            .Where(vtp => vtp.UserId == userId)
+            .ToListAsync(ct);
+
+        var feedbackReports = await _dbContext.FeedbackReports
+            .AsNoTracking()
+            .Include(fr => fr.Messages)
+            .Where(fr => fr.UserId == userId)
+            .OrderByDescending(fr => fr.CreatedAt)
+            .ToListAsync(ct);
+
+        var notifications = await _dbContext.NotificationRecipients
+            .AsNoTracking()
+            .Include(nr => nr.Notification)
+            .Where(nr => nr.UserId == userId)
+            .OrderByDescending(nr => nr.Notification.CreatedAt)
+            .ToListAsync(ct);
+
+        var ticketOrders = await _dbContext.TicketOrders
+            .AsNoTracking()
+            .Where(to => to.MatchedUserId == userId)
+            .OrderByDescending(to => to.PurchasedAt)
+            .ToListAsync(ct);
+
+        var ticketAttendees = await _dbContext.TicketAttendees
+            .AsNoTracking()
+            .Where(ta => ta.MatchedUserId == userId)
+            .ToListAsync(ct);
+
+        var campaignGrants = await _dbContext.CampaignGrants
+            .AsNoTracking()
+            .Include(cg => cg.Campaign)
+            .Include(cg => cg.Code)
+            .Where(cg => cg.UserId == userId)
+            .OrderByDescending(cg => cg.AssignedAt)
+            .ToListAsync(ct);
+
+        var campLeadAssignments = await _dbContext.CampLeads
+            .AsNoTracking()
+            .Include(cl => cl.Camp)
+            .Where(cl => cl.UserId == userId)
+            .OrderByDescending(cl => cl.JoinedAt)
+            .ToListAsync(ct);
+
+        var teamJoinRequests = await _dbContext.TeamJoinRequests
+            .AsNoTracking()
+            .Include(tjr => tjr.Team)
+            .Where(tjr => tjr.UserId == userId)
+            .OrderByDescending(tjr => tjr.RequestedAt)
+            .ToListAsync(ct);
+
+        var auditLogEntries = await _dbContext.AuditLogEntries
+            .AsNoTracking()
+            .Where(a => a.EntityId == userId || a.RelatedEntityId == userId || a.ActorUserId == userId)
+            .OrderByDescending(a => a.OccurredAt)
+            .ToListAsync(ct);
+
+        var budgetAuditLogs = await _dbContext.BudgetAuditLogs
+            .AsNoTracking()
+            .Where(bal => bal.ActorUserId == userId)
+            .OrderByDescending(bal => bal.OccurredAt)
+            .ToListAsync(ct);
+
+        var accountMergeRequests = await _dbContext.AccountMergeRequests
+            .AsNoTracking()
+            .Where(amr => amr.TargetUserId == userId || amr.SourceUserId == userId)
+            .OrderByDescending(amr => amr.CreatedAt)
+            .ToListAsync(ct);
+
         _logger.LogInformation("User {UserId} exported their data", userId);
 
         return new
@@ -493,6 +610,13 @@ public class ProfileService : IProfileService
                 user.Id,
                 user.Email,
                 user.DisplayName,
+                user.PreferredLanguage,
+                user.GoogleEmail,
+                user.UnsubscribedFromCampaigns,
+                user.SuppressScheduleChangeEmails,
+                ContactSource = user.ContactSource?.ToString(),
+                DeletionRequestedAt = user.DeletionRequestedAt.ToInvariantInstantString(),
+                DeletionScheduledFor = user.DeletionScheduledFor.ToInvariantInstantString(),
                 CreatedAt = user.CreatedAt.ToInvariantInstantString(),
                 LastLoginAt = user.LastLoginAt.ToInvariantInstantString()
             } : null,
@@ -512,11 +636,21 @@ public class ProfileService : IProfileService
                 Birthday = profile.DateOfBirth is not null ? $"{profile.DateOfBirth.Value.Month:D2}-{profile.DateOfBirth.Value.Day:D2}" : null,
                 profile.City,
                 profile.CountryCode,
+                profile.Latitude,
+                profile.Longitude,
                 profile.Bio,
                 profile.Pronouns,
                 profile.ContributionInterests,
                 profile.BoardNotes,
+                profile.MembershipTier,
+                profile.IsApproved,
                 profile.IsSuspended,
+                profile.NoPriorBurnExperience,
+                ConsentCheckStatus = profile.ConsentCheckStatus?.ToString(),
+                ConsentCheckAt = profile.ConsentCheckAt.ToInvariantInstantString(),
+                profile.ConsentCheckNotes,
+                profile.RejectionReason,
+                RejectedAt = profile.RejectedAt.ToInvariantInstantString(),
                 profile.EmergencyContactName,
                 profile.EmergencyContactPhone,
                 profile.EmergencyContactRelationship,
@@ -531,17 +665,37 @@ public class ProfileService : IProfileService
                 cf.Value,
                 cf.Visibility
             }),
+            VolunteerHistory = volunteerHistory.Select(vh => new
+            {
+                Date = vh.Date.ToIsoDateString(),
+                vh.EventName,
+                vh.Description,
+                CreatedAt = vh.CreatedAt.ToInvariantInstantString()
+            }),
+            Languages = profileLanguages.Select(pl => new
+            {
+                pl.LanguageCode,
+                pl.Proficiency
+            }),
             Applications = applications.Select(a => new
             {
-                a.Id,
                 a.Status,
                 a.MembershipTier,
                 a.Motivation,
                 a.AdditionalInfo,
                 a.SignificantContribution,
                 a.RoleUnderstanding,
+                a.Language,
                 SubmittedAt = a.SubmittedAt.ToInvariantInstantString(),
-                ResolvedAt = a.ResolvedAt.ToInvariantInstantString()
+                ResolvedAt = a.ResolvedAt.ToInvariantInstantString(),
+                TermExpiresAt = a.TermExpiresAt.ToIsoDateString(),
+                BoardMeetingDate = a.BoardMeetingDate.ToIsoDateString(),
+                StateHistory = a.StateHistory.OrderBy(sh => sh.ChangedAt).Select(sh => new
+                {
+                    sh.Status,
+                    ChangedAt = sh.ChangedAt.ToInvariantInstantString(),
+                    sh.Notes
+                })
             }),
             Consents = consents.Select(c => new
             {
@@ -557,14 +711,152 @@ public class ProfileService : IProfileService
                 TeamName = tm.Team.Name,
                 tm.Role,
                 JoinedAt = tm.JoinedAt.ToInvariantInstantString(),
-                LeftAt = tm.LeftAt.ToInvariantInstantString()
+                LeftAt = tm.LeftAt.ToInvariantInstantString(),
+                TeamRoles = tm.RoleAssignments.Select(tra => new
+                {
+                    RoleName = tra.TeamRoleDefinition.Name,
+                    AssignedAt = tra.AssignedAt.ToInvariantInstantString()
+                })
+            }),
+            TeamJoinRequests = teamJoinRequests.Select(tjr => new
+            {
+                TeamName = tjr.Team.Name,
+                tjr.Status,
+                tjr.Message,
+                RequestedAt = tjr.RequestedAt.ToInvariantInstantString(),
+                ResolvedAt = tjr.ResolvedAt.ToInvariantInstantString()
             }),
             RoleAssignments = roleAssignments.Select(ra => new
             {
                 ra.RoleName,
                 ValidFrom = ra.ValidFrom.ToInvariantInstantString(),
-                ValidTo = ra.ValidTo.ToInvariantInstantString(),
-                ra.CreatedByUserId
+                ValidTo = ra.ValidTo.ToInvariantInstantString()
+            }),
+            CommunicationPreferences = communicationPreferences.Select(cp => new
+            {
+                cp.Category,
+                cp.OptedOut,
+                cp.InboxEnabled,
+                UpdatedAt = cp.UpdatedAt.ToInvariantInstantString(),
+                cp.UpdateSource
+            }),
+            ShiftSignups = shiftSignups.Select(ss => new
+            {
+                EventName = ss.Shift.Rota.EventSettings.EventName,
+                Department = ss.Shift.Rota.Team.Name,
+                RotaName = ss.Shift.Rota.Name,
+                ss.Shift.DayOffset,
+                ss.Shift.IsAllDay,
+                ss.Status,
+                ss.Enrolled,
+                ss.StatusReason,
+                CreatedAt = ss.CreatedAt.ToInvariantInstantString(),
+                ReviewedAt = ss.ReviewedAt.ToInvariantInstantString()
+            }),
+            VolunteerEventProfiles = volunteerEventProfiles.Select(vep => new
+            {
+                vep.Skills,
+                vep.Quirks,
+                vep.Languages,
+                vep.DietaryPreference,
+                vep.Allergies,
+                vep.Intolerances,
+                vep.AllergyOtherText,
+                vep.IntoleranceOtherText,
+                vep.MedicalConditions,
+                CreatedAt = vep.CreatedAt.ToInvariantInstantString(),
+                UpdatedAt = vep.UpdatedAt.ToInvariantInstantString()
+            }),
+            GeneralAvailability = generalAvailability.Select(ga => new
+            {
+                EventName = ga.EventSettings.EventName,
+                ga.AvailableDayOffsets,
+                UpdatedAt = ga.UpdatedAt.ToInvariantInstantString()
+            }),
+            ShiftTagPreferences = tagPreferences.Select(vtp => new
+            {
+                TagName = vtp.ShiftTag.Name
+            }),
+            FeedbackReports = feedbackReports.Select(fr => new
+            {
+                fr.Category,
+                fr.Description,
+                fr.PageUrl,
+                fr.Status,
+                CreatedAt = fr.CreatedAt.ToInvariantInstantString(),
+                ResolvedAt = fr.ResolvedAt.ToInvariantInstantString(),
+                Messages = fr.Messages.OrderBy(m => m.CreatedAt).Select(m => new
+                {
+                    m.Content,
+                    IsFromUser = m.SenderUserId == userId,
+                    CreatedAt = m.CreatedAt.ToInvariantInstantString()
+                })
+            }),
+            Notifications = notifications.Select(nr => new
+            {
+                nr.Notification.Title,
+                nr.Notification.Body,
+                nr.Notification.ActionUrl,
+                nr.Notification.Priority,
+                nr.Notification.Source,
+                CreatedAt = nr.Notification.CreatedAt.ToInvariantInstantString(),
+                ReadAt = nr.ReadAt.ToInvariantInstantString(),
+                ResolvedAt = nr.Notification.ResolvedAt.ToInvariantInstantString()
+            }),
+            TicketOrders = ticketOrders.Select(to => new
+            {
+                to.BuyerName,
+                to.BuyerEmail,
+                to.TotalAmount,
+                to.Currency,
+                to.PaymentStatus,
+                to.DiscountCode,
+                PurchasedAt = to.PurchasedAt.ToInvariantInstantString()
+            }),
+            TicketAttendeeMatches = ticketAttendees
+                .Select(ta => new
+                {
+                    ta.AttendeeName,
+                    ta.AttendeeEmail,
+                    ta.TicketTypeName,
+                    ta.Price,
+                    ta.Status
+                }),
+            CampaignGrants = campaignGrants.Select(cg => new
+            {
+                CampaignTitle = cg.Campaign.Title,
+                Code = cg.Code.Code,
+                AssignedAt = cg.AssignedAt.ToInvariantInstantString(),
+                RedeemedAt = cg.RedeemedAt.ToInvariantInstantString(),
+                EmailStatus = cg.LatestEmailStatus?.ToString()
+            }),
+            CampLeadAssignments = campLeadAssignments.Select(cl => new
+            {
+                CampSlug = cl.Camp.Slug,
+                cl.Role,
+                JoinedAt = cl.JoinedAt.ToInvariantInstantString(),
+                LeftAt = cl.LeftAt.ToInvariantInstantString()
+            }),
+            AccountMergeRequests = accountMergeRequests.Select(amr => new
+            {
+                amr.Status,
+                Role = amr.TargetUserId == userId ? "Target" : "Source",
+                CreatedAt = amr.CreatedAt.ToInvariantInstantString(),
+                ResolvedAt = amr.ResolvedAt.ToInvariantInstantString()
+            }),
+            AuditLog = auditLogEntries.Select(a => new
+            {
+                a.Action,
+                a.EntityType,
+                OccurredAt = a.OccurredAt.ToInvariantInstantString(),
+                Role = a.ActorUserId == userId ? "Actor" : "Subject"
+            }),
+            BudgetAuditLog = budgetAuditLogs.Select(bal => new
+            {
+                bal.EntityType,
+                bal.FieldName,
+                bal.Description,
+                OccurredAt = bal.OccurredAt.ToInvariantInstantString()
             })
         };
     }

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -362,6 +362,27 @@ public class TeamService : ITeamService
             .ToListAsync(cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<UserTeamGoogleResource>> GetUserTeamGoogleResourcesAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var teamResources = await _dbContext.TeamMembers
+            .AsNoTracking()
+            .Where(tm => tm.UserId == userId && tm.LeftAt == null)
+            .SelectMany(tm => tm.Team.GoogleResources
+                .Where(r => r.IsActive)
+                .Select(r => new UserTeamGoogleResource(
+                    tm.Team.Name,
+                    tm.Team.Slug,
+                    r.Name,
+                    r.ResourceType,
+                    r.Url)))
+            .OrderBy(r => r.TeamName)
+            .ThenBy(r => r.ResourceName)
+            .ToListAsync(cancellationToken);
+
+        return teamResources;
+    }
+
     public async Task<IReadOnlyList<MyTeamMembershipSummary>> GetMyTeamMembershipsAsync(
         Guid userId,
         CancellationToken cancellationToken = default)

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -872,6 +872,28 @@ public class TicketQueryService : ITicketQueryService
         return filteredHumans.ToList();
     }
 
+    /// <inheritdoc />
+    public async Task<bool> HasTicketAttendeeMatchAsync(Guid userId)
+    {
+        return await _dbContext.TicketAttendees
+            .AnyAsync(a => a.MatchedUserId == userId);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<UserTicketOrderSummary>> GetUserTicketOrderSummariesAsync(Guid userId)
+    {
+        return await _dbContext.TicketOrders
+            .Where(o => o.MatchedUserId == userId)
+            .OrderByDescending(o => o.PurchasedAt)
+            .Select(o => new UserTicketOrderSummary(
+                o.BuyerName,
+                o.PurchasedAt,
+                o.Attendees.Count,
+                o.TotalAmount,
+                o.Currency))
+            .ToListAsync();
+    }
+
     private static bool HasSearchTerm([NotNullWhen(true)] string? value, int minLength = 2) =>
         !string.IsNullOrWhiteSpace(value) && value.Trim().Length >= minLength;
 

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -22,12 +22,14 @@ public class TicketQueryService : ITicketQueryService
     private readonly HumansDbContext _dbContext;
     private readonly IMemoryCache _cache;
     private readonly IBudgetService _budgetService;
+    private readonly IClock _clock;
 
-    public TicketQueryService(HumansDbContext dbContext, IMemoryCache cache, IBudgetService budgetService)
+    public TicketQueryService(HumansDbContext dbContext, IMemoryCache cache, IBudgetService budgetService, IClock clock)
     {
         _dbContext = dbContext;
         _cache = cache;
         _budgetService = budgetService;
+        _clock = clock;
     }
 
     public async Task<int> GetUserTicketCountAsync(Guid userId)
@@ -125,12 +127,12 @@ public class TicketQueryService : ITicketQueryService
         var syncState = await _dbContext.TicketSyncStates.FindAsync(1);
         if (syncState is { SyncStatus: TicketSyncStatus.Running, StatusChangedAt: not null })
         {
-            var elapsed = SystemClock.Instance.GetCurrentInstant() - syncState.StatusChangedAt.Value;
+            var elapsed = _clock.GetCurrentInstant() - syncState.StatusChangedAt.Value;
             if (elapsed > Duration.FromMinutes(30))
             {
                 syncState.SyncStatus = TicketSyncStatus.Error;
                 syncState.LastError = "Sync state was stuck in Running for >30 minutes (likely crash). Auto-reset.";
-                syncState.StatusChangedAt = SystemClock.Instance.GetCurrentInstant();
+                syncState.StatusChangedAt = _clock.GetCurrentInstant();
                 await _dbContext.SaveChangesAsync();
             }
         }

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -580,6 +580,23 @@ public class TicketQueryService : ITicketQueryService
                 u.TeamMemberships.Any(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null))
             .ToList();
 
+        // Exclude humans who declared not attending this year
+        var activeEvent = await _dbContext.EventSettings
+            .FirstOrDefaultAsync(e => e.IsActive);
+        if (activeEvent is not null && activeEvent.Year > 0)
+        {
+            var notAttendingUserIds = await _dbContext.EventParticipations
+                .Where(ep => ep.Year == activeEvent.Year
+                    && ep.Status == ParticipationStatus.NotAttending)
+                .Select(ep => ep.UserId)
+                .ToListAsync();
+
+            var notAttendingSet = new HashSet<Guid>(notAttendingUserIds);
+            activeHumans = activeHumans
+                .Where(u => !notAttendingSet.Contains(u.Id))
+                .ToList();
+        }
+
         var filteredHumans = FilterWhoHasntBoughtHumans(
             activeHumans,
             matchedUserIds,

--- a/src/Humans.Infrastructure/Services/TicketSyncService.cs
+++ b/src/Humans.Infrastructure/Services/TicketSyncService.cs
@@ -23,6 +23,7 @@ public class TicketSyncService : ITicketSyncService
     private readonly IClock _clock;
     private readonly TicketVendorSettings _settings;
     private readonly IMemoryCache _cache;
+    private readonly IUserService _userService;
     private readonly ILogger<TicketSyncService> _logger;
 
     public TicketSyncService(
@@ -32,7 +33,8 @@ public class TicketSyncService : ITicketSyncService
         IClock clock,
         IOptions<TicketVendorSettings> settings,
         ILogger<TicketSyncService> logger,
-        IMemoryCache cache)
+        IMemoryCache cache,
+        IUserService userService)
     {
         _dbContext = dbContext;
         _vendorService = vendorService;
@@ -40,6 +42,7 @@ public class TicketSyncService : ITicketSyncService
         _clock = clock;
         _settings = settings.Value;
         _cache = cache;
+        _userService = userService;
         _logger = logger;
     }
 
@@ -111,6 +114,9 @@ public class TicketSyncService : ITicketSyncService
 
             // Match discount codes to campaign grants
             var codesRedeemed = await MatchDiscountCodesAsync(ct);
+
+            // Sync event participation records
+            await SyncEventParticipationsAsync(ct);
 
             // Update sync state
             syncState.SyncStatus = TicketSyncStatus.Idle;
@@ -450,6 +456,74 @@ public class TicketSyncService : ITicketSyncService
             syncState.LastSyncAt = null;
             await _dbContext.SaveChangesAsync();
         }
+    }
+
+    /// <summary>
+    /// Derive EventParticipation records from current ticket data.
+    /// For each matched user: 1+ valid tickets → Ticketed, any checked-in → Attended.
+    /// If user had Ticketed from TicketSync but now has 0 valid tickets → remove record.
+    /// </summary>
+    private async Task SyncEventParticipationsAsync(CancellationToken ct)
+    {
+        // Determine the event year from EventSettings
+        var activeEvent = await _dbContext.EventSettings
+            .FirstOrDefaultAsync(e => e.IsActive, ct);
+
+        if (activeEvent is null || activeEvent.Year == 0)
+            return;
+
+        var year = activeEvent.Year;
+
+        // Get attendees matched to users for the active vendor event only
+        var matchedAttendees = await _dbContext.TicketAttendees
+            .Where(a => a.MatchedUserId != null && a.VendorEventId == _settings.EventId)
+            .Select(a => new { a.MatchedUserId, a.Status })
+            .ToListAsync(ct);
+
+        // Group by user
+        var userTicketStatuses = matchedAttendees
+            .GroupBy(a => a.MatchedUserId!.Value)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(a => a.Status).ToList());
+
+        // Process users with tickets
+        foreach (var (userId, statuses) in userTicketStatuses)
+        {
+            var hasCheckedIn = statuses.Any(s => s == TicketAttendeeStatus.CheckedIn);
+            var hasValidTicket = statuses.Any(s =>
+                s == TicketAttendeeStatus.Valid || s == TicketAttendeeStatus.CheckedIn);
+
+            if (hasCheckedIn)
+            {
+                await _userService.SetParticipationFromTicketSyncAsync(
+                    userId, year, ParticipationStatus.Attended);
+            }
+            else if (hasValidTicket)
+            {
+                await _userService.SetParticipationFromTicketSyncAsync(
+                    userId, year, ParticipationStatus.Ticketed);
+            }
+        }
+
+        // Handle users who previously had tickets but no longer do
+        var existingTicketSyncParticipations = await _dbContext.EventParticipations
+            .Where(ep => ep.Year == year
+                && ep.Source == ParticipationSource.TicketSync
+                && ep.Status == ParticipationStatus.Ticketed)
+            .ToListAsync(ct);
+
+        foreach (var ep in existingTicketSyncParticipations)
+        {
+            if (!userTicketStatuses.ContainsKey(ep.UserId) ||
+                !userTicketStatuses[ep.UserId].Any(s =>
+                    s == TicketAttendeeStatus.Valid || s == TicketAttendeeStatus.CheckedIn))
+            {
+                await _userService.RemoveTicketSyncParticipationAsync(ep.UserId, year);
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(ct);
     }
 
     private static Guid? LookupUserId(Dictionary<string, Guid> lookup, string? email) =>

--- a/src/Humans.Infrastructure/Services/UnsubscribeService.cs
+++ b/src/Humans.Infrastructure/Services/UnsubscribeService.cs
@@ -30,17 +30,20 @@ public class UnsubscribeService : IUnsubscribeService
     {
         // Try new category-aware token first
         var result = _preferenceService.ValidateUnsubscribeToken(token);
-        if (result is not null)
+        if (result.Status == TokenValidationStatus.Valid)
         {
-            var (userId, category) = result.Value;
-            var user = await _db.Users.FindAsync(new object[] { userId }, ct);
+            var user = await _db.Users.FindAsync(new object[] { result.UserId }, ct);
             if (user is null)
                 return UnsubscribeTokenResult.Invalid();
 
-            return UnsubscribeTokenResult.Valid(userId, user.DisplayName, category);
+            return UnsubscribeTokenResult.Valid(result.UserId, user.DisplayName, result.Category);
         }
 
-        // Fall back to legacy campaign-only token
+        // Expired new-format token — don't fall through to legacy
+        if (result.Status == TokenValidationStatus.Expired)
+            return UnsubscribeTokenResult.Expired();
+
+        // Not a new-format token at all — fall back to legacy campaign-only token
         return await ValidateLegacyTokenAsync(token, ct);
     }
 

--- a/src/Humans.Infrastructure/Services/UnsubscribeService.cs
+++ b/src/Humans.Infrastructure/Services/UnsubscribeService.cs
@@ -1,0 +1,85 @@
+using System.Security.Cryptography;
+using Humans.Application.Interfaces;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Infrastructure.Services;
+
+public class UnsubscribeService : IUnsubscribeService
+{
+    private readonly HumansDbContext _db;
+    private readonly ICommunicationPreferenceService _preferenceService;
+    private readonly IDataProtectionProvider _dataProtection;
+    private readonly ILogger<UnsubscribeService> _logger;
+
+    public UnsubscribeService(
+        HumansDbContext db,
+        ICommunicationPreferenceService preferenceService,
+        IDataProtectionProvider dataProtection,
+        ILogger<UnsubscribeService> logger)
+    {
+        _db = db;
+        _preferenceService = preferenceService;
+        _dataProtection = dataProtection;
+        _logger = logger;
+    }
+
+    public async Task<UnsubscribeTokenResult> ValidateTokenAsync(string token, CancellationToken ct = default)
+    {
+        // Try new category-aware token first
+        var result = _preferenceService.ValidateUnsubscribeToken(token);
+        if (result is not null)
+        {
+            var (userId, category) = result.Value;
+            var user = await _db.Users.FindAsync(new object[] { userId }, ct);
+            if (user is null)
+                return UnsubscribeTokenResult.Invalid();
+
+            return UnsubscribeTokenResult.Valid(userId, user.DisplayName, category);
+        }
+
+        // Fall back to legacy campaign-only token
+        return await ValidateLegacyTokenAsync(token, ct);
+    }
+
+    public async Task<UnsubscribeTokenResult> ConfirmUnsubscribeAsync(string token, string source, CancellationToken ct = default)
+    {
+        var result = await ValidateTokenAsync(token, ct);
+        if (!result.IsValid || !result.UserId.HasValue || !result.Category.HasValue)
+            return result;
+
+        await _preferenceService.UpdatePreferenceAsync(
+            result.UserId.Value, result.Category.Value, optedOut: true, source: source);
+
+        return result;
+    }
+
+    private async Task<UnsubscribeTokenResult> ValidateLegacyTokenAsync(string token, CancellationToken ct)
+    {
+        var protector = _dataProtection
+            .CreateProtector("CampaignUnsubscribe")
+            .ToTimeLimitedDataProtector();
+
+        Guid userId;
+        try
+        {
+            var userIdString = protector.Unprotect(token);
+            userId = Guid.Parse(userIdString);
+        }
+        catch (CryptographicException ex)
+        {
+            _logger.LogWarning(ex, "Unsubscribe token was expired or invalid");
+            if (ex.Message.Contains("expired", StringComparison.OrdinalIgnoreCase))
+                return UnsubscribeTokenResult.Expired();
+            return UnsubscribeTokenResult.Invalid();
+        }
+
+        var user = await _db.Users.FindAsync(new object[] { userId }, ct);
+        if (user is null)
+            return UnsubscribeTokenResult.Invalid();
+
+        return UnsubscribeTokenResult.Valid(userId, user.DisplayName, MessageCategory.Marketing, isLegacy: true);
+    }
+}

--- a/src/Humans.Infrastructure/Services/UserService.cs
+++ b/src/Humans.Infrastructure/Services/UserService.cs
@@ -1,0 +1,209 @@
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+
+namespace Humans.Infrastructure.Services;
+
+public class UserService : IUserService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
+    private readonly ILogger<UserService> _logger;
+
+    public UserService(
+        HumansDbContext dbContext,
+        IClock clock,
+        ILogger<UserService> logger)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<EventParticipation?> GetParticipationAsync(Guid userId, int year)
+    {
+        return await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+    }
+
+    public async Task<List<EventParticipation>> GetAllParticipationsForYearAsync(int year)
+    {
+        return await _dbContext.EventParticipations
+            .Where(ep => ep.Year == year)
+            .ToListAsync();
+    }
+
+    public async Task<EventParticipation> DeclareNotAttendingAsync(Guid userId, int year)
+    {
+        var existing = await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+
+        var now = _clock.GetCurrentInstant();
+
+        if (existing is not null)
+        {
+            // Don't override Attended status — it's permanent
+            if (existing.Status == ParticipationStatus.Attended)
+            {
+                _logger.LogWarning(
+                    "Cannot declare NotAttending for user {UserId} year {Year} — already Attended",
+                    userId, year);
+                return existing;
+            }
+
+            existing.Status = ParticipationStatus.NotAttending;
+            existing.Source = ParticipationSource.UserDeclared;
+            existing.DeclaredAt = now;
+        }
+        else
+        {
+            existing = new EventParticipation
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Year = year,
+                Status = ParticipationStatus.NotAttending,
+                Source = ParticipationSource.UserDeclared,
+                DeclaredAt = now,
+            };
+            _dbContext.EventParticipations.Add(existing);
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "User {UserId} declared NotAttending for year {Year}",
+            userId, year);
+
+        return existing;
+    }
+
+    public async Task<bool> UndoNotAttendingAsync(Guid userId, int year)
+    {
+        var existing = await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+
+        if (existing is null)
+            return false;
+
+        if (existing.Status != ParticipationStatus.NotAttending ||
+            existing.Source != ParticipationSource.UserDeclared)
+        {
+            _logger.LogWarning(
+                "Cannot undo NotAttending for user {UserId} year {Year} — status is {Status} from {Source}",
+                userId, year, existing.Status, existing.Source);
+            return false;
+        }
+
+        _dbContext.EventParticipations.Remove(existing);
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "User {UserId} undid NotAttending declaration for year {Year}",
+            userId, year);
+
+        return true;
+    }
+
+    public async Task SetParticipationFromTicketSyncAsync(Guid userId, int year, ParticipationStatus status)
+    {
+        var existing = await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+
+        if (existing is not null)
+        {
+            // Attended is permanent — never revert
+            if (existing.Status == ParticipationStatus.Attended)
+                return;
+
+            // Ticket purchase overrides NotAttending
+            existing.Status = status;
+            existing.Source = ParticipationSource.TicketSync;
+            existing.DeclaredAt = null;
+        }
+        else
+        {
+            existing = new EventParticipation
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Year = year,
+                Status = status,
+                Source = ParticipationSource.TicketSync,
+            };
+            _dbContext.EventParticipations.Add(existing);
+        }
+
+        // Note: caller is responsible for SaveChangesAsync (batch context)
+    }
+
+    public async Task RemoveTicketSyncParticipationAsync(Guid userId, int year)
+    {
+        var existing = await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+
+        if (existing is null)
+            return;
+
+        // Only remove TicketSync-sourced records
+        if (existing.Source != ParticipationSource.TicketSync)
+            return;
+
+        // Never remove Attended — it's permanent
+        if (existing.Status == ParticipationStatus.Attended)
+            return;
+
+        _dbContext.EventParticipations.Remove(existing);
+
+        // Note: caller is responsible for SaveChangesAsync (batch context)
+    }
+
+    public async Task<int> BackfillParticipationsAsync(int year, List<(Guid UserId, ParticipationStatus Status)> entries)
+    {
+        var existing = await _dbContext.EventParticipations
+            .Where(ep => ep.Year == year)
+            .ToDictionaryAsync(ep => ep.UserId);
+
+        var count = 0;
+        foreach (var (userId, status) in entries)
+        {
+            if (existing.TryGetValue(userId, out var ep))
+            {
+                // Don't override Attended — permanent
+                if (ep.Status == ParticipationStatus.Attended)
+                    continue;
+
+                ep.Status = status;
+                ep.Source = ParticipationSource.AdminBackfill;
+                ep.DeclaredAt = null;
+            }
+            else
+            {
+                var newEp = new EventParticipation
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    Year = year,
+                    Status = status,
+                    Source = ParticipationSource.AdminBackfill,
+                };
+                _dbContext.EventParticipations.Add(newEp);
+                existing[userId] = newEp;
+            }
+
+            count++;
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "Backfilled {Count} participation records for year {Year}",
+            count, year);
+
+        return count;
+    }
+}

--- a/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
+++ b/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
@@ -90,6 +90,12 @@ public class RoleAssignmentClaimsTransformation : IClaimsTransformation
         var now = _clock.GetCurrentInstant();
         var claims = new List<Claim>();
 
+        // Check suspension status — suspended users lose ActiveMember claim
+        // but keep role claims (Admin/Board) so they can manage their own unsuspension
+        var isSuspended = await dbContext.Profiles
+            .AsNoTracking()
+            .AnyAsync(p => p.UserId == userId && p.IsSuspended);
+
         var activeRoles = await dbContext.RoleAssignments
             .AsNoTracking()
             .Where(ra =>
@@ -105,16 +111,19 @@ public class RoleAssignmentClaimsTransformation : IClaimsTransformation
             claims.Add(new Claim(ClaimTypes.Role, role));
         }
 
-        var isVolunteerMember = await dbContext.TeamMembers
-            .AsNoTracking()
-            .AnyAsync(tm =>
-                tm.UserId == userId &&
-                tm.TeamId == SystemTeamIds.Volunteers &&
-                !tm.LeftAt.HasValue);
-
-        if (isVolunteerMember)
+        if (!isSuspended)
         {
-            claims.Add(new Claim(ActiveMemberClaimType, ActiveClaimValue));
+            var isVolunteerMember = await dbContext.TeamMembers
+                .AsNoTracking()
+                .AnyAsync(tm =>
+                    tm.UserId == userId &&
+                    tm.TeamId == SystemTeamIds.Volunteers &&
+                    !tm.LeftAt.HasValue);
+
+            if (isVolunteerMember)
+            {
+                claims.Add(new Claim(ActiveMemberClaimType, ActiveClaimValue));
+            }
         }
 
         var hasProfile = await dbContext.Profiles

--- a/src/Humans.Web/Controllers/BoardController.cs
+++ b/src/Humans.Web/Controllers/BoardController.cs
@@ -1,11 +1,9 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
 
@@ -17,18 +15,15 @@ public class BoardController : HumansControllerBase
 {
     private readonly IAuditLogService _auditLogService;
     private readonly IOnboardingService _onboardingService;
-    private readonly HumansDbContext _dbContext;
 
     public BoardController(
         IAuditLogService auditLogService,
         IOnboardingService onboardingService,
-        UserManager<User> userManager,
-        HumansDbContext dbContext)
+        UserManager<User> userManager)
         : base(userManager)
     {
         _auditLogService = auditLogService;
         _onboardingService = onboardingService;
-        _dbContext = dbContext;
     }
 
     [HttpGet("")]
@@ -70,9 +65,9 @@ public class BoardController : HumansControllerBase
     public async Task<IActionResult> AuditLog(string? filter, int page = 1)
     {
         var pageSize = 50;
-        var (items, totalCount, anomalyCount) = await _auditLogService.GetFilteredAsync(filter, page, pageSize);
+        var result = await _auditLogService.GetAuditLogPageAsync(filter, page, pageSize);
 
-        var entries = items.Select(e => new AuditLogEntryViewModel
+        var entries = result.Items.Select(e => new AuditLogEntryViewModel
         {
             Action = e.Action,
             Description = e.Description,
@@ -85,43 +80,16 @@ public class BoardController : HumansControllerBase
             RelatedEntityId = e.RelatedEntityId
         }).ToList();
 
-        // Batch-load display names for all user IDs (actors + subjects)
-        var allUserIds = entries
-            .SelectMany(e => new[] { e.ActorUserId, e.SubjectUserId })
-            .Where(id => id.HasValue)
-            .Select(id => id!.Value)
-            .Distinct()
-            .ToList();
-
-        var userDisplayNames = allUserIds.Count > 0
-            ? await _dbContext.Users.AsNoTracking()
-                .Where(u => allUserIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id, u => u.DisplayName)
-            : new Dictionary<Guid, string>();
-
-        // Batch-load team names for target teams
-        var teamIds = entries
-            .Where(e => e.TargetTeamId.HasValue)
-            .Select(e => e.TargetTeamId!.Value)
-            .Distinct()
-            .ToList();
-
-        var teamNames = teamIds.Count > 0
-            ? await _dbContext.Teams.AsNoTracking()
-                .Where(t => teamIds.Contains(t.Id))
-                .ToDictionaryAsync(t => t.Id, t => (t.Name, t.Slug))
-            : new Dictionary<Guid, (string Name, string Slug)>();
-
         var viewModel = new AuditLogListViewModel
         {
             Entries = entries,
             ActionFilter = filter,
-            AnomalyCount = anomalyCount,
-            TotalCount = totalCount,
+            AnomalyCount = result.AnomalyCount,
+            TotalCount = result.TotalCount,
             PageNumber = page,
             PageSize = pageSize,
-            UserDisplayNames = userDisplayNames,
-            TeamNames = teamNames
+            UserDisplayNames = result.UserDisplayNames,
+            TeamNames = result.TeamNames
         };
 
         return View("~/Views/Shared/AuditLog.cshtml", viewModel);

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -1,13 +1,11 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Authorization.Requirements;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using NodaTime;
 
 namespace Humans.Web.Controllers;
@@ -18,14 +16,12 @@ public class BudgetController : HumansControllerBase
 {
     private readonly IBudgetService _budgetService;
     private readonly ITeamService _teamService;
-    private readonly HumansDbContext _dbContext;
     private readonly IAuthorizationService _authService;
     private readonly ILogger<BudgetController> _logger;
 
     public BudgetController(
         IBudgetService budgetService,
         ITeamService teamService,
-        HumansDbContext dbContext,
         IAuthorizationService authService,
         UserManager<User> userManager,
         ILogger<BudgetController> logger)
@@ -33,7 +29,6 @@ public class BudgetController : HumansControllerBase
     {
         _budgetService = budgetService;
         _teamService = teamService;
-        _dbContext = dbContext;
         _authService = authService;
         _logger = logger;
     }
@@ -198,7 +193,7 @@ public class BudgetController : HumansControllerBase
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var lineItem = await _dbContext.BudgetLineItems.FindAsync(id);
+        var lineItem = await _budgetService.GetLineItemByIdAsync(id);
         if (lineItem is null) return NotFound();
 
         var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId);
@@ -226,7 +221,7 @@ public class BudgetController : HumansControllerBase
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var lineItem = await _dbContext.BudgetLineItems.FindAsync(id);
+        var lineItem = await _budgetService.GetLineItemByIdAsync(id);
         if (lineItem is null) return NotFound();
 
         var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId);

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -3,14 +3,12 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace Humans.Web.Controllers;
 
@@ -20,18 +18,15 @@ namespace Humans.Web.Controllers;
 public class CampAdminController : HumansControllerBase
 {
     private readonly ICampService _campService;
-    private readonly HumansDbContext _dbContext;
     private readonly ILogger<CampAdminController> _logger;
 
     public CampAdminController(
         ICampService campService,
-        HumansDbContext dbContext,
         UserManager<User> userManager,
         ILogger<CampAdminController> logger)
         : base(userManager)
     {
         _campService = campService;
-        _dbContext = dbContext;
         _logger = logger;
     }
 
@@ -63,14 +58,8 @@ public class CampAdminController : HumansControllerBase
                 .ToList();
 
             // Load camps with leads for the summary table
-            var campsWithLeads = await _dbContext.Camps
-                .Include(c => c.Seasons.Where(s => s.Year == settings.PublicYear))
-                .Include(c => c.Leads.Where(l => l.LeftAt == null))
-                    .ThenInclude(l => l.User)
-                .Where(c => c.Seasons.Any(s => s.Year == settings.PublicYear
-                    && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full)))
-                .OrderBy(c => c.Seasons.Where(s => s.Year == settings.PublicYear).Select(s => s.Name).FirstOrDefault())
-                .ToListAsync();
+            var activeStatuses = new[] { CampSeasonStatus.Active, CampSeasonStatus.Full };
+            var campsWithLeads = await _campService.GetCampsWithLeadsForYearAsync(settings.PublicYear, activeStatuses);
 
             var summaries = campsWithLeads.Select(c =>
             {
@@ -277,13 +266,7 @@ public class CampAdminController : HumansControllerBase
             var settings = await _campService.GetSettingsAsync();
             var year = settings.PublicYear;
 
-            var camps = await _dbContext.Camps
-                .Include(c => c.Seasons.Where(s => s.Year == year))
-                .Include(c => c.Leads.Where(l => l.LeftAt == null))
-                    .ThenInclude(l => l.User)
-                .Where(c => c.Seasons.Any(s => s.Year == year))
-                .OrderBy(c => c.Seasons.Where(s => s.Year == year).Select(s => s.Name).FirstOrDefault())
-                .ToListAsync();
+            var camps = await _campService.GetCampsWithLeadsForYearAsync(year);
 
             var csv = new StringBuilder();
             csv.AppendCsvRow(

--- a/src/Humans.Web/Controllers/ContactsController.cs
+++ b/src/Humans.Web/Controllers/ContactsController.cs
@@ -15,17 +15,20 @@ namespace Humans.Web.Controllers;
 public class ContactsController : HumansControllerBase
 {
     private readonly IContactService _contactService;
+    private readonly ICommunicationPreferenceService _preferenceService;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly ILogger<ContactsController> _logger;
 
     public ContactsController(
         UserManager<User> userManager,
         IContactService contactService,
+        ICommunicationPreferenceService preferenceService,
         IStringLocalizer<SharedResource> localizer,
         ILogger<ContactsController> logger)
         : base(userManager)
     {
         _contactService = contactService;
+        _preferenceService = preferenceService;
         _localizer = localizer;
         _logger = logger;
     }
@@ -72,6 +75,8 @@ public class ContactsController : HumansControllerBase
             if (contact is null)
                 return NotFound();
 
+            var preferences = await _preferenceService.GetPreferencesAsync(contact.Id);
+
             var viewModel = new AdminContactDetailViewModel
             {
                 UserId = contact.Id,
@@ -80,7 +85,7 @@ public class ContactsController : HumansControllerBase
                 ContactSource = contact.ContactSource,
                 ExternalSourceId = contact.ExternalSourceId,
                 CreatedAt = contact.CreatedAt,
-                CommunicationPreferences = contact.CommunicationPreferences.ToList()
+                CommunicationPreferences = preferences.ToList()
             };
 
             return View(viewModel);

--- a/src/Humans.Web/Controllers/DevLoginController.cs
+++ b/src/Humans.Web/Controllers/DevLoginController.cs
@@ -93,15 +93,18 @@ public class DevLoginController : Controller
             return NotFound();
 
         var id = PersonaGuid(info.Slug);
+        Guid resolvedUserId;
 
         await SeedLock.WaitAsync();
         try
         {
-            await EnsurePersonaAsync(info, id);
+            resolvedUserId = await EnsurePersonaAsync(info, id);
+            if (string.Equals(info.Slug, "coordinator", StringComparison.OrdinalIgnoreCase))
+                await EnsureCoordinatorTeamsAsync(resolvedUserId);
             if (IsBarrioLeadSlug(info.Slug))
-                await EnsureBarrioCampAsync(info.Slug, id);
+                await EnsureBarrioCampAsync(info.Slug, resolvedUserId);
             if (IsCityPlanningSlug(info.Slug))
-                await EnsureCityPlanningTeamAsync(id);
+                await EnsureCityPlanningTeamAsync(resolvedUserId);
         }
         finally
         {
@@ -109,11 +112,11 @@ public class DevLoginController : Controller
         }
 
         var email = $"dev-{info.Slug}@localhost";
-        var user = await _userManager.FindByIdAsync(id.ToString())
+        var user = await _userManager.FindByIdAsync(resolvedUserId.ToString())
                    ?? await _userManager.FindByEmailAsync(email);
         if (user is null)
         {
-            _logger.LogError("Dev persona {Slug} ({Id}) not found after seeding", info.Slug, id);
+            _logger.LogError("Dev persona {Slug} ({Id}) not found after seeding", info.Slug, resolvedUserId);
             return StatusCode(500, "Dev persona seeding failed");
         }
 
@@ -170,11 +173,11 @@ public class DevLoginController : Controller
             _configRegistry, "DevAuth:Enabled", "Development", defaultValue: false);
     }
 
-    private async Task EnsurePersonaAsync(DevPersonaInfo info, Guid id)
+    private async Task<Guid> EnsurePersonaAsync(DevPersonaInfo info, Guid id)
     {
         var existing = await _userManager.FindByIdAsync(id.ToString());
         if (existing is not null)
-            return;
+            return existing.Id;
 
         var email = $"dev-{info.Slug}@localhost";
 
@@ -183,7 +186,7 @@ public class DevLoginController : Controller
         if (byEmail is not null)
         {
             _logger.LogInformation("DEV: found legacy persona {Email} ({OldId}), reusing", email, byEmail.Id);
-            return;
+            return byEmail.Id;
         }
 
         var now = _clock.GetCurrentInstant();
@@ -193,7 +196,7 @@ public class DevLoginController : Controller
         if (string.Equals(info.Slug, "guest", StringComparison.OrdinalIgnoreCase))
         {
             await SeedProfilelessUserAsync(id, email, displayName, now);
-            return;
+            return id;
         }
 
         var nameParts = info.DisplayName.Split(' ', 2);
@@ -228,7 +231,7 @@ public class DevLoginController : Controller
         {
             _logger.LogError("Failed to create dev persona {Email}: {Errors}",
                 email, string.Join(", ", result.Errors.Select(e => e.Description)));
-            return;
+            return id;
         }
 
         _db.UserEmails.Add(new UserEmail
@@ -315,22 +318,14 @@ public class DevLoginController : Controller
             });
         }
 
-        // Coordinator persona: create a department + sub-team and assign as coordinator
-        if (isCoordinatorPersona)
-        {
-            await SeedCoordinatorTeamsAsync(id, now);
-        }
-
         await _db.SaveChangesAsync();
         _cache.InvalidateApprovedProfiles();
         _cache.InvalidateUserAccess(id);
-        if (isCoordinatorPersona)
-        {
-            _cache.InvalidateActiveTeams();
-        }
 
         _logger.LogInformation("DEV: seeded persona {Email} with roles [{Roles}] and teams [{Teams}]",
             email, string.Join(", ", roles), string.Join(", ", teams.Select(t => t)));
+
+        return id;
     }
 
     /// <summary>
@@ -400,23 +395,64 @@ public class DevLoginController : Controller
     }
 
     /// <summary>
-    /// Seeds a test department and sub-team for the coordinator persona.
-    /// The coordinator is assigned as coordinator of the department and member of the sub-team.
-    /// Uses deterministic IDs so teams are stable across restarts.
+    /// Ensures the coordinator persona's test department and sub-team exist with active memberships.
+    /// Called from SignIn() on every login so sync-job deactivations are repaired.
     /// </summary>
-    private async Task SeedCoordinatorTeamsAsync(Guid coordinatorUserId, Instant now)
+    private async Task EnsureCoordinatorTeamsAsync(Guid coordinatorUserId)
     {
+        var now = _clock.GetCurrentInstant();
+        var changed = false;
         var deptId = PersonaGuid("dev-test-department");
         var subTeamId = PersonaGuid("dev-test-subteam");
 
-        // Only create if the department doesn't already exist
-        var deptExists = await _db.Teams.AnyAsync(t => t.Id == deptId);
-        if (deptExists)
+        // Ensure department exists
+        if (!await _db.Teams.AnyAsync(t => t.Id == deptId))
         {
-            // Ensure the coordinator membership on department exists
-            var hasDeptMembership = await _db.TeamMembers
-                .AnyAsync(tm => tm.TeamId == deptId && tm.UserId == coordinatorUserId);
-            if (!hasDeptMembership)
+            _db.Teams.Add(new Team
+            {
+                Id = deptId,
+                Name = "Dev Test Department",
+                Description = "Test department for coordinator e2e tests",
+                Slug = "dev-test-department",
+                IsActive = true,
+                RequiresApproval = true,
+                SystemTeamType = SystemTeamType.None,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+            changed = true;
+        }
+
+        // Ensure sub-team exists
+        if (!await _db.Teams.AnyAsync(t => t.Id == subTeamId))
+        {
+            _db.Teams.Add(new Team
+            {
+                Id = subTeamId,
+                Name = "Dev Test SubTeam",
+                Description = "Test sub-team for coordinator e2e tests",
+                Slug = "dev-test-subteam",
+                IsActive = true,
+                RequiresApproval = true,
+                SystemTeamType = SystemTeamType.None,
+                ParentTeamId = deptId,
+                CreatedAt = now,
+                UpdatedAt = now
+            });
+            changed = true;
+        }
+
+        // Ensure active coordinator membership on department
+        if (!await _db.TeamMembers.AnyAsync(tm => tm.TeamId == deptId && tm.UserId == coordinatorUserId && tm.LeftAt == null))
+        {
+            var inactive = await _db.TeamMembers
+                .FirstOrDefaultAsync(tm => tm.TeamId == deptId && tm.UserId == coordinatorUserId && tm.LeftAt != null);
+            if (inactive is not null)
+            {
+                inactive.LeftAt = null;
+                inactive.Role = TeamMemberRole.Coordinator;
+            }
+            else
             {
                 _db.TeamMembers.Add(new TeamMember
                 {
@@ -427,30 +463,20 @@ public class DevLoginController : Controller
                     JoinedAt = now
                 });
             }
+            changed = true;
+        }
 
-            // Ensure sub-team exists (may have been deleted manually in preview env)
-            var subTeamExists = await _db.Teams.AnyAsync(t => t.Id == subTeamId);
-            if (!subTeamExists)
+        // Ensure active membership on sub-team
+        if (!await _db.TeamMembers.AnyAsync(tm => tm.TeamId == subTeamId && tm.UserId == coordinatorUserId && tm.LeftAt == null))
+        {
+            var inactive = await _db.TeamMembers
+                .FirstOrDefaultAsync(tm => tm.TeamId == subTeamId && tm.UserId == coordinatorUserId && tm.LeftAt != null);
+            if (inactive is not null)
             {
-                _db.Teams.Add(new Team
-                {
-                    Id = subTeamId,
-                    Name = "Dev Test SubTeam",
-                    Description = "Test sub-team for coordinator e2e tests",
-                    Slug = "dev-test-subteam",
-                    IsActive = true,
-                    RequiresApproval = true,
-                    SystemTeamType = SystemTeamType.None,
-                    ParentTeamId = deptId,
-                    CreatedAt = now,
-                    UpdatedAt = now
-                });
+                inactive.LeftAt = null;
+                inactive.Role = TeamMemberRole.Member;
             }
-
-            // Ensure coordinator membership on sub-team exists
-            var hasSubTeamMembership = await _db.TeamMembers
-                .AnyAsync(tm => tm.TeamId == subTeamId && tm.UserId == coordinatorUserId);
-            if (!hasSubTeamMembership)
+            else
             {
                 _db.TeamMembers.Add(new TeamMember
                 {
@@ -461,62 +487,18 @@ public class DevLoginController : Controller
                     JoinedAt = now
                 });
             }
-
-            return;
+            changed = true;
         }
 
-        // Create department
-        _db.Teams.Add(new Team
+        if (changed)
         {
-            Id = deptId,
-            Name = "Dev Test Department",
-            Description = "Test department for coordinator e2e tests",
-            Slug = "dev-test-department",
-            IsActive = true,
-            RequiresApproval = true,
-            SystemTeamType = SystemTeamType.None,
-            CreatedAt = now,
-            UpdatedAt = now
-        });
-
-        // Create sub-team under the department
-        _db.Teams.Add(new Team
-        {
-            Id = subTeamId,
-            Name = "Dev Test SubTeam",
-            Description = "Test sub-team for coordinator e2e tests",
-            Slug = "dev-test-subteam",
-            IsActive = true,
-            RequiresApproval = true,
-            SystemTeamType = SystemTeamType.None,
-            ParentTeamId = deptId,
-            CreatedAt = now,
-            UpdatedAt = now
-        });
-
-        // Add coordinator as coordinator of the department
-        _db.TeamMembers.Add(new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            UserId = coordinatorUserId,
-            TeamId = deptId,
-            Role = TeamMemberRole.Coordinator,
-            JoinedAt = now
-        });
-
-        // Add coordinator as regular member of the sub-team
-        _db.TeamMembers.Add(new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            UserId = coordinatorUserId,
-            TeamId = subTeamId,
-            Role = TeamMemberRole.Member,
-            JoinedAt = now
-        });
-
-        _logger.LogInformation(
-            "DEV: seeded coordinator teams — department {DeptId} ({DeptSlug}), sub-team {SubTeamId} ({SubTeamSlug})",
-            deptId, "dev-test-department", subTeamId, "dev-test-subteam");
+            await _db.SaveChangesAsync();
+            _cache.InvalidateActiveTeams();
+            _cache.InvalidateUserAccess(coordinatorUserId);
+            _logger.LogInformation(
+                "DEV: ensured coordinator teams — department {DeptId}, sub-team {SubTeamId}",
+                deptId, subTeamId);
+        }
     }
 
     /// <summary>
@@ -554,17 +536,28 @@ public class DevLoginController : Controller
             _logger.LogInformation("DEV: seeded city planning team {Slug}", teamSlug);
         }
 
-        var hasMembership = await _db.TeamMembers.AnyAsync(tm => tm.TeamId == team.Id && tm.UserId == userId);
-        if (!hasMembership)
+        var hasActiveMembership = await _db.TeamMembers
+            .AnyAsync(tm => tm.TeamId == team.Id && tm.UserId == userId && tm.LeftAt == null);
+        if (!hasActiveMembership)
         {
-            _db.TeamMembers.Add(new TeamMember
+            var inactiveMembership = await _db.TeamMembers
+                .FirstOrDefaultAsync(tm => tm.TeamId == team.Id && tm.UserId == userId && tm.LeftAt != null);
+            if (inactiveMembership is not null)
             {
-                Id = Guid.NewGuid(),
-                UserId = userId,
-                TeamId = team.Id,
-                Role = TeamMemberRole.Coordinator,
-                JoinedAt = now
-            });
+                inactiveMembership.LeftAt = null;
+                inactiveMembership.Role = TeamMemberRole.Coordinator;
+            }
+            else
+            {
+                _db.TeamMembers.Add(new TeamMember
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    TeamId = team.Id,
+                    Role = TeamMemberRole.Coordinator,
+                    JoinedAt = now
+                });
+            }
             changed = true;
         }
 

--- a/src/Humans.Web/Controllers/EmailController.cs
+++ b/src/Humans.Web/Controllers/EmailController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
@@ -9,10 +8,8 @@ using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
-using NodaTime;
 
 namespace Humans.Web.Controllers;
 
@@ -20,16 +17,16 @@ namespace Humans.Web.Controllers;
 [Route("Email")]
 public class EmailController : HumansControllerBase
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IEmailOutboxService _outboxService;
     private readonly ILogger<EmailController> _logger;
 
     public EmailController(
         UserManager<User> userManager,
-        HumansDbContext dbContext,
+        IEmailOutboxService outboxService,
         ILogger<EmailController> logger)
         : base(userManager)
     {
-        _dbContext = dbContext;
+        _outboxService = outboxService;
         _logger = logger;
     }
 
@@ -40,37 +37,18 @@ public class EmailController : HumansControllerBase
     }
 
     [HttpGet("EmailOutbox")]
-    public async Task<IActionResult> EmailOutbox([FromServices] IClock clock)
+    public async Task<IActionResult> EmailOutbox()
     {
-        var now = clock.GetCurrentInstant();
-        var cutoff24h = now - Duration.FromHours(24);
-
-        var totalCount = await _dbContext.EmailOutboxMessages.CountAsync();
-        var queuedCount = await _dbContext.EmailOutboxMessages
-            .CountAsync(m => m.Status == EmailOutboxStatus.Queued);
-        var sentLast24H = await _dbContext.EmailOutboxMessages
-            .CountAsync(m => m.Status == EmailOutboxStatus.Sent && m.SentAt > cutoff24h);
-        var failedCount = await _dbContext.EmailOutboxMessages
-            .CountAsync(m => m.Status == EmailOutboxStatus.Failed);
-
-        var pausedSetting = await _dbContext.SystemSettings
-            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused");
-        var isPaused = string.Equals(pausedSetting?.Value, "true", StringComparison.OrdinalIgnoreCase);
-
-        var messages = await _dbContext.EmailOutboxMessages
-            .Include(m => m.User)
-            .OrderByDescending(m => m.CreatedAt)
-            .Take(50)
-            .ToListAsync();
+        var stats = await _outboxService.GetOutboxStatsAsync();
 
         var viewModel = new EmailOutboxViewModel
         {
-            TotalMessageCount = totalCount,
-            QueuedCount = queuedCount,
-            SentLast24HoursCount = sentLast24H,
-            FailedCount = failedCount,
-            IsPaused = isPaused,
-            Messages = messages,
+            TotalMessageCount = stats.TotalCount,
+            QueuedCount = stats.QueuedCount,
+            SentLast24HoursCount = stats.SentLast24HoursCount,
+            FailedCount = stats.FailedCount,
+            IsPaused = stats.IsPaused,
+            Messages = stats.RecentMessages.ToList(),
         };
 
         return View(viewModel);
@@ -80,7 +58,7 @@ public class EmailController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> PauseEmailSending()
     {
-        await SetEmailPausedAsync(true);
+        await _outboxService.SetEmailPausedAsync(true);
         _logger.LogInformation("Admin {AdminId} paused email sending", User.Identity?.Name);
         SetSuccess("Email sending paused.");
         return RedirectToAction(nameof(EmailOutbox));
@@ -90,7 +68,7 @@ public class EmailController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ResumeEmailSending()
     {
-        await SetEmailPausedAsync(false);
+        await _outboxService.SetEmailPausedAsync(false);
         _logger.LogInformation("Admin {AdminId} resumed email sending", User.Identity?.Name);
         SetSuccess("Email sending resumed.");
         return RedirectToAction(nameof(EmailOutbox));
@@ -98,9 +76,9 @@ public class EmailController : HumansControllerBase
 
     [HttpPost("EmailOutbox/Retry/{id:guid}")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> RetryEmailOutboxMessage(Guid id, [FromServices] IEmailOutboxService outboxService)
+    public async Task<IActionResult> RetryEmailOutboxMessage(Guid id)
     {
-        var recipient = await outboxService.RetryMessageAsync(id);
+        var recipient = await _outboxService.RetryMessageAsync(id);
         if (recipient is null) return NotFound();
 
         SetSuccess($"Message to {recipient} queued for retry.");
@@ -109,9 +87,9 @@ public class EmailController : HumansControllerBase
 
     [HttpPost("EmailOutbox/Discard/{id:guid}")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> DiscardEmailOutboxMessage(Guid id, [FromServices] IEmailOutboxService outboxService)
+    public async Task<IActionResult> DiscardEmailOutboxMessage(Guid id)
     {
-        var recipient = await outboxService.DiscardMessageAsync(id);
+        var recipient = await _outboxService.DiscardMessageAsync(id);
         if (recipient is null) return NotFound();
 
         SetSuccess($"Message to {recipient} discarded.");
@@ -225,19 +203,4 @@ public class EmailController : HumansControllerBase
         return View(new EmailPreviewViewModel { Previews = previews, FromAddress = settings.FromAddress });
     }
 
-    private async Task SetEmailPausedAsync(bool paused)
-    {
-        var setting = await _dbContext.SystemSettings
-            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused");
-        if (setting is null)
-        {
-            setting = new SystemSetting { Key = "IsEmailSendingPaused", Value = paused ? "true" : "false" };
-            _dbContext.SystemSettings.Add(setting);
-        }
-        else
-        {
-            setting.Value = paused ? "true" : "false";
-        }
-        await _dbContext.SaveChangesAsync();
-    }
 }

--- a/src/Humans.Web/Controllers/FeedbackController.cs
+++ b/src/Humans.Web/Controllers/FeedbackController.cs
@@ -183,7 +183,7 @@ public class FeedbackController : HumansControllerBase
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogDebug(ex, "Feedback submission failed for user {UserId}", user.Id);
+            _logger.LogWarning(ex, "Feedback submission failed for user {UserId}", user.Id);
             var errorMsg = _localizer["Feedback_Error"].Value;
             if (isAjax) return Json(new { success = false, message = errorMsg });
             SetError(errorMsg);

--- a/src/Humans.Web/Controllers/FinanceController.cs
+++ b/src/Humans.Web/Controllers/FinanceController.cs
@@ -18,6 +18,7 @@ public class FinanceController : HumansControllerBase
     private readonly ITeamService _teamService;
     private readonly ITicketingBudgetService _ticketingBudgetService;
     private readonly ITicketQueryService _ticketQueryService;
+    private readonly IClock _clock;
     private readonly ILogger<FinanceController> _logger;
 
     public FinanceController(
@@ -25,6 +26,7 @@ public class FinanceController : HumansControllerBase
         ITeamService teamService,
         ITicketingBudgetService ticketingBudgetService,
         ITicketQueryService ticketQueryService,
+        IClock clock,
         UserManager<User> userManager,
         ILogger<FinanceController> logger)
         : base(userManager)
@@ -33,6 +35,7 @@ public class FinanceController : HumansControllerBase
         _teamService = teamService;
         _ticketingBudgetService = ticketingBudgetService;
         _ticketQueryService = ticketQueryService;
+        _clock = clock;
         _logger = logger;
     }
 
@@ -575,7 +578,7 @@ public class FinanceController : HumansControllerBase
             if (projections.Count > 0)
             {
                 var projectedRemaining = projections.Sum(p => p.ProjectedTickets);
-                var today = SystemClock.Instance.GetCurrentInstant().InUtc().Date;
+                var today = _clock.GetCurrentInstant().InUtc().Date;
                 var proj = ticketingGroup.TicketingProjection!;
                 var daysToEvent = Period.Between(today, proj.EventDate!.Value, PeriodUnits.Days).Days;
 

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -729,6 +729,9 @@ public class GoogleController : HumansControllerBase
         var googleEmailLookup = await dbContext.Users
             .Where(u => userIds.Contains(u.Id))
             .ToDictionaryAsync(u => u.Id, u => u.GetGoogleServiceEmail() ?? "unknown");
+        var displayNameLookup = await dbContext.Users
+            .Where(u => userIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => u.DisplayName);
         var teamLookup = await dbContext.Teams
             .Where(t => teamIds.Contains(t.Id))
             .ToDictionaryAsync(t => t.Id, t => t.Name);
@@ -740,6 +743,7 @@ public class GoogleController : HumansControllerBase
                 g => g.Select(r => $"{r.Name} ({r.ResourceType})").ToList());
 
         ViewBag.GoogleEmailLookup = googleEmailLookup;
+        ViewBag.DisplayNameLookup = displayNameLookup;
         ViewBag.TeamLookup = teamLookup;
         ViewBag.ResourceLookup = resourceLookup;
         return View(events);

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -1,12 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Web.Models;
 using NodaTime;
 
@@ -21,7 +19,7 @@ public class GuestController : HumansControllerBase
 {
     private readonly ICommunicationPreferenceService _commPrefService;
     private readonly IProfileService _profileService;
-    private readonly HumansDbContext _dbContext;
+    private readonly ITicketQueryService _ticketQueryService;
     private readonly IClock _clock;
     private readonly ILogger<GuestController> _logger;
 
@@ -36,14 +34,14 @@ public class GuestController : HumansControllerBase
         UserManager<User> userManager,
         ICommunicationPreferenceService commPrefService,
         IProfileService profileService,
-        HumansDbContext dbContext,
+        ITicketQueryService ticketQueryService,
         IClock clock,
         ILogger<GuestController> logger)
         : base(userManager)
     {
         _commPrefService = commPrefService;
         _profileService = profileService;
-        _dbContext = dbContext;
+        _ticketQueryService = ticketQueryService;
         _clock = clock;
         _logger = logger;
     }
@@ -253,31 +251,24 @@ public class GuestController : HumansControllerBase
         };
 
         // Ticket status: check for matched ticket orders and attendees
-        var hasTicketOrder = await _dbContext.TicketOrders
-            .AnyAsync(o => o.MatchedUserId == user.Id);
+        var hasTickets = await _ticketQueryService.HasTicketAttendeeMatchAsync(user.Id);
 
-        var hasTicketAttendee = await _dbContext.TicketAttendees
-            .AnyAsync(a => a.MatchedUserId == user.Id);
-
-        if (hasTicketOrder || hasTicketAttendee)
+        if (hasTickets)
         {
             viewModel.HasTickets = true;
 
             // Get ticket details for display
-            var ticketOrders = await _dbContext.TicketOrders
-                .Where(o => o.MatchedUserId == user.Id)
-                .OrderByDescending(o => o.PurchasedAt)
-                .Select(o => new GuestTicketOrderSummary
+            var orderSummaries = await _ticketQueryService.GetUserTicketOrderSummariesAsync(user.Id);
+            viewModel.TicketOrders = orderSummaries
+                .Select(s => new GuestTicketOrderSummary
                 {
-                    BuyerName = o.BuyerName,
-                    PurchasedAt = o.PurchasedAt.ToDateTimeUtc(),
-                    AttendeeCount = o.Attendees.Count,
-                    TotalAmount = o.TotalAmount,
-                    Currency = o.Currency,
+                    BuyerName = s.BuyerName,
+                    PurchasedAt = s.PurchasedAt.ToDateTimeUtc(),
+                    AttendeeCount = s.AttendeeCount,
+                    TotalAmount = s.TotalAmount,
+                    Currency = s.Currency,
                 })
-                .ToListAsync();
-
-            viewModel.TicketOrders = ticketOrders;
+                .ToList();
         }
 
         // Deletion request status
@@ -311,8 +302,8 @@ public class GuestController : HumansControllerBase
         var (userId, _) = result.Value;
 
         // Verify user still exists
-        var exists = await _dbContext.Users.AnyAsync(u => u.Id == userId);
-        return exists ? userId : null;
+        var exists = await FindUserByIdAsync(userId);
+        return exists is not null ? userId : null;
     }
 
     private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)
@@ -320,8 +311,7 @@ public class GuestController : HumansControllerBase
         var prefs = await _commPrefService.GetPreferencesAsync(userId);
         var prefsByCategory = prefs.ToDictionary(p => p.Category);
 
-        var hasTicketOrder = await _dbContext.TicketOrders
-            .AnyAsync(o => o.MatchedUserId == userId);
+        var hasTicketOrder = await _ticketQueryService.HasTicketAttendeeMatchAsync(userId);
 
         var categories = new List<CategoryPreferenceItem>();
 
@@ -342,7 +332,7 @@ public class GuestController : HumansControllerBase
                 AlertEnabled = pref?.InboxEnabled ?? true,
                 EmailEditable = !isAlwaysOn && !isTicketingLocked,
                 AlertEditable = !isAlwaysOn && !isTicketingLocked,
-                Note = isTicketingLocked ? "Locked — you have a ticket order for this year" : null,
+                Note = isTicketingLocked ? "Locked — you have a ticket for this year" : null,
             });
         }
 

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -296,14 +296,12 @@ public class GuestController : HumansControllerBase
             return null;
 
         var result = _commPrefService.ValidateUnsubscribeToken(utoken);
-        if (result is null)
+        if (result.Status != TokenValidationStatus.Valid)
             return null;
 
-        var (userId, _) = result.Value;
-
         // Verify user still exists
-        var exists = await FindUserByIdAsync(userId);
-        return exists is not null ? userId : null;
+        var exists = await FindUserByIdAsync(result.UserId);
+        return exists is not null ? result.UserId : null;
     }
 
     private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -23,6 +24,7 @@ public class HomeController : HumansControllerBase
     private readonly IClock _clock;
     private readonly TicketVendorSettings _ticketSettings;
     private readonly ITicketQueryService _ticketQueryService;
+    private readonly IUserService _userService;
     private readonly ILogger<HomeController> _logger;
 
     public HomeController(
@@ -37,6 +39,7 @@ public class HomeController : HumansControllerBase
         IClock clock,
         IOptions<TicketVendorSettings> ticketSettings,
         ITicketQueryService ticketQueryService,
+        IUserService userService,
         ILogger<HomeController> logger)
         : base(userManager)
     {
@@ -50,6 +53,7 @@ public class HomeController : HumansControllerBase
         _clock = clock;
         _ticketSettings = ticketSettings.Value;
         _ticketQueryService = ticketQueryService;
+        _userService = userService;
         _logger = logger;
     }
 
@@ -138,10 +142,20 @@ public class HomeController : HumansControllerBase
             LastLogin = user.LastLoginAt?.ToDateTimeUtc()
         };
 
+        // Load active event once — used by shift cards, ticket widget, and participation
+        EventSettings? activeEvent = null;
+        try
+        {
+            activeEvent = await _shiftMgmt.GetActiveAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load active event for dashboard");
+        }
+
         // Shift cards — fully guarded, failures must never crash the homepage
         try
         {
-            var activeEvent = await _shiftMgmt.GetActiveAsync();
             if (activeEvent is not null)
             {
                 viewModel.EventName = activeEvent.EventName;
@@ -255,7 +269,87 @@ public class HomeController : HumansControllerBase
             _logger.LogError(ex, "Failed to load ticket status for user {UserId}", user.Id);
         }
 
+        // Event participation status
+        try
+        {
+            if (activeEvent is not null && activeEvent.Year > 0)
+            {
+                viewModel.EventYear = activeEvent.Year;
+                var participation = await _userService.GetParticipationAsync(user.Id, activeEvent.Year);
+                viewModel.ParticipationStatus = participation?.Status;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load participation status for user {UserId}", user.Id);
+        }
+
         return View("Dashboard", viewModel);
+    }
+
+    [HttpPost]
+    [Authorize]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeclareNotAttending()
+    {
+        var (errorResult, user) = await ResolveCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        try
+        {
+            var activeEvent = await _shiftMgmt.GetActiveAsync();
+            if (activeEvent is null || activeEvent.Year <= 0)
+            {
+                SetError("No active event configured.");
+                return RedirectToAction(nameof(Index));
+            }
+
+            await _userService.DeclareNotAttendingAsync(user.Id, activeEvent.Year);
+            SetSuccess("You've been marked as not attending this year.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to declare not attending for user {UserId}", user.Id);
+            SetError("Something went wrong. Please try again.");
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [Authorize]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UndoNotAttending()
+    {
+        var (errorResult, user) = await ResolveCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        try
+        {
+            var activeEvent = await _shiftMgmt.GetActiveAsync();
+            if (activeEvent is null || activeEvent.Year <= 0)
+            {
+                SetError("No active event configured.");
+                return RedirectToAction(nameof(Index));
+            }
+
+            var undone = await _userService.UndoNotAttendingAsync(user.Id, activeEvent.Year);
+            if (undone)
+            {
+                SetSuccess("Your declaration has been removed.");
+            }
+            else
+            {
+                SetError("Could not undo — your status may have been updated by ticket sync.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to undo not attending for user {UserId}", user.Id);
+            SetError("Something went wrong. Please try again.");
+        }
+
+        return RedirectToAction(nameof(Index));
     }
 
     public IActionResult Privacy()

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -46,6 +46,7 @@ public class ProfileController : HumansControllerBase
     private readonly ILogger<ProfileController> _logger;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly HumansDbContext _dbContext;
+    private readonly ITicketQueryService _ticketQueryService;
     private readonly IMemoryCache _cache;
     private readonly IClock _clock;
 
@@ -90,6 +91,7 @@ public class ProfileController : HumansControllerBase
         ILogger<ProfileController> logger,
         IStringLocalizer<SharedResource> localizer,
         HumansDbContext dbContext,
+        ITicketQueryService ticketQueryService,
         IMemoryCache cache,
         IClock clock)
         : base(userManager)
@@ -111,6 +113,7 @@ public class ProfileController : HumansControllerBase
         _logger = logger;
         _localizer = localizer;
         _dbContext = dbContext;
+        _ticketQueryService = ticketQueryService;
         _cache = cache;
         _clock = clock;
     }
@@ -1646,9 +1649,8 @@ public class ProfileController : HumansControllerBase
         var prefs = await _commPrefService.GetPreferencesAsync(userId);
         var prefsByCategory = prefs.ToDictionary(p => p.Category);
 
-        // Check if user has a matched ticket order (locks ticketing preference)
-        var hasTicketOrder = await _dbContext.TicketOrders
-            .AnyAsync(o => o.MatchedUserId == userId);
+        // Check if user is a matched ticket attendee (locks ticketing preference)
+        var hasTicketOrder = await _ticketQueryService.HasTicketAttendeeMatchAsync(userId);
 
         var categories = new List<CategoryPreferenceItem>();
 
@@ -1669,7 +1671,7 @@ public class ProfileController : HumansControllerBase
                 AlertEnabled = pref?.InboxEnabled ?? true,
                 EmailEditable = !isAlwaysOn && !isTicketingLocked,
                 AlertEditable = !isAlwaysOn && !isTicketingLocked,
-                Note = isTicketingLocked ? "Locked — you have a ticket order for this year" : null,
+                Note = isTicketingLocked ? "Locked — you have a ticket for this year" : null,
             });
         }
 

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -188,7 +188,7 @@ public class ShiftsController : HumansControllerBase
 
     [HttpPost("SignUp")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> SignUp(Guid shiftId)
+    public async Task<IActionResult> SignUp(Guid shiftId, Guid? departmentId, string? fromDate, string? toDate, string? period, [FromForm(Name = "tags")] List<Guid>? tagIds)
     {
         var (currentUserNotFound, user) = await ResolveCurrentUserOrChallengeAsync();
         if (currentUserNotFound is not null)
@@ -202,19 +202,19 @@ public class ShiftsController : HumansControllerBase
         if (!result.Success)
         {
             SetError(result.Error ?? "Shift signup failed.");
-            return RedirectToAction(nameof(Index));
+            return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
         }
 
         SetSuccess(result.Warning is not null
             ? $"Signed up successfully. Note: {result.Warning}"
             : "Signed up successfully!");
 
-        return RedirectToAction(nameof(Index));
+        return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
     }
 
     [HttpPost("SignUpRange")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> SignUpRange(Guid rotaId, int startDayOffset, int endDayOffset)
+    public async Task<IActionResult> SignUpRange(Guid rotaId, int startDayOffset, int endDayOffset, Guid? departmentId, string? fromDate, string? toDate, string? period, [FromForm(Name = "tags")] List<Guid>? tagIds)
     {
         var (currentUserNotFound, user) = await ResolveCurrentUserOrChallengeAsync();
         if (currentUserNotFound is not null)
@@ -228,14 +228,27 @@ public class ShiftsController : HumansControllerBase
         if (!result.Success)
         {
             SetError(result.Error ?? "Shift range signup failed.");
-            return RedirectToAction(nameof(Index));
+            return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
         }
 
         SetSuccess(result.Warning is not null
             ? $"Signed up for date range. Note: {result.Warning}"
             : "Signed up for date range!");
 
-        return RedirectToAction(nameof(Index));
+        return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
+    }
+
+    private static RouteValueDictionary BuildFilterRouteValues(Guid? departmentId, string? fromDate, string? toDate, string? period, List<Guid>? tagIds)
+    {
+        var rv = new RouteValueDictionary();
+        if (departmentId.HasValue) rv["departmentId"] = departmentId.Value;
+        if (!string.IsNullOrEmpty(fromDate)) rv["fromDate"] = fromDate;
+        if (!string.IsNullOrEmpty(toDate)) rv["toDate"] = toDate;
+        if (!string.IsNullOrEmpty(period)) rv["period"] = period;
+        if (tagIds is { Count: > 0 })
+            for (var i = 0; i < tagIds.Count; i++)
+                rv[$"tags[{i}]"] = tagIds[i];
+        return rv;
     }
 
     [HttpPost("BailRange")]

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -758,7 +758,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to create role '{RoleName}' for team {TeamId} by user {UserId}", model.Name, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to create role '{RoleName}' for team {TeamId} by user {UserId}", model.Name, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -806,7 +806,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to update role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to update role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
             if (isAjax) return Json(new { success = false, message = ex.Message });
             SetError(ex.Message);
         }
@@ -831,7 +831,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to delete role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to delete role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -869,7 +869,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to toggle management flag for role {RoleId} in team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to toggle management flag for role {RoleId} in team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -894,7 +894,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to assign member {MemberUserId} to role {RoleId} in team {TeamId} by user {UserId}", model.UserId, roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to assign member {MemberUserId} to role {RoleId} in team {TeamId} by user {UserId}", model.UserId, roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -929,7 +929,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to unassign member {MemberId} from role {RoleId} in team {TeamId} by user {UserId}", memberId, roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to unassign member {MemberId} from role {RoleId} in team {TeamId} by user {UserId}", memberId, roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -2,6 +2,7 @@ using Hangfire;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
 using Humans.Web.Authorization;
@@ -11,6 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using NodaTime;
 
 namespace Humans.Web.Controllers;
 
@@ -22,6 +24,9 @@ public class TicketController : HumansControllerBase
     private readonly TicketVendorSettings _settings;
     private readonly ITicketQueryService _ticketQueryService;
     private readonly ITicketSyncService _ticketSyncService;
+    private readonly IUserService _userService;
+    private readonly IShiftManagementService _shiftMgmt;
+    private readonly IClock _clock;
     private readonly ILogger<TicketController> _logger;
 
     public TicketController(
@@ -29,6 +34,9 @@ public class TicketController : HumansControllerBase
         IOptions<TicketVendorSettings> settings,
         ITicketQueryService ticketQueryService,
         ITicketSyncService ticketSyncService,
+        IUserService userService,
+        IShiftManagementService shiftMgmt,
+        IClock clock,
         UserManager<User> userManager,
         ILogger<TicketController> logger)
         : base(userManager)
@@ -37,6 +45,9 @@ public class TicketController : HumansControllerBase
         _settings = settings.Value;
         _ticketQueryService = ticketQueryService;
         _ticketSyncService = ticketSyncService;
+        _userService = userService;
+        _shiftMgmt = shiftMgmt;
+        _clock = clock;
         _logger = logger;
     }
 
@@ -112,6 +123,31 @@ public class TicketController : HumansControllerBase
             VolunteersWithTickets = stats.VolunteersWithTickets,
             VolunteerCoveragePercent = stats.VolunteerCoveragePercent,
         };
+
+        // Participation breakdown for donut chart
+        try
+        {
+            var activeEvent = await _shiftMgmt.GetActiveAsync();
+            if (activeEvent is not null && activeEvent.Year > 0)
+            {
+                var participations = await _userService.GetAllParticipationsForYearAsync(activeEvent.Year);
+                var notAttendingCount = participations.Count(p => p.Status == ParticipationStatus.NotAttending);
+                var hasTicketCount = participations.Count(p =>
+                    p.Status == ParticipationStatus.Ticketed ||
+                    p.Status == ParticipationStatus.Attended);
+
+                // "No Ticket" = total active volunteers minus those with tickets minus those who declared not attending
+                var noTicketCount = Math.Max(0, stats.TotalActiveVolunteers - hasTicketCount - notAttendingCount);
+
+                model.ParticipationNotAttending = notAttendingCount;
+                model.ParticipationHasTicket = hasTicketCount;
+                model.ParticipationNoTicket = noTicketCount;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load participation breakdown for ticket dashboard");
+        }
 
         return View(model);
     }
@@ -351,6 +387,67 @@ public class TicketController : HumansControllerBase
 
         BackgroundJob.Enqueue<TicketSyncJob>(job => job.ExecuteAsync(CancellationToken.None));
         SetSuccess("Full re-sync triggered. All orders will be re-fetched.");
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpGet("Participation/Backfill")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    public async Task<IActionResult> ParticipationBackfill()
+    {
+        var activeEvent = await _shiftMgmt.GetActiveAsync();
+        var model = new ParticipationBackfillViewModel
+        {
+            Year = activeEvent?.Year ?? _clock.GetCurrentInstant().InUtc().Year,
+        };
+        return View(model);
+    }
+
+    [HttpPost("Participation/Backfill")]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    public async Task<IActionResult> ParticipationBackfill(ParticipationBackfillViewModel model)
+    {
+        if (!ModelState.IsValid || string.IsNullOrWhiteSpace(model.CsvData))
+        {
+            SetError("Please provide CSV data with UserId and Status columns.");
+            return View(model);
+        }
+
+        try
+        {
+            var entries = new List<(Guid UserId, ParticipationStatus Status)>();
+            var lines = model.CsvData.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            foreach (var line in lines)
+            {
+                var parts = line.Split(',', StringSplitOptions.TrimEntries);
+                if (parts.Length < 2) continue;
+
+                // Skip header row
+                if (string.Equals(parts[0], "UserId", StringComparison.OrdinalIgnoreCase)) continue;
+
+                if (!Guid.TryParse(parts[0], out var userId)) continue;
+                if (!Enum.TryParse<ParticipationStatus>(parts[1], ignoreCase: true, out var status)) continue;
+
+                entries.Add((userId, status));
+            }
+
+            if (entries.Count == 0)
+            {
+                SetError("No valid entries found in the CSV data.");
+                return View(model);
+            }
+
+            var count = await _userService.BackfillParticipationsAsync(model.Year, entries);
+            SetSuccess($"Successfully backfilled {count} participation records for {model.Year}.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to backfill participation data for year {Year}", model.Year);
+            SetError("Failed to process backfill data. Check the format and try again.");
+            return View(model);
+        }
+
         return RedirectToAction(nameof(Index));
     }
 

--- a/src/Humans.Web/Controllers/UnsubscribeController.cs
+++ b/src/Humans.Web/Controllers/UnsubscribeController.cs
@@ -1,76 +1,70 @@
-using System.Security.Cryptography;
 using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Mvc;
-using Humans.Infrastructure.Data;
 
 namespace Humans.Web.Controllers;
 
 public class UnsubscribeController : Controller
 {
-    private readonly HumansDbContext _db;
-    private readonly ICommunicationPreferenceService _preferenceService;
-    private readonly IDataProtectionProvider _dataProtection;
+    private readonly IUnsubscribeService _unsubscribeService;
     private readonly ILogger<UnsubscribeController> _logger;
 
     public UnsubscribeController(
-        HumansDbContext db,
-        ICommunicationPreferenceService preferenceService,
-        IDataProtectionProvider dataProtection,
+        IUnsubscribeService unsubscribeService,
         ILogger<UnsubscribeController> logger)
     {
-        _db = db;
-        _preferenceService = preferenceService;
-        _dataProtection = dataProtection;
+        _unsubscribeService = unsubscribeService;
         _logger = logger;
     }
 
     [HttpGet("/Unsubscribe/{token}")]
     public async Task<IActionResult> Index(string token)
     {
-        // Try new category-aware token first
-        var result = _preferenceService.ValidateUnsubscribeToken(token);
-        if (result is not null)
-        {
-            var (userId, _) = result.Value;
-            var user = await _db.Users.FindAsync(userId);
-            if (user is null)
-                return NotFound();
+        var result = await _unsubscribeService.ValidateTokenAsync(token);
 
-            // Redirect to comms preferences with token — no session created
+        if (result.IsExpired)
+            return View("Expired");
+
+        if (!result.IsValid)
+            return NotFound();
+
+        if (!result.IsLegacy)
+        {
+            // New tokens redirect to comms preferences with token — no session created
             return RedirectToAction(
                 nameof(GuestController.CommunicationPreferences), "Guest",
                 new { utoken = token });
         }
 
-        // Fall back to legacy campaign-only token
-        return await TryLegacyToken(token);
+        // Legacy tokens show the unsubscribe confirmation page
+        ViewData["DisplayName"] = result.DisplayName;
+        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
+        return View();
     }
 
     [HttpPost("/Unsubscribe/{token}")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Confirm(string token)
     {
-        // Try new category-aware token first
-        var result = _preferenceService.ValidateUnsubscribeToken(token);
-        if (result is not null)
+        var result = await _unsubscribeService.ConfirmUnsubscribeAsync(token, "MagicLink");
+
+        if (result.IsExpired)
+            return View("Expired");
+
+        if (!result.IsValid)
+            return NotFound();
+
+        if (!result.IsLegacy)
         {
-            var (userId, category) = result.Value;
-            var user = await _db.Users.FindAsync(userId);
-            if (user is null)
-                return NotFound();
-
-            await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "MagicLink");
-
-            // Redirect to comms preferences with token — no session created
+            // New tokens redirect to comms preferences with token — no session created
             return RedirectToAction(
                 nameof(GuestController.CommunicationPreferences), "Guest",
                 new { utoken = token });
         }
 
-        // Fall back to legacy campaign-only token
-        return await TryLegacyConfirm(token);
+        // Legacy tokens show the done page
+        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
+        return View("Done");
     }
 
     /// <summary>
@@ -84,18 +78,13 @@ public class UnsubscribeController : Controller
     {
         try
         {
-            var result = _preferenceService.ValidateUnsubscribeToken(token);
-            if (result is null)
+            var result = await _unsubscribeService.ConfirmUnsubscribeAsync(token, "OneClick");
+            if (!result.IsValid)
                 return BadRequest();
 
-            var (userId, category) = result.Value;
-            var user = await _db.Users.FindAsync(userId);
-            if (user is null)
-                return NotFound();
-
-            await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "OneClick");
-
-            _logger.LogInformation("RFC 8058 one-click unsubscribe: user {UserId} from {Category}", userId, category);
+            _logger.LogInformation(
+                "RFC 8058 one-click unsubscribe: user {UserId} from {Category}",
+                result.UserId, result.Category);
             return Ok();
         }
         catch (Exception ex)
@@ -103,65 +92,5 @@ public class UnsubscribeController : Controller
             _logger.LogError(ex, "Failed to process RFC 8058 one-click unsubscribe");
             return StatusCode(500);
         }
-    }
-
-    private async Task<IActionResult> TryLegacyToken(string token)
-    {
-        var protector = _dataProtection
-            .CreateProtector("CampaignUnsubscribe")
-            .ToTimeLimitedDataProtector();
-
-        Guid userId;
-        try
-        {
-            var userIdString = protector.Unprotect(token);
-            userId = Guid.Parse(userIdString);
-        }
-        catch (CryptographicException ex)
-        {
-            _logger.LogWarning(ex, "Unsubscribe token was expired or invalid");
-            if (ex.Message.Contains("expired", StringComparison.OrdinalIgnoreCase))
-                return View("Expired");
-            return NotFound();
-        }
-
-        var user = await _db.Users.FindAsync(userId);
-        if (user is null)
-            return NotFound();
-
-        ViewData["DisplayName"] = user.DisplayName;
-        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
-        return View();
-    }
-
-    private async Task<IActionResult> TryLegacyConfirm(string token)
-    {
-        var protector = _dataProtection
-            .CreateProtector("CampaignUnsubscribe")
-            .ToTimeLimitedDataProtector();
-
-        Guid userId;
-        try
-        {
-            var userIdString = protector.Unprotect(token);
-            userId = Guid.Parse(userIdString);
-        }
-        catch (CryptographicException ex)
-        {
-            _logger.LogWarning(ex, "Unsubscribe token was expired or invalid on POST");
-            if (ex.Message.Contains("expired", StringComparison.OrdinalIgnoreCase))
-                return View("Expired");
-            return NotFound();
-        }
-
-        var user = await _db.Users.FindAsync(userId);
-        if (user is null)
-            return NotFound();
-
-        // Use the new preference service for legacy tokens too
-        await _preferenceService.UpdatePreferenceAsync(userId, MessageCategory.Marketing, optedOut: true, source: "MagicLink");
-
-        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
-        return View("Done");
     }
 }

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -92,6 +92,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<ICityPlanningService, CityPlanningService>();
         services.AddScoped<ICampContactService, CampContactService>();
         services.AddScoped<ICommunicationPreferenceService, CommunicationPreferenceService>();
+        services.AddScoped<IUnsubscribeService, UnsubscribeService>();
         services.AddScoped<ICampaignService, CampaignService>();
         services.AddScoped<IContactFieldService, ContactFieldService>();
         services.AddScoped<IUserEmailService, UserEmailService>();

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -162,6 +162,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<IOnboardingService, OnboardingService>();
         services.AddScoped<IConsentService, ConsentService>();
         services.AddScoped<IProfileService, ProfileService>();
+        services.AddScoped<IUserService, UserService>();
         services.AddScoped<SystemTeamSyncJob>();
         services.AddScoped<ISystemTeamSync>(sp => sp.GetRequiredService<SystemTeamSyncJob>());
         services.AddScoped<SyncLegalDocumentsJob>();

--- a/src/Humans.Web/Models/AccessMatrixDefinitions.cs
+++ b/src/Humans.Web/Models/AccessMatrixDefinitions.cs
@@ -48,9 +48,10 @@ public static class AccessMatrixDefinitions
             [
                 Feature("View teams & join", "Volunteer", A, "Coordinator", A, "Board", A, "TeamsAdmin", A),
                 Feature("View team details", "Volunteer", A, "Coordinator", A, "Board", A, "TeamsAdmin", A),
-                Feature("Manage members", "Volunteer", D, "Coordinator", A, "Board", D, "TeamsAdmin", A),
-                Feature("Manage roles", "Volunteer", D, "Coordinator", A, "Board", D, "TeamsAdmin", A),
-                Feature("Create/delete teams", "Volunteer", D, "Coordinator", D, "Board", A, "TeamsAdmin", A),
+                Feature("Manage members", "Volunteer", D, "Coordinator", A, "Board", A, "TeamsAdmin", A),
+                Feature("Manage roles", "Volunteer", D, "Coordinator", A, "Board", A, "TeamsAdmin", A),
+                Feature("Create teams", "Volunteer", D, "Coordinator", D, "Board", A, "TeamsAdmin", A),
+                Feature("Delete teams", "Volunteer", D, "Coordinator", D, "Board", A, "TeamsAdmin", D),
                 Feature("Google resource sync", "Volunteer", D, "Coordinator", D, "Board", D, "TeamsAdmin", L),
             ]
         },
@@ -115,21 +116,21 @@ public static class AccessMatrixDefinitions
             [
                 Feature("View tickets & orders", "Board", A, "TicketAdmin", A),
                 Feature("Sync operations", "Board", D, "TicketAdmin", A),
-                Feature("Discount codes", "Board", D, "TicketAdmin", A),
+                Feature("Discount codes", "Board", A, "TicketAdmin", A),
             ]
         },
 
         ["Profile"] = new AccessMatrixData
         {
             SectionName = "Profile",
-            Roles = ["Volunteer", "Coordinator", "Board", "Admin"],
+            Roles = ["Volunteer", "Coordinator", "Board", "HumanAdmin", "Admin"],
             Features =
             [
-                Feature("View own profile", "Volunteer", A, "Coordinator", A, "Board", A, "Admin", A),
-                Feature("Edit own profile", "Volunteer", A, "Coordinator", A, "Board", A, "Admin", A),
-                Feature("View other profiles", "Volunteer", L, "Coordinator", A, "Board", A, "Admin", A),
-                Feature("View contact fields", "Volunteer", L, "Coordinator", L, "Board", A, "Admin", A),
-                Feature("Admin view of profile", "Volunteer", D, "Coordinator", D, "Board", A, "Admin", A),
+                Feature("View own profile", "Volunteer", A, "Coordinator", A, "Board", A, "HumanAdmin", A, "Admin", A),
+                Feature("Edit own profile", "Volunteer", A, "Coordinator", A, "Board", A, "HumanAdmin", A, "Admin", A),
+                Feature("View other profiles", "Volunteer", L, "Coordinator", A, "Board", A, "HumanAdmin", A, "Admin", A),
+                Feature("View contact fields", "Volunteer", L, "Coordinator", L, "Board", A, "HumanAdmin", A, "Admin", A),
+                Feature("Admin view of profile", "Volunteer", D, "Coordinator", D, "Board", A, "HumanAdmin", A, "Admin", A),
             ]
         },
 

--- a/src/Humans.Web/Models/DashboardViewModel.cs
+++ b/src/Humans.Web/Models/DashboardViewModel.cs
@@ -4,6 +4,10 @@ namespace Humans.Web.Models;
 
 public class DashboardViewModel
 {
+    // Event participation
+    public int? EventYear { get; set; }
+    public ParticipationStatus? ParticipationStatus { get; set; }
+
     public Guid UserId { get; set; }
     public string DisplayName { get; set; } = string.Empty;
     public string? ProfilePictureUrl { get; set; }

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -43,6 +43,11 @@ public class TicketDashboardViewModel
     public int TotalActiveVolunteers { get; set; }
     public int VolunteersWithTickets { get; set; }
     public decimal VolunteerCoveragePercent { get; set; }
+
+    // Participation breakdown
+    public int ParticipationNotAttending { get; set; }
+    public int ParticipationNoTicket { get; set; }
+    public int ParticipationHasTicket { get; set; }
 }
 
 public class PaymentMethodFeeBreakdown
@@ -223,6 +228,12 @@ public class WhoHasntBoughtViewModel : PagedListViewModel
     public string? FilterTier { get; set; }
     public string? FilterTicketStatus { get; set; } // "bought", "not_bought", or null (all)
     public List<string> AvailableTeams { get; set; } = [];
+}
+
+public class ParticipationBackfillViewModel
+{
+    public int Year { get; set; }
+    public string? CsvData { get; set; }
 }
 
 public class WhoHasntBoughtRow

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -810,6 +810,7 @@
   <data name="AdminAddRole_BoardDesc" xml:space="preserve"><value>Permisos de membre de la junta</value></data>
   <data name="AdminAddRole_TeamsAdminDesc" xml:space="preserve"><value>Gestionar tots els equips i pertinences</value></data>
   <data name="AdminAddRole_ConsentCoordinatorDesc" xml:space="preserve"><value>Verificacions de seguretat durant la incorporació</value></data>
+  <data name="AdminAddRole_CampAdminDesc" xml:space="preserve"><value>Gestionar el mapa del camp i les fases de col·locació</value></data>
   <data name="AdminAddRole_VolunteerCoordinatorDesc" xml:space="preserve"><value>Facilitació de la incorporació, gestió de torns global</value></data>
   <data name="AdminAddRole_NoInfoAdminDesc" xml:space="preserve"><value>Aprovar inscripcions en torns, veure dades mèdiques de voluntaris</value></data>
   <data name="AdminAddRole_NotesLabel" xml:space="preserve"><value>Notes (opcional)</value></data>
@@ -1321,41 +1322,41 @@
   <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notificacions</value></data>
   <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Finestra de notificacions</value></data>
   <data name="Notification_Popup_Title" xml:space="preserve"><value>Notificacions</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>cal acció</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Tanca les notificacions</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Ja ho tens tot al dia.</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>requereixen acció</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Tancar notificacions</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Estàs al dia.</value></data>
   <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No hi ha notificacions sense llegir.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Necessita la teva atenció</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Requereix la teva atenció</value></data>
   <data name="Notification_Section_Recent" xml:space="preserve"><value>Recents</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informativa</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolt</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informatius</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolts</value></data>
   <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Cues de treball</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Marca-ho tot com a llegit</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Marcar tot com a llegit</value></data>
   <data name="Notification_SeeAll" xml:space="preserve"><value>Veure totes les notificacions</value></data>
   <data name="Notification_PageTitle" xml:space="preserve"><value>Totes les notificacions</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Cerca notificacions...</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Cercar notificacions...</value></data>
   <data name="Notification_Filter_All" xml:space="preserve"><value>Totes</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Cal acció</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Requereix acció</value></data>
   <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Torns</value></data>
   <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Aprovacions</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolt</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolts</value></data>
   <data name="Notification_Tab_Unread" xml:space="preserve"><value>Sense llegir</value></data>
   <data name="Notification_Tab_All" xml:space="preserve"><value>Totes</value></data>
   <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notificacions</value></data>
   <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
   <data name="Notification_Tag_Action" xml:space="preserve"><value>Acció</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Descarta</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Descartar</value></data>
   <data name="Notification_HandledBy" xml:space="preserve"><value>Gestionat per {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notificacions dins de l’app</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notificacions dins l'aplicació</value></data>
   <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Veure →</value></data>
   <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>ara mateix</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>fa {0} min</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>fa {0} h</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>fa {0} d</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} seleccionades</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resol les seleccionades</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Descarta les seleccionades</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>fa {0}m</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>fa {0}h</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>fa {0}d</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} seleccionats</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resoldre seleccionats</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Descartar seleccionats</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Participa</value></data>
@@ -1434,5 +1435,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Colors &amp; zones sonores</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Cada barrio està acolorit segons la seva zona sonora preferida (editable des de la pàgina del barrio).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Comentaris</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Tots els estats</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Totes les categories</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Tots els informants</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Tots els assignats</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Assignat a mi</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Tots els equips</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Només sense assignar</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Netejar</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>No s'han trobat informes de comentaris.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Sense assignar</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>necessita resposta</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Selecciona un informe per veure els detalls</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversa</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Encara no hi ha missatges.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Escriu un missatge...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Envia</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Resolt {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>per {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Sense equip</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Captura de pantalla</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Donar-se de baixa dels correus</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Donar-se de baixa dels correus {0}?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Hola {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Si confirmes, deixaràs de rebre correus de {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Confirmar baixa</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>T'has donat de baixa</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Ja no rebràs correus de {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Pots gestionar les teves preferències de comunicació des de les teves</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>preferències de comunicació</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Tornar a l'inici</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Enllaç de baixa caducat</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Aquest enllaç de baixa ha caducat</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Fes servir l'enllaç d'un correu més recent, o</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>inicia sessió per gestionar les teves preferències de comunicació</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Preferències de comunicació</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Tria quines comunicacions reps i com.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Categoria</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>Correu</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Alerta</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Tornar al perfil</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Tornar al tauler</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>Correu</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Estat</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notificacions</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Visibilitat del perfil</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Inici de sessió</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Fusió pendent</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verificat</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>Pendent</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>No verificat</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Actiu</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Establir com a destinatari</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Verifica primer</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Ocult</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Tots els humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>Els meus equips</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinadors + Junta</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Només junta</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Segur que vols eliminar aquest correu?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>Correu de serveis de Google</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Aquest correu s'utilitza per a Grups de Google i unitats compartides.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>El teu correu @nobodies.team s'utilitza automàticament.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>La sincronització de Google ha fallat. El correu actual ha estat rebutjat per Google. Selecciona un altre correu.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>La sincronització de Google funciona amb el correu actual.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Seleccionat automàticament</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rebutjat</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Usar aquest</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Preferències de torns</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Pas {0} de {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>En què ets bo/bona?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Selecciona les habilitats que t'agradaria fer servir. Les pots canviar en qualsevol moment.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>Com t'agrada treballar?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Ajuda als coordinadors a assignar-te torns que s'adaptin al teu estil i disponibilitat.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Quins idiomes parles?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Això ens ajuda a ubicar-te en equips on puguis comunicar-te bé.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>Quines altres habilitats tens?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>Quan prefereixes treballar?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Altres preferències</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>Quins altres idiomes parles?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continuar</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Torns</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Explorar opcions de voluntariat</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Departament</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Tots els departaments</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>Des de</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>Fins a</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Netejar filtres</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Tots</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Muntatge</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Esdeveniment</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Desmuntatge</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filtrar per etiqueta:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Configura les teves preferències</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Selecciona etiquetes que coincideixin amb el treball que t'agrada. Els torns coincidents es ressaltaran amb una estrella.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Desar preferències</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Els torns encara no estan oberts. Només coordinadors i administradors poden veure aquesta pàgina.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Encara no hi ha torns disponibles.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Tots els torns de {0} estan complets.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Inici</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Fi</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Inscriure's en dates de {0}</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Ocupats</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>dies</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>total</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Inscrit (tots els {0} dies)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Inscrit ({0} de {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Complet</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Necessita ajuda</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} dia necessita ajuda</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} dies necessiten ajuda</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>clic per expandir</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Torn</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Fase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Hora</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Durada</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Tot el dia</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Dia complet</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essencial</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Totes les fases</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Ocult</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Coincideix amb les teves preferències</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Inscriure's</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>L'exploració de torns encara no està oberta. Torna més tard!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No hi ha cap esdeveniment actiu configurat. Un administrador ha de configurar els ajustos de l'esdeveniment primer.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configurar ajustos de l'esdeveniment</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>Els meus torns</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Propers torns</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>Pendent d'aprovació</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Passats</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Cancel·lar</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Segur que vols cancel·lar?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Cancel·lar tots els {0} dies?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Retirar</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Encara no t'has inscrit en cap torn.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Explorar torns disponibles</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>No hi ha cap esdeveniment actiu configurat.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilitat general</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Marca els dies que estàs disponible per ajudar. Els coordinadors poden veure qui està disponible en assignar torns.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Desar disponibilitat</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Tauler de torns</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} torns</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Departament</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Tots els departaments</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtrar</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Netejar</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Cap torn coincideix amb els filtres actuals.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Torn</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Data / Hora</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Places</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Prioritat</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Cercar humans per a: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Escriu un nom (mín. 2 caràcters)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>No s'han trobat humans.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>La cerca ha fallat.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Conflicte d'horari</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Legal</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Equip</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Suspès</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>Pendent</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Equips:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Unit/da el {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Últim accés {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Torns</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} places ocupades</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans inscrits</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} pendents</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Encara no hi ha torns configurats.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Inclou torns de {0} subequip(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Gestionar torns</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Mèdic</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans gestiona la pertinença a Nobodies Collective i processa dades personals d'acord amb el RGPD i la llei espanyola de protecció de dades (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Responsable del tractament</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Una associació sense ànim de lucre espanyola registrada a Andalusia.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Per a consultes sobre protecció de dades, contacta amb el nostre Delegat de Protecció de Dades a:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Dades que recopilem</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Recopilem i processem les següents categories de dades personals:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Nom, correu electrònic (de l'autenticació de Google), nom per mostrar</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Telèfon, ciutat, país (opcional)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Biografia, pertinença a equips, assignacions de rols</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>Adreça IP i agent d'usuari (per a registres de consentiment)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Sol·licituds de pertinença i declaracions de motivació</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Registres de la teva acceptació de documents legals</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Base legal del tractament</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Processem les teves dades en base a:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Tractament necessari per a la gestió de pertinença</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Manteniment de registres organitzatius i comunicació</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Compliment de la normativa espanyola sobre associacions</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Per a dades opcionals que triïs proporcionar</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Com fem servir les teves dades</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Per gestionar la teva pertinença i participació en equips</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Per comunicar-nos amb tu sobre activitats de l'organització</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Per mantenir registres de compliment legal</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Per facilitar connexions entre humans (segons la teva configuració de visibilitat)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Retenció de dades</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Conservem les teves dades segons les següents polítiques:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Dades conservades mentre el teu compte estigui actiu</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Dades conservades fins a 7 anys per compliment legal</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Conservats indefinidament segons el RGPD</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonimitzats després d'un període de gràcia de 30 dies</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Els teus drets</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Segons el RGPD, tens els següents drets:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Sol·licitar una còpia de les teves dades personals</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Sol·licitar la correcció de dades inexactes</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Sol·licitar l'eliminació de les teves dades (&quot;dret a l'oblit&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Rebre les teves dades en format llegible per màquina</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Sol·licitar la limitació del tractament</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Oposar-te a certs tipus de tractament</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Per exercir aquests drets, visita la teva configuració de {0} o contacta'ns a {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Privacitat i dades</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Aquest lloc només utilitza cookies essencials necessàries per a:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Autenticació d'usuari i gestió de sessions</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Tokens anti-falsificació per a seguretat de formularis</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Preferència de consentiment de cookies</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>No fem servir cookies d'anàlisi, publicitat ni seguiment de tercers.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Seguretat de dades</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Implementem mesures tècniques i organitzatives apropiades per protegir les teves dades, incloent:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Xifratge en trànsit (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Autenticació segura via Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Controls d'accés i registre d'auditoria</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Revisions de seguretat periòdiques</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Serveis de tercers</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Utilitzem els següents serveis de tercers:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Per a autenticació segura</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Per a provisió de recursos d'equip (unitats compartides, grups)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Canvis a aquesta política</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Podem actualitzar aquesta política de privacitat de tant en tant. Notificarem als humans actius sobre canvis significatius per correu.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contacte i reclamacions</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Per a preguntes o dubtes sobre aquesta política, contacta amb el nostre Delegat de Protecció de Dades a {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si no estàs satisfet amb la nostra resposta, tens dret a presentar una reclamació davant l'Agència Espanyola de Protecció de Dades (AEPD) a {0}.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1317,44 +1317,44 @@
   <data name="Todo_ShiftInfo_Action" xml:space="preserve"><value>Schichtinformationen ausf&#xFC;llen</value></data>
 
   <!-- Notification Inbox -->
-  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Notification popup</value></data>
-  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>need action</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Close notifications</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>You're all caught up.</value></data>
-  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No unread notifications.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Needs your attention</value></data>
-  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recent</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informational</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Work queues</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Mark all as read</value></data>
-  <data name="Notification_SeeAll" xml:space="preserve"><value>See all notifications</value></data>
-  <data name="Notification_PageTitle" xml:space="preserve"><value>All notifications</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Search notifications...</value></data>
-  <data name="Notification_Filter_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Needs action</value></data>
-  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Shifts</value></data>
-  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvals</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Unread</value></data>
-  <data name="Notification_Tab_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
-  <data name="Notification_Tag_Action" xml:space="preserve"><value>Action</value></data>
+  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Benachrichtigungen</value></data>
+  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Benachrichtigungs-Popup</value></data>
+  <data name="Notification_Popup_Title" xml:space="preserve"><value>Benachrichtigungen</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>erfordern Aktion</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Benachrichtigungen schließen</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Du bist auf dem Laufenden.</value></data>
+  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>Keine ungelesenen Benachrichtigungen.</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Erfordert deine Aufmerksamkeit</value></data>
+  <data name="Notification_Section_Recent" xml:space="preserve"><value>Kürzlich</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informativ</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Erledigt</value></data>
+  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Arbeitswarteschlangen</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Alle als gelesen markieren</value></data>
+  <data name="Notification_SeeAll" xml:space="preserve"><value>Alle Benachrichtigungen ansehen</value></data>
+  <data name="Notification_PageTitle" xml:space="preserve"><value>Alle Benachrichtigungen</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Benachrichtigungen suchen...</value></data>
+  <data name="Notification_Filter_All" xml:space="preserve"><value>Alle</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Aktion nötig</value></data>
+  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Schichten</value></data>
+  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Genehmigungen</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Erledigt</value></data>
+  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Ungelesen</value></data>
+  <data name="Notification_Tab_All" xml:space="preserve"><value>Alle</value></data>
+  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Benachrichtigungen</value></data>
+  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Dringend</value></data>
+  <data name="Notification_Tag_Action" xml:space="preserve"><value>Aktion</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Dismiss</value></data>
-  <data name="Notification_HandledBy" xml:space="preserve"><value>Handled by {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-app notifications</value></data>
-  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>View →</value></data>
-  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>just now</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m ago</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h ago</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}d ago</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selected</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Verwerfen</value></data>
+  <data name="Notification_HandledBy" xml:space="preserve"><value>Bearbeitet von {0}, {1}</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-App-Benachrichtigungen</value></data>
+  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Ansehen →</value></data>
+  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>gerade eben</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>vor {0}m</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>vor {0}h</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>vor {0}d</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} ausgewählt</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Ausgewählte erledigen</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Ausgewählte verwerfen</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Mach mit</value></data>
@@ -1433,5 +1433,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Farben &amp; Klangzonen</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Jedes Barrio ist entsprechend seiner bevorzugten Klangzone eingefärbt (auf der Barrio-Seite bearbeitbar).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Alle Status</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Alle Kategorien</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Alle Melder</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Alle Zugewiesenen</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Mir zugewiesen</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Alle Teams</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Nur nicht zugewiesen</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Zurücksetzen</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>Keine Feedback-Berichte gefunden.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Nicht zugewiesen</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>Antwort nötig</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Bericht auswählen für Details</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Konversation</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Noch keine Nachrichten.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Nachricht eingeben...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Senden</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Gelöst {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>von {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Kein Team</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Screenshot</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>E-Mails abbestellen</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Von {0}-E-Mails abmelden?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Hallo {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Wenn du bestätigst, erhältst du keine {0}-E-Mails mehr von Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Abmeldung bestätigen</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>Abgemeldet</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Du erhältst keine {0}-E-Mails mehr von Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Du kannst alle Kommunikationseinstellungen verwalten unter</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>Kommunikationseinstellungen</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Zurück zur Startseite</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Abmelde-Link abgelaufen</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Dieser Abmelde-Link ist abgelaufen</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Bitte verwende den Link aus einer neueren E-Mail, oder</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>melde dich an, um deine Kommunikationseinstellungen zu verwalten</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Kommunikationseinstellungen</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Wähle, welche Mitteilungen du erhältst und wie.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>E-Mail</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Benachrichtigung</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Zurück zum Profil</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Zurück zum Dashboard</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>E-Mail</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Status</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Benachrichtigungen</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Profil-Sichtbarkeit</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Anmeldung</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Zusammenführung ausstehend</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verifiziert</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>Ausstehend</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>Nicht verifiziert</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Aktiv</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Als Ziel setzen</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Zuerst verifizieren</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Versteckt</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Alle humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>Meine Teams</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Koordinatoren + Vorstand</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Nur Vorstand</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Bist du sicher, dass du diese E-Mail entfernen möchtest?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>Google-Dienste-E-Mail</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Diese E-Mail wird für Google Groups und freigegebene Laufwerke verwendet.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>Deine @nobodies.team E-Mail wird automatisch verwendet.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>Google-Synchronisierung fehlgeschlagen. Die aktuelle E-Mail wurde von Google abgelehnt. Wähle eine andere E-Mail.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>Google-Synchronisierung funktioniert mit der aktuellen E-Mail.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Automatisch ausgewählt</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Abgelehnt</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Verwenden</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Schichtpräferenzen</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Schritt {0} von {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>Was kannst du gut?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Wähle Fähigkeiten aus, die du einsetzen möchtest. Du kannst sie jederzeit ändern.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>Wie arbeitest du am liebsten?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Hilf Koordinatoren, dich mit passenden Schichten zu verbinden.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Welche Sprachen sprichst du?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Das hilft uns, dich in Teams einzuteilen, in denen du gut kommunizieren kannst.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>Welche anderen Fähigkeiten hast du?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>Wann arbeitest du am liebsten?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Weitere Präferenzen</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>Welche anderen Sprachen sprichst du?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Weiter</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Schichten</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Freiwilligen-Optionen durchsuchen</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Abteilung</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Alle Abteilungen</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>Von</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>Bis</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Filter zurücksetzen</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Alle</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Aufbau</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Veranstaltung</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Abbau</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Nach Tag filtern:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Präferenzen festlegen</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Wähle Tags aus, die zur Art von Arbeit passen, die du magst. Passende Schichten werden mit einem Stern markiert.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Präferenzen speichern</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Schichten sind noch nicht geöffnet. Nur Koordinatoren und Admins können diese Seite sehen.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Noch keine Schichten verfügbar.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Alle {0}-Schichten sind voll.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Ende</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Für {0}-Termine anmelden</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Datum</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Belegt</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>Tage</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>gesamt</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Angemeldet (alle {0} Tage)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Angemeldet ({0} von {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Voll</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Hilfe nötig</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} Tag braucht Hilfe</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} Tage brauchen Hilfe</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>klicken zum Aufklappen</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Schicht</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Phase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Zeit</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Dauer</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Ganztägig</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Ganzer Tag</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essentiell</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Wichtig</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Alle Phasen</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Versteckt</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Passt zu deinen Präferenzen</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Anmelden</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>Schichten-Übersicht ist noch nicht geöffnet. Schau später wieder!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Kein aktives Event konfiguriert. Ein Admin muss zuerst die Event-Einstellungen einrichten.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Event-Einstellungen konfigurieren</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>Meine Schichten</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Kommende Schichten</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>Genehmigung ausstehend</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Vergangen</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Absagen</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Bist du sicher, dass du absagen möchtest?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Von allen {0} Tagen absagen?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Zurückziehen</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Noch keine Schicht-Anmeldungen.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Verfügbare Schichten durchsuchen</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>Kein aktives Event konfiguriert.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Allgemeine Verfügbarkeit</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Markiere, an welchen Tagen du helfen kannst. Koordinatoren können sehen, wer verfügbar ist.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Verfügbarkeit speichern</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Schicht-Dashboard</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} Schichten</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Datum</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Abteilung</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Alle Abteilungen</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtern</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Zurücksetzen</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Keine Schichten passen zu den aktuellen Filtern.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Schicht</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Datum / Zeit</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Plätze</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Priorität</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Humans suchen für: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Namen eingeben (min. 2 Zeichen)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>Keine humans gefunden.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>Suche fehlgeschlagen.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Terminkonflikt</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Recht</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Team</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Gesperrt</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>Ausstehend</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Teams:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Beigetreten {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Letzter Login {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Schichten</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} Plätze belegt</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans angemeldet</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} ausstehend</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Noch keine Schichten konfiguriert.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Enthält Schichten von {0} Sub-Team(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Schichten verwalten</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Medizinisch</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans verwaltet die Mitgliedschaft von Nobodies Collective und verarbeitet personenbezogene Daten gemäß DSGVO und spanischem Datenschutzrecht (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Verantwortlicher</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Ein spanischer gemeinnütziger Verein mit Sitz in Andalusien.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Für Datenschutzanfragen kontaktiere unseren Datenschutzbeauftragten unter:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Daten, die wir erheben</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Wir erheben und verarbeiten folgende Kategorien personenbezogener Daten:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Name, E-Mail-Adresse (aus der Google-Authentifizierung), Anzeigename</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Telefonnummer, Stadt, Land (optional)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Biografie, Teammitgliedschaften, Rollenzuweisungen</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>IP-Adresse und User-Agent (für Einwilligungsprotokolle)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Mitgliedsanträge und Motivationsschreiben</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Aufzeichnungen deiner Zustimmung zu rechtlichen Dokumenten</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Rechtsgrundlage der Verarbeitung</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Wir verarbeiten deine Daten auf folgender Grundlage:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Verarbeitung notwendig für die Mitgliederverwaltung</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Führung organisatorischer Aufzeichnungen und Kommunikation</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Einhaltung spanischer Vereinsvorschriften</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Für optionale Daten, die du freiwillig angibst</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Wie wir deine Daten verwenden</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Zur Verwaltung deiner Mitgliedschaft und Teamteilnahme</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Um mit dir über organisatorische Aktivitäten zu kommunizieren</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Zur Führung gesetzlich vorgeschriebener Aufzeichnungen</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Um Verbindungen zwischen humans zu ermöglichen (basierend auf deinen Sichtbarkeitseinstellungen)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Datenspeicherung</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Wir speichern deine Daten gemäß folgender Richtlinien:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Daten werden gespeichert, solange dein Konto aktiv ist</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Daten bis zu 7 Jahre gespeichert für gesetzliche Anforderungen</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Unbegrenzt gespeichert gemäß DSGVO-Anforderungen</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Nach 30-tägiger Frist anonymisiert</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Deine Rechte</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Gemäß DSGVO hast du folgende Rechte:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Eine Kopie deiner personenbezogenen Daten anfordern</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Berichtigung ungenauer Daten anfordern</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Löschung deiner Daten beantragen (&quot;Recht auf Vergessenwerden&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Deine Daten in maschinenlesbarem Format erhalten</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Einschränkung der Verarbeitung beantragen</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Widerspruch gegen bestimmte Arten der Verarbeitung einlegen</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Um diese Rechte auszuüben, besuche deine {0}-Einstellungen oder kontaktiere uns unter {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Datenschutz &amp; Daten</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Diese Website verwendet nur essenzielle Cookies, die benötigt werden für:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Benutzerauthentifizierung und Sitzungsverwaltung</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Anti-Fälschungs-Token für Formularsicherheit</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Cookie-Einwilligungspräferenz</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>Wir verwenden keine Analyse-, Werbe- oder Tracking-Cookies von Drittanbietern.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Datensicherheit</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Wir setzen angemessene technische und organisatorische Maßnahmen zum Schutz deiner Daten um, darunter:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Verschlüsselung bei der Übertragung (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Sichere Authentifizierung über Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Zugriffskontrollen und Audit-Protokollierung</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Regelmäßige Sicherheitsüberprüfungen</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Drittanbieter-Dienste</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Wir nutzen folgende Drittanbieter-Dienste:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Für sichere Authentifizierung</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Für Team-Ressourcenbereitstellung (freigegebene Laufwerke, Gruppen)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Änderungen dieser Richtlinie</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Wir können diese Datenschutzrichtlinie von Zeit zu Zeit aktualisieren. Wir werden aktive humans über wesentliche Änderungen per E-Mail benachrichtigen.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Kontakt &amp; Beschwerden</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Bei Fragen oder Bedenken zu dieser Richtlinie kontaktiere unseren Datenschutzbeauftragten unter {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Wenn du mit unserer Antwort nicht zufrieden bist, hast du das Recht, eine Beschwerde bei der Spanischen Datenschutzbehörde (AEPD) unter {0} einzureichen.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1319,44 +1319,44 @@
   <data name="Todo_ShiftInfo_Action" xml:space="preserve"><value>Completar info de turno</value></data>
 
   <!-- Notification Inbox -->
-  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Notification popup</value></data>
-  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>need action</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Close notifications</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>You're all caught up.</value></data>
-  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No unread notifications.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Needs your attention</value></data>
-  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recent</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informational</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Work queues</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Mark all as read</value></data>
-  <data name="Notification_SeeAll" xml:space="preserve"><value>See all notifications</value></data>
-  <data name="Notification_PageTitle" xml:space="preserve"><value>All notifications</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Search notifications...</value></data>
-  <data name="Notification_Filter_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Needs action</value></data>
-  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Shifts</value></data>
-  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvals</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Unread</value></data>
-  <data name="Notification_Tab_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
-  <data name="Notification_Tag_Action" xml:space="preserve"><value>Action</value></data>
+  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notificaciones</value></data>
+  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Ventana de notificaciones</value></data>
+  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notificaciones</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>requieren acción</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Cerrar notificaciones</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Estás al día.</value></data>
+  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No hay notificaciones sin leer.</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Requiere tu atención</value></data>
+  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recientes</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informativos</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resueltos</value></data>
+  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Colas de trabajo</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Marcar todo como leído</value></data>
+  <data name="Notification_SeeAll" xml:space="preserve"><value>Ver todas las notificaciones</value></data>
+  <data name="Notification_PageTitle" xml:space="preserve"><value>Todas las notificaciones</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Buscar notificaciones...</value></data>
+  <data name="Notification_Filter_All" xml:space="preserve"><value>Todas</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Requiere acción</value></data>
+  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Turnos</value></data>
+  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Aprobaciones</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resueltos</value></data>
+  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Sin leer</value></data>
+  <data name="Notification_Tab_All" xml:space="preserve"><value>Todas</value></data>
+  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notificaciones</value></data>
+  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgente</value></data>
+  <data name="Notification_Tag_Action" xml:space="preserve"><value>Acción</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Dismiss</value></data>
-  <data name="Notification_HandledBy" xml:space="preserve"><value>Handled by {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-app notifications</value></data>
-  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>View →</value></data>
-  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>just now</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m ago</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h ago</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}d ago</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selected</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Descartar</value></data>
+  <data name="Notification_HandledBy" xml:space="preserve"><value>Gestionado por {0}, {1}</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notificaciones en la aplicación</value></data>
+  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Ver →</value></data>
+  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>ahora mismo</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>hace {0}m</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>hace {0}h</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>hace {0}d</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} seleccionados</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolver seleccionados</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Descartar seleccionados</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Participa</value></data>
@@ -1435,5 +1435,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Colores y zonas de sonido</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Cada barrio está coloreado según su zona de sonido preferida (editable desde la página de tu barrio).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Comentarios</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Todos los estados</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Todas las categorías</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Todos los informantes</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Todos los asignados</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Asignado a mí</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Todos los equipos</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Solo sin asignar</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Limpiar</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>No se encontraron informes de comentarios.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Sin asignar</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>necesita respuesta</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Selecciona un informe para ver detalles</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversación</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Aún no hay mensajes.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Escribe un mensaje...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Enviar</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Resuelto {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>por {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Sin equipo</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Captura de pantalla</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Darse de baja de correos</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>¿Darse de baja de correos de {0}?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Hola {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Si confirmas, dejarás de recibir correos de {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Confirmar baja</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>Te has dado de baja</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Ya no recibirás correos de {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Puedes gestionar tus preferencias de comunicación desde tus</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>preferencias de comunicación</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Volver al inicio</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Enlace de baja caducado</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Este enlace de baja ha caducado</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Usa el enlace de un correo más reciente, o</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>inicia sesión para gestionar tus preferencias de comunicación</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Preferencias de comunicación</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Elige qué comunicaciones recibes y cómo.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Categoría</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>Correo</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Alerta</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Volver al perfil</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Volver al panel</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>Correo</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Estado</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notificaciones</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Visibilidad del perfil</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Inicio de sesión</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Fusión pendiente</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verificado</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>Pendiente</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>No verificado</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Activo</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Establecer como destino</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Verifica primero</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Oculto</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Todos los humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>Mis equipos</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinadores + Junta</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Solo junta</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>¿Seguro que quieres eliminar este correo?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>Correo de servicios de Google</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Este correo se usa para acceder a Grupos de Google y unidades compartidas.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>Tu correo @nobodies.team se usa automáticamente.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>La sincronización de Google falló. El correo actual fue rechazado por Google. Selecciona otro correo para reintentar.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>La sincronización de Google funciona con el correo actual.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Seleccionado automáticamente</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rechazado</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Usar este</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Preferencias de turnos</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Paso {0} de {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>¿En qué eres bueno/a?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Selecciona las habilidades que te gustaría usar. Puedes cambiarlas en cualquier momento.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>¿Cómo te gusta trabajar?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Ayuda a los coordinadores a asignarte turnos que se adapten a tu estilo y disponibilidad.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>¿Qué idiomas hablas?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Esto nos ayuda a ubicarte en equipos donde puedas comunicarte bien.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>¿Qué otras habilidades tienes?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>¿Cuándo prefieres trabajar?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Otras preferencias</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>¿Qué otros idiomas hablas?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continuar</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Turnos</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Explorar opciones de voluntariado</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Departamento</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Todos los departamentos</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>Desde</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>Hasta</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Limpiar filtros</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Todos</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Montaje</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Evento</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Desmontaje</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filtrar por etiqueta:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Configura tus preferencias</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Selecciona etiquetas que coincidan con el trabajo que te gusta. Los turnos coincidentes se resaltarán con una estrella.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Guardar preferencias</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Los turnos aún no están abiertos. Solo coordinadores y administradores pueden ver esta página.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Aún no hay turnos disponibles.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Todos los turnos de {0} están completos.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Inicio</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Fin</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Inscribirse en fechas de {0}</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Fecha</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Ocupados</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>días</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>total</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Inscrito (los {0} días)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Inscrito ({0} de {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Completo</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Necesita ayuda</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} día necesita ayuda</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} días necesitan ayuda</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>clic para expandir</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Fase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Hora</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Duración</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Todo el día</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Día completo</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Esencial</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Importante</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Todas las fases</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Oculto</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Coincide con tus preferencias</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Inscribirse</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La exploración de turnos aún no está abierta. ¡Vuelve más tarde!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No hay ningún evento activo configurado. Un administrador debe configurar los ajustes del evento primero.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configurar ajustes del evento</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>Mis turnos</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Próximos turnos</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>Pendiente de aprobación</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Pasados</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>¿Seguro que quieres cancelar?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>¿Cancelar todos los {0} días?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Retirar</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Aún no te has inscrito en ningún turno.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Explorar turnos disponibles</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>No hay evento activo configurado.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilidad general</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Marca los días que estás disponible para ayudar. Los coordinadores pueden ver quién está disponible al asignar turnos.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Guardar disponibilidad</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Panel de turnos</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} turnos</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Fecha</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Departamento</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Todos los departamentos</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtrar</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Limpiar</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Ningún turno coincide con los filtros actuales.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Fecha / Hora</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Plazas</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Prioridad</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Buscar humans para: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Escribe un nombre (mín. 2 caracteres)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>No se encontraron humans.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>La búsqueda falló.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Conflicto de horario</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Legal</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Equipo</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Suspendido</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>Pendiente</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Equipos:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Se unió en {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Último acceso {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Turnos</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} plazas ocupadas</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans inscritos</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} pendientes</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Aún no hay turnos configurados.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Incluye turnos de {0} subequipo(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Gestionar turnos</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Médico</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans gestiona la membresía de Nobodies Collective y procesa datos personales conforme al RGPD y la ley española de protección de datos (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Responsable del tratamiento</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Una asociación sin ánimo de lucro española registrada en Andalucía.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Para consultas sobre protección de datos, contacta con nuestro Delegado de Protección de Datos en:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Datos que recopilamos</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Recopilamos y procesamos las siguientes categorías de datos personales:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Nombre, correo electrónico (de la autenticación de Google), nombre para mostrar</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Teléfono, ciudad, país (opcional)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Biografía, pertenencia a equipos, asignaciones de roles</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>Dirección IP y agente de usuario (para registros de consentimiento)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Solicitudes de membresía y declaraciones de motivación</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Registros de tu aceptación de documentos legales</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Base legal del tratamiento</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Procesamos tus datos en base a:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Tratamiento necesario para la gestión de membresía</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Mantenimiento de registros organizativos y comunicación</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Cumplimiento de la normativa española sobre asociaciones</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Para datos opcionales que elijas proporcionar</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Cómo usamos tus datos</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Para gestionar tu membresía y participación en equipos</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Para comunicarnos contigo sobre actividades de la organización</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Para mantener registros de cumplimiento legal</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Para facilitar conexiones entre humans (según tu configuración de visibilidad)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Retención de datos</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Conservamos tus datos según las siguientes políticas:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Datos conservados mientras tu cuenta esté activa</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Datos conservados hasta 7 años por cumplimiento legal</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Conservados indefinidamente según lo requiere el RGPD</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonimizados después de un periodo de gracia de 30 días</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Tus derechos</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Según el RGPD, tienes los siguientes derechos:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Solicitar una copia de tus datos personales</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Solicitar la corrección de datos inexactos</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Solicitar la eliminación de tus datos (&quot;derecho al olvido&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Recibir tus datos en formato legible por máquina</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Solicitar la limitación del tratamiento</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Oponerte a ciertos tipos de tratamiento</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Para ejercer estos derechos, visita tu configuración de {0} o contáctanos en {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Privacidad y datos</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Este sitio solo usa cookies esenciales necesarias para:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Autenticación de usuario y gestión de sesiones</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Tokens anti-falsificación para seguridad de formularios</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Preferencia de consentimiento de cookies</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>No usamos cookies de análisis, publicidad ni seguimiento de terceros.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Seguridad de datos</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Implementamos medidas técnicas y organizativas apropiadas para proteger tus datos, incluyendo:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Cifrado en tránsito (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Autenticación segura vía Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Controles de acceso y registro de auditoría</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Revisiones de seguridad periódicas</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Servicios de terceros</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Usamos los siguientes servicios de terceros:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Para autenticación segura</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Para provisión de recursos de equipo (unidades compartidas, grupos)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Cambios a esta política</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Podemos actualizar esta política de privacidad periódicamente. Notificaremos a los humans activos sobre cambios significativos por correo.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contacto y reclamaciones</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Para preguntas o dudas sobre esta política, contacta con nuestro Delegado de Protección de Datos en {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si no estás satisfecho con nuestra respuesta, tienes derecho a presentar una reclamación ante la Agencia Española de Protección de Datos (AEPD) en {0}.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1318,43 +1318,43 @@
 
   <!-- Notification Inbox -->
   <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Notification popup</value></data>
+  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Popup de notifications</value></data>
   <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>need action</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Close notifications</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>You're all caught up.</value></data>
-  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No unread notifications.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Needs your attention</value></data>
-  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recent</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informational</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Work queues</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Mark all as read</value></data>
-  <data name="Notification_SeeAll" xml:space="preserve"><value>See all notifications</value></data>
-  <data name="Notification_PageTitle" xml:space="preserve"><value>All notifications</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Search notifications...</value></data>
-  <data name="Notification_Filter_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Needs action</value></data>
-  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Shifts</value></data>
-  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvals</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Unread</value></data>
-  <data name="Notification_Tab_All" xml:space="preserve"><value>All</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>nécessitent une action</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Fermer les notifications</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Vous êtes à jour.</value></data>
+  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>Aucune notification non lue.</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Nécessite votre attention</value></data>
+  <data name="Notification_Section_Recent" xml:space="preserve"><value>Récentes</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informationnelles</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Résolues</value></data>
+  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Files d'attente</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Tout marquer comme lu</value></data>
+  <data name="Notification_SeeAll" xml:space="preserve"><value>Voir toutes les notifications</value></data>
+  <data name="Notification_PageTitle" xml:space="preserve"><value>Toutes les notifications</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Rechercher des notifications...</value></data>
+  <data name="Notification_Filter_All" xml:space="preserve"><value>Toutes</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Action nécessaire</value></data>
+  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Quarts</value></data>
+  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approbations</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Résolues</value></data>
+  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Non lues</value></data>
+  <data name="Notification_Tab_All" xml:space="preserve"><value>Toutes</value></data>
   <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifications</value></data>
   <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
   <data name="Notification_Tag_Action" xml:space="preserve"><value>Action</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Dismiss</value></data>
-  <data name="Notification_HandledBy" xml:space="preserve"><value>Handled by {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-app notifications</value></data>
-  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>View →</value></data>
-  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>just now</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m ago</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h ago</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}d ago</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selected</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Ignorer</value></data>
+  <data name="Notification_HandledBy" xml:space="preserve"><value>Géré par {0}, {1}</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notifications dans l'application</value></data>
+  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Voir →</value></data>
+  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>à l'instant</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>il y a {0}m</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>il y a {0}h</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>il y a {0}j</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} sélectionné(s)</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Résoudre la sélection</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Ignorer la sélection</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Participe</value></data>
@@ -1433,5 +1433,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Couleurs &amp; zones sonores</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Chaque barrio est coloré selon sa zone sonore préférée (modifiable depuis la page de ton barrio).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Retours</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Tous les statuts</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Toutes les catégories</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Tous les signaleurs</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Tous les assignés</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Assigné à moi</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Toutes les équipes</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Non assignés uniquement</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Effacer</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>Aucun rapport trouvé.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Non assigné</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>réponse nécessaire</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Sélectionnez un rapport pour voir les détails</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversation</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Pas encore de messages.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Écrivez un message...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Envoyer</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Résolu {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>par {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Aucune équipe</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Capture d'écran</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Se désabonner des e-mails</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Se désabonner des e-mails {0} ?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Bonjour {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Si vous confirmez, vous ne recevrez plus les e-mails {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Confirmer le désabonnement</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>Vous êtes désabonné(e)</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Vous ne recevrez plus les e-mails {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Vous pouvez gérer vos préférences de communication depuis vos</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>préférences de communication</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Retour à l'accueil</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Lien de désabonnement expiré</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Ce lien de désabonnement a expiré</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Veuillez utiliser le lien d'un e-mail plus récent, ou</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>connectez-vous pour gérer vos préférences de communication</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Préférences de communication</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Choisissez quelles communications vous recevez et comment.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Catégorie</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>E-mail</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Alerte</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Retour au profil</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Retour au tableau de bord</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>E-mail</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Statut</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Visibilité du profil</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Connexion</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Fusion en attente</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Vérifié</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>En attente</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>Non vérifié</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Actif</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Définir comme cible</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Vérifiez d'abord</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Masqué</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Tous les humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>Mes équipes</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinateurs + Bureau</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Bureau uniquement</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Êtes-vous sûr de vouloir supprimer cet e-mail ?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>E-mail des services Google</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Cet e-mail est utilisé pour Google Groups et l'accès aux Drive partagés.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>Votre e-mail @nobodies.team est automatiquement utilisé.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>La synchronisation Google a échoué. L'e-mail actuel a été rejeté par Google. Sélectionnez un autre e-mail.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>La synchronisation Google fonctionne avec l'e-mail actuel.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Sélectionné automatiquement</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rejeté</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Utiliser</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Préférences de quarts</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Étape {0} sur {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>Qu'est-ce que vous savez faire ?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Sélectionnez les compétences que vous souhaitez utiliser. Vous pouvez les modifier à tout moment.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>Comment aimez-vous travailler ?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Aidez les coordinateurs à vous associer des quarts adaptés à votre style et disponibilité.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Quelles langues parlez-vous ?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Cela nous aide à vous placer dans des équipes où vous pouvez bien communiquer.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>Quelles autres compétences avez-vous ?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>Quand préférez-vous travailler ?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Autres préférences</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>Quelles autres langues parlez-vous ?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continuer</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Quarts</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Parcourir les options de bénévolat</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Département</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Tous les départements</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>De</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>À</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Effacer les filtres</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Tous</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Montage</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Événement</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Démontage</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filtrer par tag :</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Définir vos préférences</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Sélectionnez les tags correspondant au type de travail que vous aimez. Les quarts correspondants seront mis en valeur avec une étoile.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Enregistrer les préférences</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Les quarts ne sont pas encore ouverts. Seuls les coordinateurs et admins peuvent voir cette page.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Aucun quart disponible pour le moment.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Tous les quarts de {0} sont complets.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Début</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Fin</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>S'inscrire aux dates de {0}</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Rempli</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>jours</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>total</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Inscrit ({0} jours)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Inscrit ({0} sur {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Complet</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Aide nécessaire</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} jour a besoin d'aide</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} jours ont besoin d'aide</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>cliquez pour développer</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Quart</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Phase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Heure</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Durée</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Toute la journée</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Journée entière</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essentiel</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Toutes les phases</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Masqué</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Correspond à vos préférences</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>S'inscrire</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La navigation des quarts n'est pas encore ouverte. Revenez plus tard !</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Aucun événement actif configuré. Un administrateur doit d'abord configurer les paramètres de l'événement.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configurer les paramètres de l'événement</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>Mes quarts</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Prochains quarts</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>En attente d'approbation</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Passés</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Se retirer</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Êtes-vous sûr de vouloir vous retirer ?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Se retirer des {0} jours ?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Retirer</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Aucune inscription aux quarts pour le moment.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Parcourir les quarts disponibles</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>Aucun événement actif configuré.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilité générale</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Indiquez les jours où vous êtes disponible. Les coordinateurs peuvent voir qui est disponible lors de l'attribution des quarts.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Enregistrer la disponibilité</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Tableau de bord des quarts</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} quarts</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Département</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Tous les départements</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtrer</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Effacer</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Aucun quart ne correspond aux filtres actuels.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Quart</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Date / Heure</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Places</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Priorité</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Rechercher des humans pour : {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Tapez un nom (min. 2 caractères)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>Aucun humans trouvé.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>La recherche a échoué.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Conflit d'horaire</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Juridique</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Équipe</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Suspendu</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>En attente</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Équipes :</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Inscrit(e) en {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Dernière connexion {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Quarts</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} places remplies</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans inscrits</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} en attente</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Aucun quart configuré pour le moment.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Inclut les quarts de {0} sous-équipe(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Gérer les quarts</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Médical</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans gère les adhésions de Nobodies Collective et traite les données personnelles conformément au RGPD et à la loi espagnole sur la protection des données (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Responsable du traitement</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Une association espagnole à but non lucratif enregistrée en Andalousie.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Pour les questions relatives à la protection des données, contactez notre Délégué à la Protection des Données à :</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Données que nous collectons</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Nous collectons et traitons les catégories suivantes de données personnelles :</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Nom, adresse e-mail (authentification Google), nom d'affichage</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Numéro de téléphone, ville, pays (optionnel)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Bio, adhésions aux équipes, attributions de rôles</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>Adresse IP et agent utilisateur (pour les registres de consentement)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Demandes d'adhésion et lettres de motivation</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Enregistrements de votre accord aux documents juridiques</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Base juridique du traitement</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Nous traitons vos données sur la base de :</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Traitement nécessaire à la gestion des adhésions</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Tenue des registres organisationnels et communication</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Conformité aux réglementations espagnoles sur les associations</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Pour les données optionnelles que vous choisissez de fournir</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Comment nous utilisons vos données</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Pour gérer votre adhésion et participation aux équipes</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Pour communiquer avec vous au sujet des activités de l'organisation</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Pour maintenir les registres de conformité légale</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Pour faciliter les connexions entre humans (selon vos paramètres de visibilité)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Conservation des données</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Nous conservons vos données selon les politiques suivantes :</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Données conservées tant que votre compte est actif</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Données conservées jusqu'à 7 ans pour conformité légale</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Conservés indéfiniment conformément au RGPD</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonymisées après un délai de grâce de 30 jours</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Vos droits</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>En vertu du RGPD, vous avez les droits suivants :</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Demander une copie de vos données personnelles</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Demander la correction de données inexactes</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Demander la suppression de vos données (« droit à l'oubli »)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Recevoir vos données dans un format lisible par machine</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Demander la limitation du traitement</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>S'opposer à certains types de traitement</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Pour exercer ces droits, visitez vos paramètres {0} ou contactez-nous à {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Confidentialité &amp; données</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Ce site n'utilise que des cookies essentiels nécessaires pour :</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Authentification des utilisateurs et gestion des sessions</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Jetons anti-falsification pour la sécurité des formulaires</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Préférence de consentement aux cookies</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>Nous n'utilisons pas de cookies d'analyse, de publicité ou de suivi tiers.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Sécurité des données</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Nous mettons en œuvre des mesures techniques et organisationnelles appropriées pour protéger vos données, notamment :</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Chiffrement en transit (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Authentification sécurisée via Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Contrôles d'accès et journalisation d'audit</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Révisions de sécurité régulières</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Services tiers</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Nous utilisons les services tiers suivants :</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Pour une authentification sécurisée</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Pour le provisionnement des ressources d'équipe (drives partagés, groupes)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Modifications de cette politique</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Nous pouvons mettre à jour cette politique de confidentialité de temps en temps. Nous informerons les humans actifs des changements importants par e-mail.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contact &amp; réclamations</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Pour toute question ou préoccupation concernant cette politique, contactez notre Délégué à la Protection des Données à {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si vous n'êtes pas satisfait de notre réponse, vous avez le droit de déposer une plainte auprès de l'Agence Espagnole de Protection des Données (AEPD) à {0}.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1317,44 +1317,44 @@
   <data name="Todo_ShiftInfo_Action" xml:space="preserve"><value>Compila info turno</value></data>
 
   <!-- Notification Inbox -->
-  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Notification popup</value></data>
-  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>need action</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Close notifications</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>You're all caught up.</value></data>
-  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No unread notifications.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Needs your attention</value></data>
-  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recent</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informational</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Work queues</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Mark all as read</value></data>
-  <data name="Notification_SeeAll" xml:space="preserve"><value>See all notifications</value></data>
-  <data name="Notification_PageTitle" xml:space="preserve"><value>All notifications</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Search notifications...</value></data>
-  <data name="Notification_Filter_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Needs action</value></data>
-  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Shifts</value></data>
-  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvals</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Unread</value></data>
-  <data name="Notification_Tab_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
-  <data name="Notification_Tag_Action" xml:space="preserve"><value>Action</value></data>
+  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifiche</value></data>
+  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Popup notifiche</value></data>
+  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifiche</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>richiedono azione</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Chiudi notifiche</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Sei in pari.</value></data>
+  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>Nessuna notifica non letta.</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Richiede la tua attenzione</value></data>
+  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recenti</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informativi</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Risolte</value></data>
+  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Code di lavoro</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Segna tutto come letto</value></data>
+  <data name="Notification_SeeAll" xml:space="preserve"><value>Vedi tutte le notifiche</value></data>
+  <data name="Notification_PageTitle" xml:space="preserve"><value>Tutte le notifiche</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Cerca notifiche...</value></data>
+  <data name="Notification_Filter_All" xml:space="preserve"><value>Tutte</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Azione necessaria</value></data>
+  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Turni</value></data>
+  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvazioni</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Risolte</value></data>
+  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Non lette</value></data>
+  <data name="Notification_Tab_All" xml:space="preserve"><value>Tutte</value></data>
+  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifiche</value></data>
+  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgente</value></data>
+  <data name="Notification_Tag_Action" xml:space="preserve"><value>Azione</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Dismiss</value></data>
-  <data name="Notification_HandledBy" xml:space="preserve"><value>Handled by {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-app notifications</value></data>
-  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>View →</value></data>
-  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>just now</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m ago</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h ago</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}d ago</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selected</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Ignora</value></data>
+  <data name="Notification_HandledBy" xml:space="preserve"><value>Gestito da {0}, {1}</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notifiche in-app</value></data>
+  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Vedi →</value></data>
+  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>proprio ora</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m fa</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h fa</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}g fa</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selezionati</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Risolvi selezionati</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Ignora selezionati</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Partecipa</value></data>
@@ -1433,5 +1433,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Colori &amp; zone sonore</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Ogni barrio è colorato in base alla sua zona sonora preferita (modificabile dalla pagina del barrio).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Tutti gli stati</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Tutte le categorie</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Tutti i segnalatori</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Tutti gli assegnatari</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Assegnato a me</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Tutti i team</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Solo non assegnati</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Cancella</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>Nessun rapporto trovato.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Non assegnato</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>risposta necessaria</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Seleziona un rapporto per i dettagli</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversazione</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Ancora nessun messaggio.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Scrivi un messaggio...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Invia</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Risolto {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>da {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Nessun team</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Screenshot</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Annulla iscrizione e-mail</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Annullare l'iscrizione alle e-mail {0}?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Ciao {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Se confermi, non riceverai più e-mail {0} da Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Conferma annullamento</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>Iscrizione annullata</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Non riceverai più e-mail {0} da Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Puoi gestire le preferenze di comunicazione dalle tue</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>preferenze di comunicazione</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Torna alla home</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Link di annullamento scaduto</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Questo link di annullamento è scaduto</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Usa il link da un'e-mail più recente, o</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>accedi per gestire le preferenze di comunicazione</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Preferenze di comunicazione</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Scegli quali comunicazioni ricevere e come.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Categoria</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>E-mail</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Avviso</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Torna al profilo</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Torna alla dashboard</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>E-mail</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Stato</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notifiche</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Visibilità profilo</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Accesso</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Unione in sospeso</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verificata</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>In sospeso</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>Non verificata</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Attivo</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Imposta come destinazione</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Verifica prima</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Nascosto</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Tutti gli humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>I miei team</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinatori + Consiglio</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Solo consiglio</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Sei sicuro di voler rimuovere questa e-mail?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>E-mail servizi Google</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Questa e-mail viene usata per Google Groups e Drive condivisi.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>La tua e-mail @nobodies.team viene usata automaticamente.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>Sincronizzazione Google fallita. L'e-mail attuale è stata rifiutata da Google. Seleziona un'altra e-mail.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>La sincronizzazione Google funziona con l'e-mail attuale.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Selezionata automaticamente</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rifiutata</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Usa questa</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Preferenze turni</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Passaggio {0} di {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>In cosa sei bravo/a?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Seleziona le abilità che vorresti usare. Puoi cambiarle in qualsiasi momento.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>Come ti piace lavorare?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Aiuta i coordinatori ad assegnarti turni adatti al tuo stile e disponibilità.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Quali lingue parli?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Questo ci aiuta ad inserirti in team dove puoi comunicare bene.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>Quali altre abilità hai?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>Quando preferisci lavorare?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Altre preferenze</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>Quali altre lingue parli?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continua</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Turni</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Sfoglia opzioni di volontariato</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Dipartimento</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Tutti i dipartimenti</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>Da</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>A</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Cancella filtri</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Tutti</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Montaggio</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Evento</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Smontaggio</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filtra per tag:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Imposta le tue preferenze</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Seleziona i tag che corrispondono al tipo di lavoro che ti piace. I turni corrispondenti saranno evidenziati con una stella.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Salva preferenze</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>I turni non sono ancora aperti. Solo coordinatori e admin possono vedere questa pagina.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Nessun turno disponibile al momento.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Tutti i turni di {0} sono completi.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Inizio</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Fine</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Iscriviti per le date di {0}</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Occupati</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>giorni</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>totale</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Iscritto (tutti i {0} giorni)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Iscritto ({0} di {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Completo</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Serve aiuto</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} giorno ha bisogno di aiuto</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} giorni hanno bisogno di aiuto</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>clicca per espandere</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Fase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Ora</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Durata</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Tutto il giorno</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Giornata intera</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essenziale</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Importante</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Tutte le fasi</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Nascosto</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Corrisponde alle tue preferenze</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Iscriviti</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La consultazione dei turni non è ancora aperta. Torna più tardi!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Nessun evento attivo configurato. Un amministratore deve prima configurare le impostazioni dell'evento.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configura impostazioni evento</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>I miei turni</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Prossimi turni</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>In attesa di approvazione</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Passati</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Ritirati</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Sei sicuro di volerti ritirare?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Ritirarsi da tutti i {0} giorni?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Ritira</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Nessuna iscrizione ai turni ancora.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Sfoglia turni disponibili</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>Nessun evento attivo configurato.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilità generale</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Segna i giorni in cui sei disponibile. I coordinatori possono vedere chi è disponibile quando assegnano i turni.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Salva disponibilità</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Dashboard turni</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} turni</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Dipartimento</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Tutti i dipartimenti</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtra</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Cancella</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Nessun turno corrisponde ai filtri attuali.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Data / Ora</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Posti</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Priorità</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Cerca humans per: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Digita un nome (min. 2 caratteri)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>Nessun humans trovato.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>Ricerca fallita.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Conflitto di orario</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Legale</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Staff</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Sospeso</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>In sospeso</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Team:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Iscritto/a il {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Ultimo accesso {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Turni</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} posti occupati</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans iscritti</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} in sospeso</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Nessun turno configurato ancora.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Include turni da {0} sotto-team</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Gestisci turni</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Medico</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans gestisce l'appartenenza a Nobodies Collective e tratta i dati personali in conformità con il GDPR e la legge spagnola sulla protezione dei dati (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Titolare del trattamento</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Un'associazione senza scopo di lucro spagnola registrata in Andalusia.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Per richieste sulla protezione dei dati, contatta il nostro Responsabile della Protezione dei Dati a:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Dati che raccogliamo</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Raccogliamo e trattiamo le seguenti categorie di dati personali:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Nome, indirizzo e-mail (dall'autenticazione Google), nome visualizzato</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Numero di telefono, città, paese (opzionale)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Biografia, appartenenze ai team, assegnazioni di ruolo</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>Indirizzo IP e user agent (per i registri di consenso)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Domande di adesione e dichiarazioni di motivazione</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Registri del tuo consenso ai documenti legali</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Base giuridica del trattamento</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Trattiamo i tuoi dati sulla base di:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Trattamento necessario per la gestione dell'adesione</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Mantenimento dei registri organizzativi e comunicazione</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Conformità alle normative spagnole sulle associazioni</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Per i dati opzionali che scegli di fornire</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Come utilizziamo i tuoi dati</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Per gestire la tua adesione e partecipazione ai team</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Per comunicare con te riguardo le attività dell'organizzazione</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Per mantenere i registri di conformità legale</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Per facilitare connessioni tra humans (in base alle tue impostazioni di visibilità)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Conservazione dei dati</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Conserviamo i tuoi dati secondo le seguenti politiche:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Dati conservati finché il tuo account è attivo</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Dati conservati fino a 7 anni per conformità legale</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Conservati indefinitamente come richiesto dal GDPR</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonimizzati dopo un periodo di grazia di 30 giorni</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>I tuoi diritti</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Ai sensi del GDPR, hai i seguenti diritti:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Richiedere una copia dei tuoi dati personali</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Richiedere la correzione di dati inesatti</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Richiedere la cancellazione dei tuoi dati (&quot;diritto all'oblio&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Ricevere i tuoi dati in formato leggibile da macchina</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Richiedere la limitazione del trattamento</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Opporsi a determinati tipi di trattamento</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Per esercitare questi diritti, visita le impostazioni {0} o contattaci a {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Privacy e dati</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookie</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Questo sito utilizza solo cookie essenziali necessari per:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Autenticazione utente e gestione delle sessioni</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Token anti-falsificazione per la sicurezza dei moduli</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Preferenza di consenso ai cookie</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>Non utilizziamo cookie di analisi, pubblicità o tracciamento di terze parti.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Sicurezza dei dati</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Implementiamo misure tecniche e organizzative appropriate per proteggere i tuoi dati, tra cui:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Crittografia in transito (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Autenticazione sicura tramite Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Controlli di accesso e registrazione audit</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Revisioni di sicurezza regolari</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Servizi di terze parti</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Utilizziamo i seguenti servizi di terze parti:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Per l'autenticazione sicura</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Per il provisioning delle risorse del team (drive condivisi, gruppi)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Modifiche a questa politica</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Potremmo aggiornare questa politica sulla privacy di tanto in tanto. Notificheremo gli humans attivi dei cambiamenti significativi via e-mail.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contatti e reclami</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Per domande o dubbi su questa politica, contatta il nostro Responsabile della Protezione dei Dati a {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Se non sei soddisfatto della nostra risposta, hai il diritto di presentare un reclamo all'Agenzia Spagnola per la Protezione dei Dati (AEPD) a {0}.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1454,4 +1454,256 @@
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Colours &amp; sound zones</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Each barrio is coloured by its preferred sound zone (editable from your barrio page).</value></data>
 
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>All Statuses</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>All Categories</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>All Reporters</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>All Assignees</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Assigned to me</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>All Teams</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Unassigned only</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Clear</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>No feedback reports found.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Unassigned</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>needs reply</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Select a report to view details</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversation</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>No messages yet.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Type a message...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Send</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Resolved {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>by {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>No team</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Screenshot</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Unsubscribe from Emails</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Unsubscribe from {0} emails?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Hi {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>If you confirm, you will no longer receive {0} emails from Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Confirm Unsubscribe</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>You've been unsubscribed</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>You will no longer receive {0} emails from Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>You can manage all your communication preferences from your</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>communication preferences</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Back to home</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Unsubscribe link expired</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>This unsubscribe link has expired</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Please use the link from a more recent email, or</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>sign in to manage your communication preferences</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Communication Preferences</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Choose which communications you receive and how.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Category</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>Email</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Alert</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Back to Profile</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Back to Dashboard</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>Email</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Status</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Profile Visibility</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Sign-in</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Merge pending</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verified</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>Pending</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>Unverified</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Active</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Set as target</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Verify first</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Hidden</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>All humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>My teams</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinators + Board</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Board only</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Are you sure you want to remove this email?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>Google Services Email</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>This email is used for Google Groups and Shared Drive access.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>Your @nobodies.team email is automatically used.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>Google sync failed. The current email was rejected by Google. Select a different email below to retry sync.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>Google sync is working with the current email.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Auto-selected</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rejected</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Use this</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Shift Preferences</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Step {0} of {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>What are you good at?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Select skills you'd like to use. You can change these anytime.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>How do you like to work?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Help coordinators match you with shifts that fit your style and availability.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Which languages do you speak?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>This helps us match you with teams where you can communicate well.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>What other skills do you have?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>When do you prefer to work?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Other preferences</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>What other languages do you speak?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continue</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Shifts</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Browse Volunteer Options</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Department</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>All Departments</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>From</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>To</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Clear Filters</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>All</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Set-up</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Event</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Strike</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filter by tag:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Set your preferences</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Select tags that match the kind of work you enjoy. Matching shifts will be highlighted with a star.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Save Preferences</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Shifts aren't open yet. Only coordinators and admins can see this page.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>No shifts available yet.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>All {0} shifts are full.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>End</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Sign up for {0} dates</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Filled</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>days</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>total</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Signed up (all {0} days)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Signed up ({0} of {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Full</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Needs help</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} day needs help</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} days need help</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>click to expand</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Shift</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Phase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Time</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Duration</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>All day</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Full day</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essential</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>All Phases</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Hidden</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Matches your preferences</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Sign Up</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>Shift browsing is not yet open. Check back later!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No active event is configured. An admin needs to set up event settings first.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configure Event Settings</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>My Shifts</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Upcoming Shifts</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>Pending Approval</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Past</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Bail</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Are you sure you want to bail?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Bail from all {0} days?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Withdraw</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>No shift signups yet.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Browse available shifts</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>No active event configured.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>General Availability</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Mark which days you're available to help. Coordinators can see who's in the pool when assigning shifts.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Save Availability</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Shift Dashboard</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} shifts</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Department</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>All departments</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filter</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Clear</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>No shifts match the current filters.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Shift</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Date / Time</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Slots</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Priority</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Search humans for: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Type a name (min 2 chars)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>No humans found.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>Search failed.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Schedule conflict</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Legal</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Staff</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Suspended</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>Pending</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Teams:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Joined {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Last login {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Shifts</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} slots filled</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans signed up</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} pending</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>No shifts configured yet.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Includes shifts from {0} sub-team(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Manage Shifts</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Medical</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans manages membership for Nobodies Collective and processes personal data in accordance with GDPR and Spanish data protection law (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Data Controller</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>A Spanish nonprofit association registered in Andalucia.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>For data protection inquiries, contact our Data Protection Officer at:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Data We Collect</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>We collect and process the following categories of personal data:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Name, email address (from Google authentication), display name/burner name</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Phone number, city, country (optional)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Bio, team memberships, role assignments</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>IP address and user agent (for consent records)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Membership applications and motivation statements</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Records of your agreement to legal documents</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Legal Basis for Processing</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>We process your data based on:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Processing necessary for membership management</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Maintaining organizational records and communication</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Compliance with Spanish nonprofit regulations</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>For optional data you choose to provide</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>How We Use Your Data</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>To manage your membership and team participation</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>To communicate with you about organizational activities</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>To maintain legal compliance records</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>To facilitate connections between humans (based on your visibility settings)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Data Retention</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>We retain your data according to the following policies:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Data retained while your account is active</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Data retained for up to 7 years for legal compliance</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Retained indefinitely as required for GDPR compliance</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonymized after 30-day grace period</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Your Rights</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Under GDPR, you have the following rights:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Request a copy of your personal data</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Request correction of inaccurate data</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Request deletion of your data (&quot;right to be forgotten&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Receive your data in a machine-readable format</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Request limitation of processing</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Object to certain types of processing</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>To exercise these rights, visit your {0} settings or contact us at {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Privacy &amp; Data</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>This site uses only essential cookies required for:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>User authentication and session management</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Anti-forgery tokens for form security</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Cookie consent preference</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>We do not use analytics, advertising, or third-party tracking cookies.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Data Security</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>We implement appropriate technical and organizational measures to protect your data, including:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Encryption in transit (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Secure authentication via Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Access controls and audit logging</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Regular security reviews</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Third-Party Services</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>We use the following third-party services:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>For secure authentication</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>For team resource provisioning (shared drives, groups)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Changes to This Policy</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>We may update this privacy policy from time to time. We will notify active humans of significant changes via email.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contact &amp; Complaints</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>For questions or concerns about this policy, contact our Data Protection Officer at {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>If you are not satisfied with our response, you have the right to lodge a complaint with the Spanish Data Protection Agency (AEPD) at {0}.</value><comment>{0} = AEPD URL</comment></data>
+
+
 </root>

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -1,24 +1,19 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace Humans.Web.ViewComponents;
 
 public class AuditLogViewComponent : ViewComponent
 {
     private readonly IAuditLogService _auditLogService;
-    private readonly HumansDbContext _dbContext;
     private readonly ILogger<AuditLogViewComponent> _logger;
 
     public AuditLogViewComponent(
         IAuditLogService auditLogService,
-        HumansDbContext dbContext,
         ILogger<AuditLogViewComponent> logger)
     {
         _auditLogService = auditLogService;
-        _dbContext = dbContext;
         _logger = logger;
     }
 
@@ -54,7 +49,6 @@ public class AuditLogViewComponent : ViewComponent
                 entityType, entityId, userId, actionList, limit);
 
             // Batch-load display names for all referenced user IDs
-            // (actors, subjects via EntityId for User/Profile types, and RelatedEntityId for User types)
             var userIds = model.Entries
                 .SelectMany(e => new Guid?[]
                 {
@@ -67,13 +61,7 @@ public class AuditLogViewComponent : ViewComponent
                 .Distinct()
                 .ToList();
 
-            if (userIds.Count > 0)
-            {
-                model.UserDisplayNames = await _dbContext.Users
-                    .AsNoTracking()
-                    .Where(u => userIds.Contains(u.Id))
-                    .ToDictionaryAsync(u => u.Id, u => u.DisplayName);
-            }
+            model.UserDisplayNames = await _auditLogService.GetUserDisplayNamesAsync(userIds);
 
             // Batch-load team names for entries that reference teams
             var teamIds = model.Entries
@@ -87,13 +75,7 @@ public class AuditLogViewComponent : ViewComponent
                 .Distinct()
                 .ToList();
 
-            if (teamIds.Count > 0)
-            {
-                model.TeamNames = await _dbContext.Teams
-                    .AsNoTracking()
-                    .Where(t => teamIds.Contains(t.Id))
-                    .ToDictionaryAsync(t => t.Id, t => (t.Name, t.Slug));
-            }
+            model.TeamNames = await _auditLogService.GetTeamNamesAsync(teamIds);
         }
         catch (Exception ex)
         {

--- a/src/Humans.Web/ViewComponents/MyGoogleResourcesViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/MyGoogleResourcesViewComponent.cs
@@ -1,24 +1,23 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 
 namespace Humans.Web.ViewComponents;
 
 public class MyGoogleResourcesViewComponent : ViewComponent
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly ITeamService _teamService;
     private readonly UserManager<User> _userManager;
     private readonly ILogger<MyGoogleResourcesViewComponent> _logger;
 
     public MyGoogleResourcesViewComponent(
-        HumansDbContext dbContext,
+        ITeamService teamService,
         UserManager<User> userManager,
         ILogger<MyGoogleResourcesViewComponent> logger)
     {
-        _dbContext = dbContext;
+        _teamService = teamService;
         _userManager = userManager;
         _logger = logger;
     }
@@ -31,45 +30,25 @@ public class MyGoogleResourcesViewComponent : ViewComponent
             if (user is null)
                 return Content(string.Empty);
 
-            // Get the user's active team memberships with their Google resources
-            var teamResources = await _dbContext.TeamMembers
-                .AsNoTracking()
-                .Where(tm => tm.UserId == user.Id && tm.LeftAt == null)
-                .Select(tm => new
-                {
-                    TeamName = tm.Team.Name,
-                    TeamSlug = tm.Team.Slug,
-                    Resources = tm.Team.GoogleResources
-                        .Where(r => r.IsActive)
-                        .Select(r => new MyGoogleResourceItem
-                        {
-                            Name = r.Name,
-                            ResourceType = r.ResourceType,
-                            Url = r.Url
-                        })
-                        .ToList()
-                })
-                .Where(t => t.Resources.Count > 0)
-                .OrderBy(t => t.TeamName)
-                .ToListAsync();
+            var resources = await _teamService.GetUserTeamGoogleResourcesAsync(user.Id);
 
-            if (teamResources.Count == 0)
+            if (resources.Count == 0)
                 return Content(string.Empty);
 
-            var model = new MyGoogleResourcesViewModel();
-
-            foreach (var team in teamResources)
+            var model = new MyGoogleResourcesViewModel
             {
-                foreach (var resource in team.Resources)
+                Resources = resources.Select(r => new MyGoogleResourceWithTeam
                 {
-                    model.Resources.Add(new MyGoogleResourceWithTeam
+                    TeamName = r.TeamName,
+                    TeamSlug = r.TeamSlug,
+                    Resource = new MyGoogleResourceItem
                     {
-                        TeamName = team.TeamName,
-                        TeamSlug = team.TeamSlug,
-                        Resource = resource
-                    });
-                }
-            }
+                        Name = r.ResourceName,
+                        ResourceType = r.ResourceType,
+                        Url = r.Url
+                    }
+                }).ToList()
+            };
 
             return View(model);
         }

--- a/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
@@ -1,25 +1,22 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Humans.Application;
 using Humans.Application.Interfaces;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 
 namespace Humans.Web.ViewComponents;
 
 public class NavBadgesViewComponent : ViewComponent
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IOnboardingService _onboardingService;
     private readonly IFeedbackService _feedbackService;
     private readonly IMemoryCache _cache;
 
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(2);
 
-    public NavBadgesViewComponent(HumansDbContext dbContext, IFeedbackService feedbackService, IMemoryCache cache)
+    public NavBadgesViewComponent(IOnboardingService onboardingService, IFeedbackService feedbackService, IMemoryCache cache)
     {
-        _dbContext = dbContext;
+        _onboardingService = onboardingService;
         _feedbackService = feedbackService;
         _cache = cache;
     }
@@ -30,9 +27,7 @@ public class NavBadgesViewComponent : ViewComponent
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;
 
-            var reviewCount = await _dbContext.Profiles
-                .CountAsync(p => !p.IsApproved && p.RejectedAt == null);
-
+            var reviewCount = await _onboardingService.GetPendingReviewCountAsync();
             var feedbackCount = await _feedbackService.GetActionableCountAsync();
 
             return (Review: reviewCount, Feedback: feedbackCount);
@@ -66,9 +61,7 @@ public class NavBadgesViewComponent : ViewComponent
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;
 
-            return await _dbContext.Applications
-                .CountAsync(a => a.Status == ApplicationStatus.Submitted
-                    && !a.BoardVotes.Any(v => v.BoardMemberUserId == currentUserId));
+            return await _onboardingService.GetUnvotedApplicationCountAsync(currentUserId);
         });
     }
 }

--- a/src/Humans.Web/ViewComponents/NotificationBellViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NotificationBellViewComponent.cs
@@ -1,9 +1,7 @@
 using Humans.Application;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
+using Humans.Application.Interfaces;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using System.Security.Claims;
 
@@ -11,14 +9,14 @@ namespace Humans.Web.ViewComponents;
 
 public class NotificationBellViewComponent : ViewComponent
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly INotificationInboxService _notificationInboxService;
     private readonly IMemoryCache _cache;
 
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(2);
 
-    public NotificationBellViewComponent(HumansDbContext dbContext, IMemoryCache cache)
+    public NotificationBellViewComponent(INotificationInboxService notificationInboxService, IMemoryCache cache)
     {
-        _dbContext = dbContext;
+        _notificationInboxService = notificationInboxService;
         _cache = cache;
     }
 
@@ -34,17 +32,7 @@ public class NotificationBellViewComponent : ViewComponent
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;
 
-            var actionableCount = await _dbContext.NotificationRecipients
-                .CountAsync(nr => nr.UserId == userId.Value &&
-                                  nr.ReadAt == null &&
-                                  nr.Notification.ResolvedAt == null &&
-                                  nr.Notification.Class == NotificationClass.Actionable);
-
-            var informationalCount = await _dbContext.NotificationRecipients
-                .CountAsync(nr => nr.UserId == userId.Value &&
-                                  nr.ReadAt == null &&
-                                  nr.Notification.ResolvedAt == null &&
-                                  nr.Notification.Class == NotificationClass.Informational);
+            var (actionableCount, informationalCount) = await _notificationInboxService.GetUnreadBadgeCountsAsync(userId.Value);
 
             return new NotificationBadgeViewModel
             {

--- a/src/Humans.Web/Views/Admin/AudienceSegmentation.cshtml
+++ b/src/Humans.Web/Views/Admin/AudienceSegmentation.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Audience Segmentation";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Audience Segmentation</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Audience Segmentation</h1>
 </div>

--- a/src/Humans.Web/Views/Admin/EditLegalDocument.cshtml
+++ b/src/Humans.Web/Views/Admin/EditLegalDocument.cshtml
@@ -93,7 +93,7 @@
                                 <strong>@version.VersionNumber</strong>
                                 @if (version.RequiresReConsent)
                                 {
-                                    <span class="badge bg-warning ms-1" title="Members must re-consent">Re-consent</span>
+                                    <span class="badge bg-warning ms-1" title="Humans must re-consent">Re-consent</span>
                                 }
                             </td>
                             <td>

--- a/src/Humans.Web/Views/Admin/LegalDocuments.cshtml
+++ b/src/Humans.Web/Views/Admin/LegalDocuments.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Legal Documents";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Board" asp-action="Index">Board</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Legal Documents</li>
+    </ol>
+</nav>
+
 <h1>Legal Documents</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Admin/Logs.cshtml
+++ b/src/Humans.Web/Views/Admin/Logs.cshtml
@@ -6,7 +6,14 @@
 }
 
 <div class="container-fluid px-4">
-    <div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <nav aria-label="breadcrumb" class="mt-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-action="Index">Admin</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Application Logs</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
         <h1>Application Logs</h1>
         <span class="text-muted">Showing @Model.Count of last 200 (in-memory buffer)</span>
     </div>

--- a/src/Humans.Web/Views/AdminDuplicateAccounts/Detail.cshtml
+++ b/src/Humans.Web/Views/AdminDuplicateAccounts/Detail.cshtml
@@ -3,6 +3,14 @@
     ViewData["Title"] = "Resolve Duplicate Account";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item"><a asp-action="Index">Duplicate Accounts</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Resolve</li>
+    </ol>
+</nav>
+
 <h1>Resolve Duplicate Account</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/AdminDuplicateAccounts/Index.cshtml
+++ b/src/Humans.Web/Views/AdminDuplicateAccounts/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Duplicate Account Detection";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Duplicate Account Detection</li>
+    </ol>
+</nav>
+
 <h1>Duplicate Account Detection</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/AdminMerge/Detail.cshtml
+++ b/src/Humans.Web/Views/AdminMerge/Detail.cshtml
@@ -4,6 +4,14 @@
     var isPending = string.Equals(Model.Status, "Pending", StringComparison.Ordinal);
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item"><a asp-action="Index">Merge Requests</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Detail</li>
+    </ol>
+</nav>
+
 <h1>Merge Request Detail</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/AdminMerge/Index.cshtml
+++ b/src/Humans.Web/Views/AdminMerge/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Account Merge Requests";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Account Merge Requests</li>
+    </ol>
+</nav>
+
 <h1>Account Merge Requests</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Application/Index.cshtml
+++ b/src/Humans.Web/Views/Application/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = Localizer["MyApplications_Title"].Value;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Governance" asp-action="Index">@Localizer["Governance_Title"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["MyApplications_Title"]</li>
+    </ol>
+</nav>
+
 <h1 class="mb-4">@Localizer["MyApplications_Title"]</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Budget/Index.cshtml
+++ b/src/Humans.Web/Views/Budget/Index.cshtml
@@ -10,6 +10,13 @@
     var unallocated = totalAllocated - totalLineItems;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Summary">Budget</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Model.Year.Name</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div class="d-flex align-items-center gap-3">
         <h1 class="mb-0">@Model.Year.Name</h1>

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -134,7 +134,7 @@
                 <div class="card-body">
                     <div class="row g-3">
                         <div class="col-md-4">
-                            <label asp-for="AcceptingMembers" class="form-label">Accepting New Members?</label>
+                            <label asp-for="AcceptingMembers" class="form-label">Accepting New Humans?</label>
                             <select asp-for="AcceptingMembers" class="form-select"
                                     asp-items="@(new SelectList(Enum.GetValues<YesNoMaybe>()))"></select>
                         </div>
@@ -163,7 +163,7 @@
                                     asp-items="@(new SelectList(Enum.GetValues<AdultPlayspacePolicy>()))"></select>
                         </div>
                         <div class="col-md-4">
-                            <label asp-for="MemberCount" class="form-label">Expected Members</label>
+                            <label asp-for="MemberCount" class="form-label">Expected Humans</label>
                             <input asp-for="MemberCount" class="form-control" type="number" min="1" />
                         </div>
                     </div>

--- a/src/Humans.Web/Views/Camp/Register.cshtml
+++ b/src/Humans.Web/Views/Camp/Register.cshtml
@@ -113,7 +113,7 @@
         <div class="card-body">
             <div class="row g-3">
                 <div class="col-md-4">
-                    <label asp-for="AcceptingMembers" class="form-label">Accepting New Members?</label>
+                    <label asp-for="AcceptingMembers" class="form-label">Accepting New Humans?</label>
                     <select asp-for="AcceptingMembers" class="form-select"
                             asp-items="@(new SelectList(Enum.GetValues<YesNoMaybe>()))"></select>
                 </div>
@@ -143,7 +143,7 @@
                             asp-items="@(new SelectList(Enum.GetValues<AdultPlayspacePolicy>()))"></select>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="MemberCount" class="form-label">Expected Members</label>
+                    <label asp-for="MemberCount" class="form-label">Expected Humans</label>
                     <input asp-for="MemberCount" class="form-control" type="number" min="1" />
                 </div>
             </div>

--- a/src/Humans.Web/Views/CampAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = Localizer["Camp_AdminTitle"];
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Camp" asp-action="Index">@Localizer["Camp_Plural"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Camp_AdminTitle"]</li>
+    </ol>
+</nav>
+
 <h1>@Localizer["Camp_AdminTitle"]</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Campaign/Create.cshtml
+++ b/src/Humans.Web/Views/Campaign/Create.cshtml
@@ -2,6 +2,13 @@
     ViewData["Title"] = "New Campaign";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Campaigns</a></li>
+        <li class="breadcrumb-item active" aria-current="page">New Campaign</li>
+    </ol>
+</nav>
+
 <h1>New Campaign</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Campaign/Edit.cshtml
+++ b/src/Humans.Web/Views/Campaign/Edit.cshtml
@@ -9,6 +9,14 @@
     var replyToAddress = ViewBag.ReplyToAddress as string ?? Model.ReplyToAddress;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Campaigns</a></li>
+        <li class="breadcrumb-item"><a asp-action="Detail" asp-route-id="@Model.Id">@Model.Title</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Edit</li>
+    </ol>
+</nav>
+
 <h1>Edit Campaign</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Campaign/Index.cshtml
+++ b/src/Humans.Web/Views/Campaign/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Campaigns";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin Tools</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Campaigns</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Campaigns</h1>
     <a asp-action="Create" class="btn btn-primary">

--- a/src/Humans.Web/Views/CityPlanning/Admin.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Admin.cshtml
@@ -7,7 +7,7 @@
     <div class="d-flex align-items-center gap-3 mb-4">
         <h1 class="mb-0">@Localizer["CityPlanning_Admin_Title"]</h1>
         <a href="/CityPlanning" class="btn btn-outline-secondary btn-sm">
-            <i class="fa fa-map"></i> @Localizer["CityPlanning_Admin_ViewMap"]
+            <i class="fa-solid fa-map"></i> @Localizer["CityPlanning_Admin_ViewMap"]
         </a>
     </div>
 
@@ -16,7 +16,7 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-door-open me-1"></i> @Localizer["CityPlanning_Admin_PlacementPhaseCard"] (@settings.Year)
+                    <i class="fa-solid fa-door-open me-1"></i> @Localizer["CityPlanning_Admin_PlacementPhaseCard"] (@settings.Year)
                 </div>
                 <div class="card-body">
                     <p class="mb-3">
@@ -43,7 +43,7 @@
                         <form method="post" action="/CityPlanning/Admin/ClosePlacement">
                             @Html.AntiForgeryToken()
                             <button type="submit" class="btn btn-warning">
-                                <i class="fa fa-lock me-1"></i> @Localizer["CityPlanning_Admin_ClosePlacement"]
+                                <i class="fa-solid fa-lock me-1"></i> @Localizer["CityPlanning_Admin_ClosePlacement"]
                             </button>
                         </form>
                     }
@@ -52,7 +52,7 @@
                         <form method="post" action="/CityPlanning/Admin/OpenPlacement">
                             @Html.AntiForgeryToken()
                             <button type="submit" class="btn btn-success">
-                                <i class="fa fa-lock-open me-1"></i> @Localizer["CityPlanning_Admin_OpenPlacement"]
+                                <i class="fa-solid fa-lock-open me-1"></i> @Localizer["CityPlanning_Admin_OpenPlacement"]
                             </button>
                         </form>
                     }
@@ -64,7 +64,7 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-calendar me-1"></i> @Localizer["CityPlanning_Admin_PlacementDatesCard"] (@settings.Year)
+                    <i class="fa-solid fa-calendar me-1"></i> @Localizer["CityPlanning_Admin_PlacementDatesCard"] (@settings.Year)
                 </div>
                 <div class="card-body">
                     <p class="text-muted small mb-3">@Localizer["CityPlanning_Admin_PlacementDatesHint"]</p>
@@ -81,7 +81,7 @@
                                    value="@(settings.PlacementClosesAt?.ToString("yyyy-MM-ddTHH:mm", null) ?? string.Empty)" />
                         </div>
                         <button type="submit" class="btn btn-primary btn-sm">
-                            <i class="fa fa-save me-1"></i> @Localizer["CityPlanning_Admin_SaveDates"]
+                            <i class="fa-solid fa-save me-1"></i> @Localizer["CityPlanning_Admin_SaveDates"]
                         </button>
                     </form>
                 </div>
@@ -92,21 +92,21 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-draw-polygon me-1"></i> @Localizer["CityPlanning_Admin_LimitZoneCard"] (@settings.Year)
+                    <i class="fa-solid fa-draw-polygon me-1"></i> @Localizer["CityPlanning_Admin_LimitZoneCard"] (@settings.Year)
                 </div>
                 <div class="card-body">
                     @if (settings.LimitZoneGeoJson != null)
                     {
-                        <p class="text-success mb-3"><i class="fa fa-check-circle me-1"></i> @Localizer["CityPlanning_Admin_LimitZoneUploaded"]</p>
+                        <p class="text-success mb-3"><i class="fa-solid fa-check-circle me-1"></i> @Localizer["CityPlanning_Admin_LimitZoneUploaded"]</p>
                         <div class="d-flex gap-2">
                             <a href="/CityPlanning/Admin/DownloadLimitZone" class="btn btn-outline-secondary btn-sm" download="limit-zone-@(settings.Year).geojson">
-                                <i class="fa fa-download me-1"></i> @Localizer["CityPlanning_Admin_Download"]
+                                <i class="fa-solid fa-download me-1"></i> @Localizer["CityPlanning_Admin_Download"]
                             </a>
                             <form method="post" action="/CityPlanning/Admin/DeleteLimitZone" class="d-inline">
                                 @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-outline-danger btn-sm"
                                         data-confirm="@Localizer["CityPlanning_Admin_LimitZoneDeleteConfirm"]">
-                                    <i class="fa fa-trash me-1"></i> @Localizer["CityPlanning_Admin_Remove"]
+                                    <i class="fa-solid fa-trash me-1"></i> @Localizer["CityPlanning_Admin_Remove"]
                                 </button>
                             </form>
                         </div>
@@ -122,7 +122,7 @@
                             <input type="file" name="file" accept=".geojson,.json" class="form-control form-control-sm" required />
                         </div>
                         <button type="submit" class="btn btn-primary btn-sm">
-                            <i class="fa fa-upload me-1"></i> @Localizer["CityPlanning_Admin_Upload"]
+                            <i class="fa-solid fa-upload me-1"></i> @Localizer["CityPlanning_Admin_Upload"]
                         </button>
                     </form>
                 </div>
@@ -133,21 +133,21 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-layer-group me-1"></i> @Localizer["CityPlanning_Admin_OfficialZonesCard"] (@settings.Year)
+                    <i class="fa-solid fa-layer-group me-1"></i> @Localizer["CityPlanning_Admin_OfficialZonesCard"] (@settings.Year)
                 </div>
                 <div class="card-body">
                     @if (settings.OfficialZonesGeoJson != null)
                     {
-                        <p class="text-success mb-3"><i class="fa fa-check-circle me-1"></i> @Localizer["CityPlanning_Admin_OfficialZonesUploaded"]</p>
+                        <p class="text-success mb-3"><i class="fa-solid fa-check-circle me-1"></i> @Localizer["CityPlanning_Admin_OfficialZonesUploaded"]</p>
                         <div class="d-flex gap-2">
                             <a href="/CityPlanning/Admin/DownloadOfficialZones" class="btn btn-outline-secondary btn-sm" download="official-zones-@(settings.Year).geojson">
-                                <i class="fa fa-download me-1"></i> @Localizer["CityPlanning_Admin_Download"]
+                                <i class="fa-solid fa-download me-1"></i> @Localizer["CityPlanning_Admin_Download"]
                             </a>
                             <form method="post" action="/CityPlanning/Admin/DeleteOfficialZones" class="d-inline">
                                 @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-outline-danger btn-sm"
                                         data-confirm="@Localizer["CityPlanning_Admin_OfficialZonesDeleteConfirm"]">
-                                    <i class="fa fa-trash me-1"></i> @Localizer["CityPlanning_Admin_Remove"]
+                                    <i class="fa-solid fa-trash me-1"></i> @Localizer["CityPlanning_Admin_Remove"]
                                 </button>
                             </form>
                         </div>
@@ -163,7 +163,7 @@
                             <input type="file" name="file" accept=".geojson,.json" class="form-control form-control-sm" required />
                         </div>
                         <button type="submit" class="btn btn-primary btn-sm">
-                            <i class="fa fa-upload me-1"></i> @Localizer["CityPlanning_Admin_Upload"]
+                            <i class="fa-solid fa-upload me-1"></i> @Localizer["CityPlanning_Admin_Upload"]
                         </button>
                     </form>
                 </div>
@@ -174,12 +174,12 @@
         <div class="col-12">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-file-export me-1"></i> @Localizer["CityPlanning_Admin_ExportCard"]
+                    <i class="fa-solid fa-file-export me-1"></i> @Localizer["CityPlanning_Admin_ExportCard"]
                 </div>
                 <div class="card-body">
                     <p class="mb-2">@string.Format(Localizer["CityPlanning_Admin_ExportDescription"].Value, settings.Year)</p>
                     <a href="/api/city-planning/export.geojson?year=@settings.Year" class="btn btn-outline-secondary btn-sm" download="city-planning-@(settings.Year).geojson">
-                        <i class="fa fa-download me-1"></i> @string.Format(Localizer["CityPlanning_Admin_DownloadGeoJson"].Value, settings.Year)
+                        <i class="fa-solid fa-download me-1"></i> @string.Format(Localizer["CityPlanning_Admin_DownloadGeoJson"].Value, settings.Year)
                     </a>
                 </div>
             </div>

--- a/src/Humans.Web/Views/CityPlanning/Index.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Index.cshtml
@@ -58,7 +58,7 @@
                     }
                 </div>
                 <button class="btn btn-primary btn-sm small" data-bs-toggle="modal" data-bs-target="#placement-help-modal">
-                    <i class="fa fa-question-circle me-1"></i>@Localizer["CityPlanning_HelpButton"]
+                    <i class="fa-solid fa-question-circle me-1"></i>@Localizer["CityPlanning_HelpButton"]
                 </button>
             </div>
         </div>
@@ -74,7 +74,7 @@
             @if (isPlacementOpen && !string.IsNullOrEmpty(userCampSeasonId))
             {
                 <button id="add-my-barrio-btn" class="btn btn-primary btn-sm shadow" style="display:none">
-                    <i class="fa fa-plus me-1"></i> @Localizer["CityPlanning_AddMyBarrioButton"]
+                    <i class="fa-solid fa-plus me-1"></i> @Localizer["CityPlanning_AddMyBarrioButton"]
                 </button>
             }
             @if (isMapAdmin && seasonsWithout.Any())
@@ -90,13 +90,13 @@
                 </div>
             }
             <button id="save-btn" class="btn btn-success btn-sm" style="display:none" disabled>
-                <i class="fa fa-save me-1"></i> @Localizer["CityPlanning_SaveButton"]
+                <i class="fa-solid fa-save me-1"></i> @Localizer["CityPlanning_SaveButton"]
             </button>
             <button id="cancel-btn" class="btn btn-outline-secondary btn-sm" style="display:none">
-                <i class="fa fa-times me-1"></i> @Localizer["Common_Cancel"]
+                <i class="fa-solid fa-times me-1"></i> @Localizer["Common_Cancel"]
             </button>
             <button id="history-btn" class="btn btn-outline-primary btn-sm" style="display:none" disabled>
-                <i class="fa fa-history me-1"></i> @Localizer["CityPlanning_HistoryButton"]
+                <i class="fa-solid fa-history me-1"></i> @Localizer["CityPlanning_HistoryButton"]
             </button>
             </div>
         </div>
@@ -106,7 +106,7 @@
         <div class="card">
             <div class="card-body">
                 <a href="/CityPlanning/Admin" class="btn btn-outline-primary btn-sm">
-                    <i class="fa fa-cog me-1"></i> @Localizer["CityPlanning_AdminLink"]
+                    <i class="fa-solid fa-cog me-1"></i> @Localizer["CityPlanning_AdminLink"]
                 </a>
             </div>
         </div>

--- a/src/Humans.Web/Views/Consent/Index.cshtml
+++ b/src/Humans.Web/Views/Consent/Index.cshtml
@@ -4,6 +4,13 @@
     var totalPending = Model.TeamGroups.Sum(g => g.Documents.Count(d => !d.HasConsented));
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Profile" asp-action="Index">Profile</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["ConsentIndex_Title"]</li>
+    </ol>
+</nav>
+
 <h1>@Localizer["ConsentIndex_Title"]</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Contacts/Index.cshtml
+++ b/src/Humans.Web/Views/Contacts/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Contacts";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Profile" asp-action="AdminList">Humans</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Contacts</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Contacts</h1>
     <div class="d-flex align-items-center gap-3">

--- a/src/Humans.Web/Views/Email/EmailOutbox.cshtml
+++ b/src/Humans.Web/Views/Email/EmailOutbox.cshtml
@@ -11,6 +11,13 @@
     }
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Email Outbox</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
         <h1 class="mb-0">Email Outbox</h1>

--- a/src/Humans.Web/Views/Feedback/Index.cshtml
+++ b/src/Humans.Web/Views/Feedback/Index.cshtml
@@ -1,15 +1,15 @@
 @model Humans.Web.Models.FeedbackPageViewModel
 @{
-    ViewData["Title"] = "Feedback";
+    ViewData["Title"] = Localizer["Feedback_PageTitle"].Value;
 }
 
 <div class="container-fluid">
-    <h2 class="mb-3">Feedback</h2>
+    <h2 class="mb-3">@Localizer["Feedback_PageTitle"]</h2>
 
     <!-- Filter bar -->
     <form method="get" class="feedback-filter-form d-flex gap-2 mb-3 flex-wrap">
         <select name="status" class="form-select form-select-sm" style="width: auto;">
-            <option value="">All Statuses</option>
+            <option value="">@Localizer["Feedback_AllStatuses"]</option>
             @foreach (var s in Enum.GetValues<Humans.Domain.Enums.FeedbackStatus>())
             {
                 if (Model.StatusFilter == s)
@@ -23,7 +23,7 @@
             }
         </select>
         <select name="category" class="form-select form-select-sm" style="width: auto;">
-            <option value="">All Categories</option>
+            <option value="">@Localizer["Feedback_AllCategories"]</option>
             @foreach (var c in Enum.GetValues<Humans.Domain.Enums.FeedbackCategory>())
             {
                 if (Model.CategoryFilter == c)
@@ -39,7 +39,7 @@
         @if (Model.IsAdmin && Model.Reporters.Count > 0)
         {
             <select name="reporterUserId" class="form-select form-select-sm" style="width: auto;">
-                <option value="">All Reporters</option>
+                <option value="">@Localizer["Feedback_AllReporters"]</option>
                 @foreach (var r in Model.Reporters)
                 {
                     if (Model.ReporterFilter == r.UserId)
@@ -56,14 +56,14 @@
         @if (Model.IsAdmin)
         {
             <select name="assignedTo" class="form-select form-select-sm" style="width: auto;">
-                <option value="">All Assignees</option>
+                <option value="">@Localizer["Feedback_AllAssignees"]</option>
                 @if (Model.AssignedToFilter == Model.CurrentUserId)
                 {
-                    <option value="@Model.CurrentUserId" selected>Assigned to me</option>
+                    <option value="@Model.CurrentUserId" selected>@Localizer["Feedback_AssignedToMe"]</option>
                 }
                 else
                 {
-                    <option value="@Model.CurrentUserId">Assigned to me</option>
+                    <option value="@Model.CurrentUserId">@Localizer["Feedback_AssignedToMe"]</option>
                 }
                 @foreach (var a in Model.AssigneeOptions)
                 {
@@ -81,7 +81,7 @@
                 }
             </select>
             <select name="team" class="form-select form-select-sm" style="width: auto;">
-                <option value="">All Teams</option>
+                <option value="">@Localizer["Feedback_AllTeams"]</option>
                 @foreach (var t in Model.TeamOptions)
                 {
                     if (Model.TeamFilter == t.Id)
@@ -105,12 +105,12 @@
                     <input class="form-check-input feedback-filter-checkbox" type="checkbox" name="unassigned" value="true"
                            id="unassignedFilter">
                 }
-                <label class="form-check-label small" for="unassignedFilter">Unassigned only</label>
+                <label class="form-check-label small" for="unassignedFilter">@Localizer["Feedback_UnassignedOnly"]</label>
             </div>
         }
         @if (Model.StatusFilter.HasValue || Model.CategoryFilter.HasValue || Model.ReporterFilter.HasValue || Model.AssignedToFilter.HasValue || Model.TeamFilter.HasValue || Model.UnassignedFilter)
         {
-            <a asp-action="Index" class="btn btn-sm btn-outline-secondary">Clear</a>
+            <a asp-action="Index" class="btn btn-sm btn-outline-secondary">@Localizer["Feedback_Clear"]</a>
         }
     </form>
 
@@ -119,7 +119,7 @@
         <div class="col-md-5 col-lg-4 border-end overflow-auto" style="max-height: 80vh;">
             @if (Model.Reports.Count == 0)
             {
-                <p class="text-muted p-3">No feedback reports found.</p>
+                <p class="text-muted p-3">@Localizer["Feedback_NoReports"]</p>
             }
             @foreach (var report in Model.Reports)
             {
@@ -172,7 +172,7 @@
                                 @if (isUnassigned)
                                 {
                                     <span class="badge bg-secondary bg-opacity-10 text-secondary border border-secondary-subtle" style="font-size: 0.65rem;">
-                                        Unassigned
+                                        @Localizer["Feedback_Unassigned"]
                                     </span>
                                 }
                             </span>
@@ -182,7 +182,7 @@
                         <span></span>
                         @if (report.NeedsReply && Model.IsAdmin)
                         {
-                            <span class="text-danger"><i class="fa-solid fa-circle fa-xs"></i> needs reply</span>
+                            <span class="text-danger"><i class="fa-solid fa-circle fa-xs"></i> @Localizer["Feedback_NeedsReply"]</span>
                         }
                         @if (report.GitHubIssueNumber.HasValue)
                         {
@@ -196,7 +196,7 @@
         <!-- Right panel: detail -->
         <div class="col-md-7 col-lg-8" id="detail-panel">
             <div class="d-flex align-items-center justify-content-center h-100 text-muted">
-                <p>Select a report to view details</p>
+                <p>@Localizer["Feedback_SelectReport"]</p>
             </div>
         </div>
     </div>

--- a/src/Humans.Web/Views/Feedback/_Detail.cshtml
+++ b/src/Humans.Web/Views/Feedback/_Detail.cshtml
@@ -60,7 +60,7 @@
                 <div class="input-group input-group-sm" style="width: auto;">
                     <span class="input-group-text"><i class="fa-solid fa-user fa-xs"></i></span>
                     <select name="AssignedToUserId" class="form-select form-select-sm detail-auto-submit" style="width: auto; min-width: 160px;">
-                        <option value="">Unassigned</option>
+                        <option value="">@Localizer["Feedback_Unassigned"]</option>
                         @foreach (var a in Model.AssigneeOptions)
                         {
                             if (Model.AssignedToUserId == a.Id)
@@ -81,7 +81,7 @@
                 <div class="input-group input-group-sm" style="width: auto;">
                     <span class="input-group-text"><i class="fa-solid fa-users fa-xs"></i></span>
                     <select name="AssignedToTeamId" class="form-select form-select-sm detail-auto-submit" style="width: auto; min-width: 160px;">
-                        <option value="">No team</option>
+                        <option value="">@Localizer["Feedback_NoTeam"]</option>
                         @foreach (var t in Model.TeamOptions)
                         {
                             if (Model.AssignedToTeamId == t.Id)
@@ -125,17 +125,17 @@
 {
     <div class="mb-3">
         <a href="@Model.ScreenshotUrl" target="_blank" class="text-muted small">
-            <i class="fa-solid fa-paperclip"></i> Screenshot
+            <i class="fa-solid fa-paperclip"></i> @Localizer["Feedback_ScreenshotLink"]
         </a>
     </div>
 }
 
 <!-- Conversation -->
-<h6 class="text-muted text-uppercase mb-3" style="font-size: 0.75rem; letter-spacing: 0.05em;">Conversation</h6>
+<h6 class="text-muted text-uppercase mb-3" style="font-size: 0.75rem; letter-spacing: 0.05em;">@Localizer["Feedback_Conversation"]</h6>
 
 @if (Model.Messages.Count == 0)
 {
-    <p class="text-muted small">No messages yet.</p>
+    <p class="text-muted small">@Localizer["Feedback_NoMessages"]</p>
 }
 
 @foreach (var msg in Model.Messages)
@@ -154,18 +154,18 @@
     @Html.AntiForgeryToken()
     <div class="d-flex gap-2">
         <textarea name="Content" class="form-control form-control-sm" rows="2"
-                  placeholder="Type a message..." required maxlength="5000"></textarea>
-        <button type="submit" class="btn btn-primary btn-sm align-self-end">Send</button>
+                  placeholder="@Localizer["Feedback_MessagePlaceholder"].Value" required maxlength="5000"></textarea>
+        <button type="submit" class="btn btn-primary btn-sm align-self-end">@Localizer["Feedback_Send"]</button>
     </div>
 </form>
 
 @if (Model.ResolvedAt.HasValue)
 {
     <div class="text-muted small mt-3">
-        Resolved @Model.ResolvedAt.Value.ToString("MMM dd, HH:mm")
+        @Html.Raw(string.Format(Localizer["Feedback_ResolvedAt"].Value, Html.Encode(Model.ResolvedAt.Value.ToString("MMM dd, HH:mm"))))
         @if (!string.IsNullOrEmpty(Model.ResolvedByName))
         {
-            <text> by @Model.ResolvedByName</text>
+            <text> @Html.Raw(string.Format(Localizer["Feedback_ResolvedBy"].Value, Html.Encode(Model.ResolvedByName)))</text>
         }
     </div>
 }

--- a/src/Humans.Web/Views/Google/AllGroups.cshtml
+++ b/src/Humans.Web/Views/Google/AllGroups.cshtml
@@ -54,7 +54,14 @@
 </style>
 
 <div class="container-fluid px-4">
-    <div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <nav aria-label="breadcrumb" class="mt-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-action="Index">Google</a></li>
+            <li class="breadcrumb-item active" aria-current="page">All Domain Groups</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
         <h1>All Domain Groups</h1>
         <div class="d-flex gap-2">
             @if (driftedGroups.Count > 0)

--- a/src/Humans.Web/Views/Google/SyncSettings.cshtml
+++ b/src/Humans.Web/Views/Google/SyncSettings.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Sync Settings";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Google</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Sync Settings</li>
+    </ol>
+</nav>
+
 <h2>Sync Settings</h2>
 <p class="text-muted">Configure how automated sync jobs handle each service.</p>
 

--- a/src/Humans.Web/Views/Google/_SyncOutboxTable.cshtml
+++ b/src/Humans.Web/Views/Google/_SyncOutboxTable.cshtml
@@ -2,6 +2,7 @@
 @model IList<Humans.Domain.Entities.GoogleSyncOutboxEvent>
 @{
     var googleEmailLookup = (Dictionary<Guid, string>)ViewData["GoogleEmailLookup"]!;
+    var displayNameLookup = (Dictionary<Guid, string>)ViewData["DisplayNameLookup"]!;
     var teamLookup = (Dictionary<Guid, string>)ViewData["TeamLookup"]!;
     var resourceLookup = (Dictionary<Guid, List<string>>)ViewData["ResourceLookup"]!;
     var showError = (bool)ViewData["ShowError"]!;
@@ -39,7 +40,8 @@ else
                     <tr>
                         <td><code>@evt.EventType</code></td>
                         <td>
-                            <human-link user-id="@evt.UserId" admin="true" show-popover="true" />
+                            <human-link user-id="@evt.UserId" admin="true" show-popover="true"
+                                        display-name="@displayNameLookup.GetValueOrDefault(evt.UserId, "Unknown")" />
                         </td>
                         <td><small class="text-muted">@googleEmail</small></td>
                         <td>@teamName</td>

--- a/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
@@ -1,6 +1,6 @@
 @model Humans.Web.Models.CommunicationPreferencesViewModel
 @{
-    ViewData["Title"] = "Communication Preferences";
+    ViewData["Title"] = Localizer["CommPrefs_Title"].Value;
 }
 
 <div class="row">
@@ -9,14 +9,14 @@
         {
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a asp-action="Index">Dashboard</a></li>
-                    <li class="breadcrumb-item active" aria-current="page">Communication Preferences</li>
+                    <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Dashboard_Title"]</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">@Localizer["CommPrefs_Title"]</li>
                 </ol>
             </nav>
         }
 
-        <h1>Communication Preferences</h1>
-        <p class="text-muted">Choose which communications you receive and how.</p>
+        <h1>@Localizer["CommPrefs_Title"]</h1>
+        <p class="text-muted">@Localizer["CommPrefs_Description"]</p>
 
         <vc:temp-data-alerts />
 
@@ -25,9 +25,9 @@
                 <table class="table table-hover mb-0 align-middle">
                     <thead>
                         <tr>
-                            <th style="min-width: 250px;">Category</th>
-                            <th class="text-center" style="width: 100px;">Email</th>
-                            <th class="text-center" style="width: 100px;">Alert</th>
+                            <th style="min-width: 250px;">@Localizer["CommPrefs_Category"]</th>
+                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Email"]</th>
+                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Alert"]</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -89,7 +89,7 @@
 
         @if (string.IsNullOrEmpty(Model.UnsubscribeToken))
         {
-            <a asp-action="Index" class="btn btn-outline-secondary">Back to Dashboard</a>
+            <a asp-action="Index" class="btn btn-outline-secondary">@Localizer["CommPrefs_BackToDashboard"]</a>
         }
     </div>
 </div>

--- a/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
@@ -59,8 +59,9 @@
                                     {
                                         <input type="checkbox"
                                                class="form-check-input"
-                                               disabled
-                                               checked />
+                                               checked
+                                               disabled />
+                                        <span class="text-muted small">Always on</span>
                                     }
                                 </td>
                                 <td class="text-center">
@@ -76,8 +77,9 @@
                                     {
                                         <input type="checkbox"
                                                class="form-check-input"
-                                               disabled
-                                               checked />
+                                               checked
+                                               disabled />
+                                        <span class="text-muted small">Always on</span>
                                     }
                                 </td>
                             </tr>

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -67,7 +67,7 @@
                         </ul>
                     </div>
                     <div class="card-footer">
-                        <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Volunteer Options</a>
+                        <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Shift Options</a>
                     </div>
                 </div>
             }

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -227,6 +227,22 @@
                         </div>
                     </div>
                 }
+                else if (Model.ParticipationStatus == ParticipationStatus.NotAttending)
+                {
+                    <div class="d-flex align-items-center mb-3">
+                        <i class="fa-solid fa-circle-xmark text-secondary fs-3 me-3"></i>
+                        <div>
+                            <strong>You're marked as not attending this year.</strong>
+                            <br /><span class="text-muted">Changed your mind? You can undo this below.</span>
+                        </div>
+                    </div>
+                    <form asp-action="UndoNotAttending" method="post">
+                        @Html.AntiForgeryToken()
+                        <button type="submit" class="btn btn-outline-primary btn-sm">
+                            <i class="fa-solid fa-rotate-left me-1"></i> Undo — I might attend
+                        </button>
+                    </form>
+                }
                 else
                 {
                     <p class="mb-2">We don't see a ticket linked to your account yet.</p>
@@ -234,6 +250,16 @@
                         <i class="fa-solid fa-external-link-alt me-1"></i> Buy your ticket now
                     </a>
                     <p class="text-muted small mt-2 mb-0">Bought on a different email? <a href="/Profile/Me/Emails">Add it here</a></p>
+                    @if (Model.EventYear.HasValue)
+                    {
+                        <hr />
+                        <form asp-action="DeclareNotAttending" method="post">
+                            @Html.AntiForgeryToken()
+                            <button type="submit" class="btn btn-outline-secondary btn-sm">
+                                <i class="fa-solid fa-xmark me-1"></i> Not attending this year
+                            </button>
+                        </form>
+                    }
                 }
             </div>
         </div>

--- a/src/Humans.Web/Views/Home/Privacy.cshtml
+++ b/src/Humans.Web/Views/Home/Privacy.cshtml
@@ -3,101 +3,103 @@
 }
 <h1>@Localizer["Privacy_Title"]</h1>
 
-<p class="lead">Humans manages membership for Nobodies Collective and processes personal data in accordance with GDPR and Spanish data protection law (LOPDGDD).</p>
+<p class="lead">@Localizer["Privacy_Lead"]</p>
 
-<h2>Data Controller</h2>
+<h2>@Localizer["Privacy_DataControllerTitle"]</h2>
 <p>
     <strong>Nobodies Collective</strong><br />
-    A Spanish nonprofit association registered in Andalucia.<br />
-    For data protection inquiries, contact our Data Protection Officer at: <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>
+    @Localizer["Privacy_DataControllerBody"]<br />
+    @Localizer["Privacy_DataControllerDPO"] <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>
 </p>
 
-<h2>Data We Collect</h2>
-<p>We collect and process the following categories of personal data:</p>
+<h2>@Localizer["Privacy_DataWeCollectTitle"]</h2>
+<p>@Localizer["Privacy_DataWeCollectIntro"]</p>
 <ul>
-    <li><strong>Identity data:</strong> Name, email address (from Google authentication), display name/burner name</li>
-    <li><strong>Contact data:</strong> Phone number, city, country (optional)</li>
-    <li><strong>Profile data:</strong> Bio, team memberships, role assignments</li>
-    <li><strong>Technical data:</strong> IP address and user agent (for consent records)</li>
-    <li><strong>Application data:</strong> Membership applications and motivation statements</li>
-    <li><strong>Consent records:</strong> Records of your agreement to legal documents</li>
+    <li><strong>@Localizer["Privacy_Collect_Identity"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Contact"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Profile"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Technical"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Application"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Consent"]</strong></li>
 </ul>
 
-<h2>Legal Basis for Processing</h2>
-<p>We process your data based on:</p>
+<h2>@Localizer["Privacy_LegalBasisTitle"]</h2>
+<p>@Localizer["Privacy_LegalBasisIntro"]</p>
 <ul>
-    <li><strong>Contract:</strong> Processing necessary for membership management</li>
-    <li><strong>Legitimate interest:</strong> Maintaining organizational records and communication</li>
-    <li><strong>Legal obligation:</strong> Compliance with Spanish nonprofit regulations</li>
-    <li><strong>Consent:</strong> For optional data you choose to provide</li>
+    <li><strong>@Localizer["Privacy_Legal_Contract"]</strong></li>
+    <li><strong>@Localizer["Privacy_Legal_LegitimateInterest"]</strong></li>
+    <li><strong>@Localizer["Privacy_Legal_LegalObligation"]</strong></li>
+    <li><strong>@Localizer["Privacy_Legal_Consent"]</strong></li>
 </ul>
 
-<h2>How We Use Your Data</h2>
+<h2>@Localizer["Privacy_HowWeUseTitle"]</h2>
 <ul>
-    <li>To manage your membership and team participation</li>
-    <li>To communicate with you about organizational activities</li>
-    <li>To maintain legal compliance records</li>
-    <li>To facilitate connections between humans (based on your visibility settings)</li>
+    <li>@Localizer["Privacy_Use_Membership"]</li>
+    <li>@Localizer["Privacy_Use_Communicate"]</li>
+    <li>@Localizer["Privacy_Use_LegalCompliance"]</li>
+    <li>@Localizer["Privacy_Use_Connections"]</li>
 </ul>
 
-<h2>Data Retention</h2>
-<p>We retain your data according to the following policies:</p>
+<h2>@Localizer["Privacy_DataRetentionTitle"]</h2>
+<p>@Localizer["Privacy_DataRetentionIntro"]</p>
 <ul>
-    <li><strong>Active accounts:</strong> Data retained while your account is active</li>
-    <li><strong>Inactive accounts:</strong> Data retained for up to 7 years for legal compliance</li>
-    <li><strong>Consent records:</strong> Retained indefinitely as required for GDPR compliance</li>
-    <li><strong>Deleted accounts:</strong> Anonymized after 30-day grace period</li>
+    <li><strong>@Localizer["Privacy_Retention_Active"]</strong></li>
+    <li><strong>@Localizer["Privacy_Retention_Inactive"]</strong></li>
+    <li><strong>@Localizer["Privacy_Retention_Consent"]</strong></li>
+    <li><strong>@Localizer["Privacy_Retention_Deleted"]</strong></li>
 </ul>
 
-<h2>Your Rights</h2>
-<p>Under GDPR, you have the following rights:</p>
+<h2>@Localizer["Privacy_YourRightsTitle"]</h2>
+<p>@Localizer["Privacy_YourRightsIntro"]</p>
 <ul>
-    <li><strong>Access:</strong> Request a copy of your personal data</li>
-    <li><strong>Rectification:</strong> Request correction of inaccurate data</li>
-    <li><strong>Erasure:</strong> Request deletion of your data ("right to be forgotten")</li>
-    <li><strong>Portability:</strong> Receive your data in a machine-readable format</li>
-    <li><strong>Restriction:</strong> Request limitation of processing</li>
-    <li><strong>Objection:</strong> Object to certain types of processing</li>
+    <li><strong>@Localizer["Privacy_Rights_Access"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Rectification"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Erasure"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Portability"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Restriction"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Objection"]</strong></li>
 </ul>
 <p>
-    To exercise these rights, visit your <a asp-controller="Profile" asp-action="Privacy">Privacy & Data</a> settings or contact us at
-    <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>.
+    @Html.Raw(string.Format(
+        Localizer["Privacy_YourRightsExercise"].Value,
+        "<a href=\"" + Html.Encode(Url.Action("Privacy", "Profile")) + "\">" + Localizer["Privacy_PrivacyAndData"].Value + "</a>",
+        "<a href=\"mailto:" + Html.Encode(ViewData["DpoEmail"]) + "\">" + Html.Encode(ViewData["DpoEmail"]) + "</a>"))
 </p>
 
-<h2>Cookies</h2>
-<p>This site uses only essential cookies required for:</p>
+<h2>@Localizer["Privacy_CookiesTitle"]</h2>
+<p>@Localizer["Privacy_CookiesIntro"]</p>
 <ul>
-    <li>User authentication and session management</li>
-    <li>Anti-forgery tokens for form security</li>
-    <li>Cookie consent preference</li>
+    <li>@Localizer["Privacy_Cookies_Auth"]</li>
+    <li>@Localizer["Privacy_Cookies_Antiforgery"]</li>
+    <li>@Localizer["Privacy_Cookies_Consent"]</li>
 </ul>
-<p>We do not use analytics, advertising, or third-party tracking cookies.</p>
+<p>@Localizer["Privacy_CookiesNoTracking"]</p>
 
-<h2>Data Security</h2>
-<p>We implement appropriate technical and organizational measures to protect your data, including:</p>
+<h2>@Localizer["Privacy_DataSecurityTitle"]</h2>
+<p>@Localizer["Privacy_DataSecurityIntro"]</p>
 <ul>
-    <li>Encryption in transit (HTTPS)</li>
-    <li>Secure authentication via Google OAuth</li>
-    <li>Access controls and audit logging</li>
-    <li>Regular security reviews</li>
-</ul>
-
-<h2>Third-Party Services</h2>
-<p>We use the following third-party services:</p>
-<ul>
-    <li><strong>Google OAuth:</strong> For secure authentication (Google's <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>)</li>
-    <li><strong>Google Workspace:</strong> For team resource provisioning (shared drives, groups)</li>
+    <li>@Localizer["Privacy_Security_Encryption"]</li>
+    <li>@Localizer["Privacy_Security_OAuth"]</li>
+    <li>@Localizer["Privacy_Security_AccessControls"]</li>
+    <li>@Localizer["Privacy_Security_Reviews"]</li>
 </ul>
 
-<h2>Changes to This Policy</h2>
-<p>We may update this privacy policy from time to time. We will notify active humans of significant changes via email.</p>
+<h2>@Localizer["Privacy_ThirdPartyTitle"]</h2>
+<p>@Localizer["Privacy_ThirdPartyIntro"]</p>
+<ul>
+    <li><strong>Google OAuth:</strong> @Localizer["Privacy_ThirdParty_GoogleOAuth"] (Google's <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>)</li>
+    <li><strong>Google Workspace:</strong> @Localizer["Privacy_ThirdParty_GoogleWorkspace"]</li>
+</ul>
 
-<h2>Contact & Complaints</h2>
+<h2>@Localizer["Privacy_ChangesTitle"]</h2>
+<p>@Localizer["Privacy_ChangesBody"]</p>
+
+<h2>@Localizer["Privacy_ContactTitle"]</h2>
 <p>
-    For questions or concerns about this policy, contact our Data Protection Officer at
-    <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>.
+    @Html.Raw(string.Format(Localizer["Privacy_ContactBody"].Value,
+        "<a href=\"mailto:" + Html.Encode(ViewData["DpoEmail"]) + "\">" + Html.Encode(ViewData["DpoEmail"]) + "</a>"))
 </p>
 <p>
-    If you are not satisfied with our response, you have the right to lodge a complaint with the
-    Spanish Data Protection Agency (AEPD) at <a href="https://www.aepd.es" target="_blank" rel="noopener noreferrer">www.aepd.es</a>.
+    @Html.Raw(string.Format(Localizer["Privacy_ComplaintBody"].Value,
+        "<a href=\"https://www.aepd.es\" target=\"_blank\" rel=\"noopener noreferrer\">www.aepd.es</a>"))
 </p>

--- a/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
@@ -1,19 +1,19 @@
 @model Humans.Web.Models.CommunicationPreferencesViewModel
 @{
-    ViewData["Title"] = "Communication Preferences";
+    ViewData["Title"] = Localizer["CommPrefs_Title"].Value;
 }
 
 <div class="row">
     <div class="col-12" style="max-width: 900px;">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Communication Preferences</li>
+                <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Nav_MyProfile"]</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@Localizer["CommPrefs_Title"]</li>
             </ol>
         </nav>
 
-        <h1>Communication Preferences</h1>
-        <p class="text-muted">Choose which communications you receive and how.</p>
+        <h1>@Localizer["CommPrefs_Title"]</h1>
+        <p class="text-muted">@Localizer["CommPrefs_Description"]</p>
 
         <vc:temp-data-alerts />
 
@@ -22,9 +22,9 @@
                 <table class="table table-hover mb-0 align-middle">
                     <thead>
                         <tr>
-                            <th style="min-width: 250px;">Category</th>
-                            <th class="text-center" style="width: 100px;">Email</th>
-                            <th class="text-center" style="width: 100px;">Alert</th>
+                            <th style="min-width: 250px;">@Localizer["CommPrefs_Category"]</th>
+                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Email"]</th>
+                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Alert"]</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -84,7 +84,7 @@
             </div>
         </div>
 
-        <a asp-action="Index" class="btn btn-outline-secondary">Back to Profile</a>
+        <a asp-action="Index" class="btn btn-outline-secondary">@Localizer["CommPrefs_BackToProfile"]</a>
     </div>
 </div>
 

--- a/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
@@ -56,8 +56,9 @@
                                     {
                                         <input type="checkbox"
                                                class="form-check-input"
-                                               disabled
-                                               checked />
+                                               checked
+                                               disabled />
+                                        <span class="text-muted small">Always on</span>
                                     }
                                 </td>
                                 <td class="text-center">
@@ -73,8 +74,9 @@
                                     {
                                         <input type="checkbox"
                                                class="form-check-input"
-                                               disabled
-                                               checked />
+                                               checked
+                                               disabled />
+                                        <span class="text-muted small">Always on</span>
                                     }
                                 </td>
                             </tr>

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -5,6 +5,13 @@
 
 <div class="row">
     <div class="col-12" style="max-width: 900px;">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@Localizer["ProfileEdit_Title"]</li>
+            </ol>
+        </nav>
+
         <h1>@Localizer["ProfileEdit_Title"]</h1>
 
         <form asp-action="Edit" method="post" enctype="multipart/form-data">

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -5,6 +5,13 @@
 
 <div class="row">
     <div class="col-md-8">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@Localizer["Emails_Title"]</li>
+            </ol>
+        </nav>
+
         <h1>@Localizer["Emails_Title"]</h1>
         <p class="text-muted">
             @Localizer["Emails_Description"]

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -21,10 +21,10 @@
                     <table class="table table-hover mb-0">
                         <thead>
                             <tr>
-                                <th>Email</th>
-                                <th>Status</th>
-                                <th>Notifications</th>
-                                <th>Profile Visibility</th>
+                                <th>@Localizer["Emails_Header_Email"]</th>
+                                <th>@Localizer["Emails_Header_Status"]</th>
+                                <th>@Localizer["Emails_Header_Notifications"]</th>
+                                <th>@Localizer["Emails_Header_Visibility"]</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -36,38 +36,38 @@
                                         <code>@email.Email</code>
                                         @if (email.IsOAuth)
                                         {
-                                            <span class="badge bg-secondary ms-1">Sign-in</span>
+                                            <span class="badge bg-secondary ms-1">@Localizer["Emails_SignIn"]</span>
                                         }
                                     </td>
                                     <td>
                                         @if (email.IsMergePending)
                                         {
                                             <span class="badge bg-info text-dark">
-                                                <i class="fa-solid fa-code-merge me-1"></i>Merge pending
+                                                <i class="fa-solid fa-code-merge me-1"></i>@Localizer["Emails_MergePending"]
                                             </span>
                                         }
                                         else if (email.IsVerified)
                                         {
                                             <span class="badge bg-success">
-                                                <i class="fa-solid fa-check me-1"></i>Verified
+                                                <i class="fa-solid fa-check me-1"></i>@Localizer["Emails_Verified"]
                                             </span>
                                         }
                                         else if (email.IsPendingVerification)
                                         {
                                             <span class="badge bg-warning text-dark">
-                                                <i class="fa-solid fa-clock me-1"></i>Pending
+                                                <i class="fa-solid fa-clock me-1"></i>@Localizer["Emails_StatusPending"]
                                             </span>
                                         }
                                         else
                                         {
-                                            <span class="badge bg-secondary">Unverified</span>
+                                            <span class="badge bg-secondary">@Localizer["Emails_Unverified"]</span>
                                         }
                                     </td>
                                     <td>
                                         @if (email.IsNotificationTarget)
                                         {
                                             <span class="badge bg-primary">
-                                                <i class="fa-solid fa-bell me-1"></i>Active
+                                                <i class="fa-solid fa-bell me-1"></i>@Localizer["Emails_NotifActive"]
                                             </span>
                                         }
                                         else if (email.IsVerified)
@@ -76,13 +76,13 @@
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="emailId" value="@email.Id" />
                                                 <button type="submit" class="btn btn-outline-primary btn-sm">
-                                                    Set as target
+                                                    @Localizer["Emails_SetAsTarget"]
                                                 </button>
                                             </form>
                                         }
                                         else
                                         {
-                                            <span class="text-muted small">Verify first</span>
+                                            <span class="text-muted small">@Localizer["Emails_VerifyFirst"]</span>
                                         }
                                     </td>
                                     <td>
@@ -92,11 +92,11 @@
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="emailId" value="@email.Id" />
                                                 <select name="visibility" class="form-select form-select-sm js-auto-submit" style="width: auto; display: inline-block;">
-                                                    <option value="" selected="@(email.Visibility == null ? "selected" : null)">Hidden</option>
-                                                    <option value="AllActiveProfiles" selected="@(email.Visibility == ContactFieldVisibility.AllActiveProfiles ? "selected" : null)">All humans</option>
-                                                    <option value="MyTeams" selected="@(email.Visibility == ContactFieldVisibility.MyTeams ? "selected" : null)">My teams</option>
-                                                    <option value="CoordinatorsAndBoard" selected="@(email.Visibility == ContactFieldVisibility.CoordinatorsAndBoard ? "selected" : null)">Coordinators + Board</option>
-                                                    <option value="BoardOnly" selected="@(email.Visibility == ContactFieldVisibility.BoardOnly ? "selected" : null)">Board only</option>
+                                                    <option value="" selected="@(email.Visibility == null ? "selected" : null)">@Localizer["Emails_Visibility_Hidden"]</option>
+                                                    <option value="AllActiveProfiles" selected="@(email.Visibility == ContactFieldVisibility.AllActiveProfiles ? "selected" : null)">@Localizer["Emails_Visibility_AllHumans"]</option>
+                                                    <option value="MyTeams" selected="@(email.Visibility == ContactFieldVisibility.MyTeams ? "selected" : null)">@Localizer["Emails_Visibility_MyTeams"]</option>
+                                                    <option value="CoordinatorsAndBoard" selected="@(email.Visibility == ContactFieldVisibility.CoordinatorsAndBoard ? "selected" : null)">@Localizer["Emails_Visibility_CoordinatorsBoard"]</option>
+                                                    <option value="BoardOnly" selected="@(email.Visibility == ContactFieldVisibility.BoardOnly ? "selected" : null)">@Localizer["Emails_Visibility_BoardOnly"]</option>
                                                 </select>
                                             </form>
                                         }
@@ -109,7 +109,7 @@
                                         @if (!email.IsOAuth)
                                         {
                                             <form asp-action="DeleteEmail" method="post" class="d-inline"
-                                                  data-confirm="Are you sure you want to remove this email?">
+                                                  data-confirm="@Localizer["Emails_ConfirmRemove"].Value">
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="emailId" value="@email.Id" />
                                                 <button type="submit" class="btn btn-outline-danger btn-sm">
@@ -128,29 +128,28 @@
 
         <div class="card mb-4">
             <div class="card-header">
-                <h5 class="mb-0"><i class="fa-brands fa-google me-2"></i>Google Services Email</h5>
+                <h5 class="mb-0"><i class="fa-brands fa-google me-2"></i>@Localizer["Emails_GoogleTitle"]</h5>
             </div>
             <div class="card-body">
                 <p class="text-muted small mb-3">
-                    This email is used for Google Groups and Shared Drive access.
+                    @Localizer["Emails_GoogleDescription"]
                     @if (Model.HasNobodiesTeamEmail)
                     {
-                        <text>Your @@nobodies.team email is automatically used.</text>
+                        <text>@Localizer["Emails_GoogleAutoNobodies"]</text>
                     }
                 </p>
                 @if (Model.GoogleEmailStatus == Humans.Domain.Enums.GoogleEmailStatus.Rejected)
                 {
                     <div class="alert alert-danger mb-3">
                         <i class="fa-solid fa-triangle-exclamation me-1"></i>
-                        <strong>Google sync failed.</strong> The current email was rejected by Google.
-                        Select a different email below to retry sync.
+                        @Localizer["Emails_GoogleRejected"]
                     </div>
                 }
                 else if (Model.GoogleEmailStatus == Humans.Domain.Enums.GoogleEmailStatus.Valid)
                 {
                     <div class="alert alert-success mb-3 py-2">
                         <i class="fa-solid fa-circle-check me-1"></i>
-                        Google sync is working with the current email.
+                        @Localizer["Emails_GoogleValid"]
                     </div>
                 }
                 @foreach (var email in Model.Emails.Where(e => e.IsVerified))
@@ -159,16 +158,16 @@
                         @if (email.IsGoogleServiceEmail)
                         {
                             <span class="badge bg-primary me-2">
-                                <i class="fa-solid fa-check me-1"></i>Active
+                                <i class="fa-solid fa-check me-1"></i>@Localizer["Emails_NotifActive"]
                             </span>
                             <code>@email.Email</code>
                             @if (email.IsNobodiesTeamDomain)
                             {
-                                <span class="badge bg-info text-dark ms-2">Auto-selected</span>
+                                <span class="badge bg-info text-dark ms-2">@Localizer["Emails_AutoSelected"]</span>
                             }
                             @if (Model.GoogleEmailStatus == Humans.Domain.Enums.GoogleEmailStatus.Rejected && !Model.HasNobodiesTeamEmail)
                             {
-                                <span class="badge bg-danger ms-2">Rejected</span>
+                                <span class="badge bg-danger ms-2">@Localizer["Emails_GoogleRejectedBadge"]</span>
                             }
                         }
                         else if (!Model.HasNobodiesTeamEmail)
@@ -176,7 +175,7 @@
                             <form asp-action="SetGoogleServiceEmail" method="post" class="d-inline me-2">
                                 @Html.AntiForgeryToken()
                                 <input type="hidden" name="emailId" value="@email.Id" />
-                                <button type="submit" class="btn btn-outline-primary btn-sm">Use this</button>
+                                <button type="submit" class="btn btn-outline-primary btn-sm">@Localizer["Emails_UseThis"]</button>
                             </form>
                             <code>@email.Email</code>
                         }

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -157,6 +157,7 @@
                         }
                     </a>
                     <a asp-controller="Profile" asp-action="ShiftInfo" class="list-group-item list-group-item-action">Shift Info</a>
+                    <a asp-controller="Profile" asp-action="Emails" class="list-group-item list-group-item-action">@Localizer["Emails_Title"]</a>
                     <a asp-controller="Profile" asp-action="CommunicationPreferences" class="list-group-item list-group-item-action">Communication Preferences</a>
                     <a asp-controller="Governance" asp-action="Index" class="list-group-item list-group-item-action">@Localizer["Nav_Governance"]</a>
                     <a asp-controller="Profile" asp-action="Privacy" class="list-group-item list-group-item-action">@Localizer["ProfilePrivacy_Title"]</a>

--- a/src/Humans.Web/Views/Profile/Privacy.cshtml
+++ b/src/Humans.Web/Views/Profile/Privacy.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = Localizer["ProfilePrivacy_Title"].Value;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["ProfilePrivacy_Title"]</li>
+    </ol>
+</nav>
+
 <h1>@Localizer["ProfilePrivacy_Title"]</h1>
 
 <p class="lead">@Localizer["ProfilePrivacy_Lead"]</p>

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -1,14 +1,14 @@
 @model Humans.Web.Models.ShiftInfoViewModel
 @{
-    ViewData["Title"] = "Shift Preferences";
+    ViewData["Title"] = Localizer["ShiftInfo_Title"].Value;
 }
 
 <div class="row">
     <div class="col-12" style="max-width: 560px; margin: 0 auto;">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Shift Preferences</li>
+                <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Nav_MyProfile"]</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@Localizer["ShiftInfo_Title"]</li>
             </ol>
         </nav>
 
@@ -16,9 +16,9 @@
 
         @* Wizard header *@
         <div class="text-center mb-4">
-            <div class="text-muted text-uppercase small" id="stepLabel">Step 1 of 3</div>
-            <h1 class="h4 mt-1 mb-1" id="stepTitle">What are you good at?</h1>
-            <p class="text-muted small" id="stepSubtitle">Select skills you'd like to use. You can change these anytime.</p>
+            <div class="text-muted text-uppercase small" id="stepLabel">@string.Format(Localizer["ShiftInfo_StepOf"].Value, 1, 3)</div>
+            <h1 class="h4 mt-1 mb-1" id="stepTitle">@Localizer["ShiftInfo_SkillsTitle"]</h1>
+            <p class="text-muted small" id="stepSubtitle">@Localizer["ShiftInfo_SkillsSubtitle"]</p>
             <div class="d-flex justify-content-center gap-2 mt-3" id="progressDots">
                 <span class="progress-dot active" data-step="0"></span>
                 <span class="progress-dot" data-step="1"></span>
@@ -45,13 +45,13 @@
                 </div>
                 <div class="other-text-input mt-3" style="display: @(Model.SelectedSkills.Contains("Other") ? "block" : "none");">
                     <input type="text" name="SkillOtherText" class="form-control" maxlength="200"
-                           value="@Model.SkillOtherText" placeholder="What other skills do you have?" />
+                           value="@Model.SkillOtherText" placeholder="@Localizer["ShiftInfo_OtherSkills"].Value" />
                 </div>
             </div>
 
             @* ===== STEP 1: Work Style ===== *@
             <div class="step-pane" id="step-1">
-                <p class="fw-bold small text-muted mb-2">When do you prefer to work?</p>
+                <p class="fw-bold small text-muted mb-2">@Localizer["ShiftInfo_WorkTime"]</p>
                 <div class="radio-card-grid">
                     @foreach (var tp in Humans.Web.Models.ShiftInfoViewModel.TimePreferenceOptions)
                     {
@@ -68,7 +68,7 @@
                     }
                 </div>
 
-                <p class="fw-bold small text-muted mb-2 mt-4">Other preferences</p>
+                <p class="fw-bold small text-muted mb-2 mt-4">@Localizer["ShiftInfo_OtherPrefs"]</p>
                 @foreach (var quirk in Humans.Web.Models.ShiftInfoViewModel.ToggleQuirkOptions)
                 {
                     var isChecked = Model.SelectedQuirks.Contains(quirk);
@@ -96,21 +96,21 @@
                 </div>
                 <div class="other-text-input mt-3" style="display: @(Model.SelectedLanguages.Contains("Other") ? "block" : "none");">
                     <input type="text" name="LanguageOtherText" class="form-control" maxlength="200"
-                           value="@Model.LanguageOtherText" placeholder="What other languages do you speak?" />
+                           value="@Model.LanguageOtherText" placeholder="@Localizer["ShiftInfo_OtherLanguages"].Value" />
                 </div>
             </div>
 
             @* ===== Navigation ===== *@
             <div class="d-flex justify-content-between align-items-center mt-4">
                 <button type="button" class="btn btn-outline-secondary" id="backBtn" style="display:none">
-                    &larr; Back
+                    &larr; @Localizer["Common_Back"]
                 </button>
                 <div></div>
                 <button type="button" class="btn btn-primary" id="nextBtn">
-                    Continue &rarr;
+                    @Localizer["ShiftInfo_Continue"] &rarr;
                 </button>
                 <button type="submit" class="btn btn-primary" id="saveBtn" style="display:none">
-                    Save
+                    @Localizer["Common_Save"]
                 </button>
             </div>
         </form>
@@ -169,9 +169,9 @@
 <script>
 (function() {
     const STEPS = [
-        { label: 'Step 1 of 3', title: 'What are you good at?', subtitle: 'Select skills you\'d like to use. You can change these anytime.' },
-        { label: 'Step 2 of 3', title: 'How do you like to work?', subtitle: 'Help coordinators match you with shifts that fit your style and availability.' },
-        { label: 'Step 3 of 3', title: 'Which languages do you speak?', subtitle: 'This helps us match you with teams where you can communicate well.' }
+        { label: '@Html.Raw(string.Format(Localizer["ShiftInfo_StepOf"].Value, 1, 3))', title: '@Html.Raw(Localizer["ShiftInfo_SkillsTitle"].Value.Replace("'", "\\'"))', subtitle: '@Html.Raw(Localizer["ShiftInfo_SkillsSubtitle"].Value.Replace("'", "\\'"))' },
+        { label: '@Html.Raw(string.Format(Localizer["ShiftInfo_StepOf"].Value, 2, 3))', title: '@Html.Raw(Localizer["ShiftInfo_WorkStyleTitle"].Value.Replace("'", "\\'"))', subtitle: '@Html.Raw(Localizer["ShiftInfo_WorkStyleSubtitle"].Value.Replace("'", "\\'"))' },
+        { label: '@Html.Raw(string.Format(Localizer["ShiftInfo_StepOf"].Value, 3, 3))', title: '@Html.Raw(Localizer["ShiftInfo_LanguagesTitle"].Value.Replace("'", "\\'"))', subtitle: '@Html.Raw(Localizer["ShiftInfo_LanguagesSubtitle"].Value.Replace("'", "\\'"))' }
     ];
 
     let current = 0;

--- a/src/Humans.Web/Views/Shared/_ApplicationsListContent.cshtml
+++ b/src/Humans.Web/Views/Shared/_ApplicationsListContent.cshtml
@@ -1,5 +1,12 @@
 @model Humans.Web.Models.AdminApplicationListViewModel
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Board" asp-action="Index">Board</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["AdminApplications_Title"]</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>@Localizer["AdminApplications_Title"]</h1>
     <span class="text-muted">@string.Format(Localizer["Admin_TotalCount"].Value, Model.TotalCount)</span>

--- a/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
@@ -50,7 +50,7 @@
             </li>
             <li>
                 <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Legal" asp-action="Index">
-                    <i class="fa-solid fa-scale-balanced fa-fw"></i> Legal
+                    <i class="fa-solid fa-scale-balanced fa-fw"></i> @Localizer["Nav_Legal"]
                 </a>
             </li>
             <li>
@@ -65,7 +65,7 @@
             </li>
             <li>
                 <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="About" asp-action="Staff">
-                    <i class="fa-solid fa-users fa-fw"></i> Staff
+                    <i class="fa-solid fa-users fa-fw"></i> @Localizer["Nav_Staff"]
                 </a>
             </li>
             <li>

--- a/src/Humans.Web/Views/Shared/_ProfileCard.cshtml
+++ b/src/Humans.Web/Views/Shared/_ProfileCard.cshtml
@@ -14,11 +14,11 @@
             }
             else if (Model.MembershipStatus == "Suspended")
             {
-                <span class="badge bg-danger me-1">Suspended</span>
+                <span class="badge bg-danger me-1">@Localizer["ProfileCard_Suspended"]</span>
             }
             else
             {
-                <span class="badge bg-warning text-dark me-1">Pending</span>
+                <span class="badge bg-warning text-dark me-1">@Localizer["ProfileCard_PendingBadge"]</span>
             }
             @if (!string.IsNullOrEmpty(Model.PreferredLanguage))
             {
@@ -28,7 +28,7 @@
         @if (Model.Teams.Count > 0)
         {
             <div class="mt-2">
-                <small class="text-muted">Teams:</small>
+                <small class="text-muted">@Localizer["ProfileCard_Teams"]</small>
                 @foreach (var team in Model.Teams)
                 {
                     <span class="badge bg-light text-dark border">@team</span>
@@ -38,11 +38,11 @@
         <div class="mt-2 text-muted" style="font-size: 0.8rem;">
             @if (Model.MemberSince.HasValue)
             {
-                <span>Joined @Model.MemberSince.Value.ToString("MMM yyyy")</span>
+                <span>@string.Format(Localizer["ProfileCard_Joined"].Value, Model.MemberSince.Value.ToString("MMM yyyy"))</span>
             }
             @if (Model.LastLogin.HasValue)
             {
-                <span class="ms-2">Last login @Model.LastLogin.Value.ToString("d MMM yyyy")</span>
+                <span class="ms-2">@string.Format(Localizer["ProfileCard_LastLogin"].Value, Model.LastLogin.Value.ToString("d MMM yyyy"))</span>
             }
         </div>
     </div>

--- a/src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml
+++ b/src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml
@@ -2,7 +2,7 @@
 
 <div class="card mb-4">
     <div class="card-header">
-        <h6 class="mb-0"><i class="fa-solid fa-clock me-1"></i> Shifts</h6>
+        <h6 class="mb-0"><i class="fa-solid fa-clock me-1"></i> @Localizer["ShiftsSummary_Title"]</h6>
     </div>
     <div class="card-body">
         @if (Model.TotalSlots > 0)
@@ -16,29 +16,29 @@
                 </div>
             </div>
             <div class="d-flex justify-content-between align-items-center mb-2">
-                <span>@Model.ConfirmedCount / @Model.TotalSlots slots filled</span>
-                <span>@Model.UniqueVolunteerCount humans signed up</span>
+                <span>@string.Format(Localizer["ShiftsSummary_SlotsFilled"].Value, Model.ConfirmedCount, Model.TotalSlots)</span>
+                <span>@string.Format(Localizer["ShiftsSummary_HumansSignedUp"].Value, Model.UniqueVolunteerCount)</span>
             </div>
             @if (Model.PendingCount > 0)
             {
                 <a href="@Model.ShiftsUrl" class="badge bg-warning text-dark text-decoration-none">
-                    @Model.PendingCount pending
+                    @string.Format(Localizer["ShiftsSummary_PendingCount"].Value, Model.PendingCount)
                 </a>
             }
         }
         else
         {
-            <p class="text-muted mb-0">No shifts configured yet.</p>
+            <p class="text-muted mb-0">@Localizer["ShiftsSummary_NoShifts"]</p>
         }
         @if (Model.IncludesSubTeamCount > 0)
         {
             <small class="text-muted d-block mt-1">
-                <i class="fa-solid fa-sitemap me-1"></i>Includes shifts from @Model.IncludesSubTeamCount sub-team@(Model.IncludesSubTeamCount != 1 ? "s" : "")
+                <i class="fa-solid fa-sitemap me-1"></i>@string.Format(Localizer["ShiftsSummary_IncludesSubTeams"].Value, Model.IncludesSubTeamCount)
             </small>
         }
         @if (Model.CanManageShifts)
         {
-            <a href="@Model.ShiftsUrl" class="btn btn-sm btn-outline-primary mt-2 w-100">Manage Shifts <i class="fa-solid fa-lock auth-lock-icon"></i></a>
+            <a href="@Model.ShiftsUrl" class="btn btn-sm btn-outline-primary mt-2 w-100">@Localizer["ShiftsSummary_ManageShifts"] <i class="fa-solid fa-lock auth-lock-icon"></i></a>
         }
     </div>
 </div>

--- a/src/Humans.Web/Views/Shared/_VolunteerProfileBadges.cshtml
+++ b/src/Humans.Web/Views/Shared/_VolunteerProfileBadges.cshtml
@@ -21,7 +21,7 @@
         }
         @if (Model.ShowMedical && !string.IsNullOrEmpty(Model.Profile.MedicalConditions))
         {
-            <span class="badge bg-danger" title="@Model.Profile.MedicalConditions">Medical</span>
+            <span class="badge bg-danger" title="@Model.Profile.MedicalConditions">@Localizer["Medical_Badge"]</span>
         }
     </span>
 }

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -8,6 +8,13 @@
 }
 
 <div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-controller="Shifts" asp-action="Index">Shifts</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Shift Dashboard</li>
+        </ol>
+    </nav>
+
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h2>@Localizer["ShiftDash_Title"]</h2>
         <span class="badge bg-secondary fs-6">@string.Format(Localizer["ShiftDash_ShiftsCount"].Value, Model.Shifts.Count)</span>

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -2,15 +2,15 @@
 @using Humans.Web.Controllers
 
 @{
-    ViewData["Title"] = "Shift Dashboard";
+    ViewData["Title"] = Localizer["ShiftDash_Title"].Value;
     var searchUrl = Url.Action(nameof(ShiftDashboardController.SearchVolunteers), "ShiftDashboard");
     var voluntellUrl = Url.Action(nameof(ShiftDashboardController.Voluntell), "ShiftDashboard");
 }
 
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2>Shift Dashboard</h2>
-        <span class="badge bg-secondary fs-6">@Model.Shifts.Count shifts</span>
+        <h2>@Localizer["ShiftDash_Title"]</h2>
+        <span class="badge bg-secondary fs-6">@string.Format(Localizer["ShiftDash_ShiftsCount"].Value, Model.Shifts.Count)</span>
     </div>
 
     <vc:temp-data-alerts />
@@ -20,13 +20,13 @@
         <div class="card-body">
             <form method="get" class="row g-2 align-items-end">
                 <div class="col-md-3">
-                    <label class="form-label">Date</label>
+                    <label class="form-label">@Localizer["ShiftDash_Date"]</label>
                     <input type="date" name="date" value="@Model.SelectedDate" class="form-control" />
                 </div>
                 <div class="col-md-4">
-                    <label class="form-label">Department</label>
+                    <label class="form-label">@Localizer["ShiftDash_Department"]</label>
                     <select name="departmentId" class="form-select">
-                        <option value="">All departments</option>
+                        <option value="">@Localizer["ShiftDash_AllDepartments"]</option>
                         @foreach (var dept in Model.Departments)
                         {
                             <option value="@dept.TeamId" selected="@(Model.SelectedDepartmentId == dept.TeamId ? "selected" : null)">@dept.Name</option>
@@ -34,8 +34,8 @@
                     </select>
                 </div>
                 <div class="col-md-auto">
-                    <button type="submit" class="btn btn-primary">Filter</button>
-                    <a asp-action="Index" class="btn btn-outline-secondary ms-1">Clear</a>
+                    <button type="submit" class="btn btn-primary">@Localizer["ShiftDash_Filter"]</button>
+                    <a asp-action="Index" class="btn btn-outline-secondary ms-1">@Localizer["ShiftDash_Clear"]</a>
                 </div>
             </form>
         </div>
@@ -50,7 +50,7 @@
     @* Urgency table *@
     @if (Model.Shifts.Count == 0)
     {
-        <div class="alert alert-info">No shifts match the current filters.</div>
+        <div class="alert alert-info">@Localizer["ShiftDash_NoShiftsMatch"]</div>
     }
     else
     {
@@ -58,11 +58,11 @@
             <table class="table table-hover align-middle">
                 <thead class="table-light">
                     <tr>
-                        <th>Shift</th>
-                        <th>Department</th>
-                        <th>Date / Time</th>
-                        <th>Slots</th>
-                        <th>Priority</th>
+                        <th>@Localizer["ShiftDash_Shift"]</th>
+                        <th>@Localizer["ShiftDash_Department"]</th>
+                        <th>@Localizer["ShiftDash_DateTime"]</th>
+                        <th>@Localizer["ShiftDash_Slots"]</th>
+                        <th>@Localizer["ShiftDash_Priority"]</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -82,9 +82,9 @@
                         };
                         var periodLabel = period switch
                         {
-                            ShiftPeriod.Build => "Set-up",
-                            ShiftPeriod.Event => "Event",
-                            ShiftPeriod.Strike => "Strike",
+                            ShiftPeriod.Build => Localizer["Shifts_SetUp"].Value,
+                            ShiftPeriod.Event => Localizer["Shifts_Event"].Value,
+                            ShiftPeriod.Strike => Localizer["Shifts_Strike"].Value,
                             _ => ""
                         };
                         var priorityBadge = shift.Rota.Priority switch
@@ -120,17 +120,17 @@
                                         data-bs-toggle="collapse"
                                         data-bs-target="#@collapseId"
                                         data-shift-id="@shift.Id">
-                                    Voluntell
+                                    @Localizer["ShiftDash_Voluntell"]
                                 </button>
                             </td>
                         </tr>
                         <tr class="collapse" id="@collapseId">
                             <td colspan="6">
                                 <div class="p-3 bg-light rounded border">
-                                    <label class="form-label fw-semibold">Search humans for: @shift.Rota.Name</label>
+                                    <label class="form-label fw-semibold">@string.Format(Localizer["ShiftDash_SearchHumans"].Value, shift.Rota.Name)</label>
                                     <input type="text"
                                            class="form-control mb-2 volunteer-search-input"
-                                           placeholder="Type a name (min 2 chars)..."
+                                           placeholder="@Localizer["ShiftDash_SearchPlaceholder"].Value"
                                            data-shift-id="@shift.Id"
                                            autocomplete="off" />
                                     <div class="volunteer-results" data-shift-id="@shift.Id"></div>
@@ -152,9 +152,9 @@
     ["SearchUrl"] = searchUrl,
     ["VoluntellUrl"] = voluntellUrl,
     ["AssignButtonClass"] = "btn-success",
-    ["NoResultsText"] = "No humans found.",
-    ["ErrorText"] = "Search failed.",
-    ["OverlapLabel"] = "Schedule conflict",
+    ["NoResultsText"] = Localizer["ShiftDash_NoHumansFound"].Value,
+    ["ErrorText"] = Localizer["ShiftDash_SearchFailed"].Value,
+    ["OverlapLabel"] = Localizer["ShiftDash_ScheduleConflict"].Value,
     ["DietaryPreferenceStyle"] = "muted",
     ["ShowPoolBadge"] = false
 })

--- a/src/Humans.Web/Views/Shifts/BrowsingClosed.cshtml
+++ b/src/Humans.Web/Views/Shifts/BrowsingClosed.cshtml
@@ -1,8 +1,8 @@
 @{
-    ViewData["Title"] = "Shifts";
+    ViewData["Title"] = Localizer["Shifts_Title"].Value;
 }
 
 <div class="container py-4 text-center">
-    <h2>Shifts</h2>
-    <p class="text-muted mt-4">Shift browsing is not yet open. Check back later!</p>
+    <h2>@Localizer["Shifts_Title"]</h2>
+    <p class="text-muted mt-4">@Localizer["Shifts_BrowsingClosed"]</p>
 </div>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -2,7 +2,7 @@
 @using NodaTime
 
 @{
-    ViewData["Title"] = "Shifts";
+    ViewData["Title"] = Localizer["Shifts_Title"].Value;
     var es = Model.EventSettings;
     var tz = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
 
@@ -26,9 +26,9 @@
     {
         return shift.GetShiftPeriod(es) switch
         {
-            ShiftPeriod.Build => "Set-up",
-            ShiftPeriod.Event => "Event",
-            ShiftPeriod.Strike => "Strike",
+            ShiftPeriod.Build => Localizer["Shifts_SetUp"].Value,
+            ShiftPeriod.Event => Localizer["Shifts_Event"].Value,
+            ShiftPeriod.Strike => Localizer["Shifts_Strike"].Value,
             _ => ""
         };
     }
@@ -47,12 +47,12 @@
 
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>Browse Volunteer Options</h2>
+        <h2>@Localizer["Shifts_BrowseTitle"]</h2>
         <div class="d-flex gap-2">
             <vc:access-matrix section="Shifts" />
             <a asp-controller="ShiftDashboard" asp-action="Index" class="btn btn-outline-warning" authorize-policy="ShiftDepartmentManager"><i class="fa-solid fa-gauge-high me-1"></i>Dashboard <i class="fa-solid fa-lock auth-lock-icon"></i></a>
             <a asp-action="Settings" class="btn btn-outline-secondary" authorize-policy="AdminOnly"><i class="fa-solid fa-gear me-1"></i>Settings <i class="fa-solid fa-lock auth-lock-icon"></i></a>
-            <a asp-action="Mine" class="btn btn-outline-primary">My Shifts</a>
+            <a asp-action="Mine" class="btn btn-outline-primary">@Localizer["Shifts_MyShiftsTitle"]</a>
         </div>
     </div>
 
@@ -60,9 +60,9 @@
 
     <form method="get" class="row g-2 mb-4 align-items-end">
         <div class="col-auto">
-            <label class="form-label mb-1">Department</label>
+            <label class="form-label mb-1">@Localizer["Shifts_Department"]</label>
             <select name="departmentId" class="form-select form-select-sm">
-                <option value="">All Departments</option>
+                <option value="">@Localizer["Shifts_AllDepartments"]</option>
                 @foreach (var dept in Model.AllDepartments)
                 {
                     <option value="@dept.TeamId" selected="@(Model.FilterDepartmentId == dept.TeamId ? "selected" : null)">@dept.Name</option>
@@ -70,13 +70,13 @@
             </select>
         </div>
         <div class="col-auto">
-            <label class="form-label mb-1">From</label>
+            <label class="form-label mb-1">@Localizer["Shifts_From"]</label>
             <input type="date" name="fromDate" class="form-control form-control-sm" value="@Model.FilterFromDate"
                    min="@pickerMin.ToString("yyyy-MM-dd", null)"
                    max="@pickerMax.ToString("yyyy-MM-dd", null)" />
         </div>
         <div class="col-auto">
-            <label class="form-label mb-1">To</label>
+            <label class="form-label mb-1">@Localizer["Shifts_To"]</label>
             <input type="date" name="toDate" class="form-control form-control-sm" value="@Model.FilterToDate"
                    min="@pickerMin.ToString("yyyy-MM-dd", null)"
                    max="@pickerMax.ToString("yyyy-MM-dd", null)" />
@@ -84,7 +84,7 @@
         @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterFromDate) || !string.IsNullOrEmpty(Model.FilterToDate) || !string.IsNullOrEmpty(Model.FilterPeriod) || Model.FilterTagIds.Count > 0)
         {
             <div class="col-auto">
-                <a asp-action="Index" class="btn btn-sm btn-outline-secondary">Clear Filters</a>
+                <a asp-action="Index" class="btn btn-sm btn-outline-secondary">@Localizer["Shifts_ClearFilters"]</a>
             </div>
         }
         <input type="hidden" name="period" value="@Model.FilterPeriod" />
@@ -98,20 +98,20 @@
     }
     <div class="btn-group mb-3" role="group" aria-label="Period filter">
         <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, fromDate = Model.FilterFromDate, toDate = Model.FilterToDate })"
-           class="btn btn-sm @(string.IsNullOrEmpty(activePeriod) ? "btn-primary" : "btn-outline-primary")">All</a>
+           class="btn btn-sm @(string.IsNullOrEmpty(activePeriod) ? "btn-primary" : "btn-outline-primary")">@Localizer["Shifts_All"]</a>
         <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Build" })"
-           class="btn btn-sm @(activePeriod == "Build" ? "btn-info" : "btn-outline-info")">Set-up</a>
+           class="btn btn-sm @(activePeriod == "Build" ? "btn-info" : "btn-outline-info")">@Localizer["Shifts_SetUp"]</a>
         <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Event" })"
-           class="btn btn-sm @(activePeriod == "Event" ? "btn-success" : "btn-outline-success")">Event</a>
+           class="btn btn-sm @(activePeriod == "Event" ? "btn-success" : "btn-outline-success")">@Localizer["Shifts_Event"]</a>
         <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Strike" })"
-           class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">Strike</a>
+           class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">@Localizer["Shifts_Strike"]</a>
     </div>
 
     @if (Model.AllTags.Count > 0)
     {
         <div class="mb-3">
             <div class="d-flex flex-wrap gap-1 align-items-center">
-                <small class="text-muted me-1"><i class="fa-solid fa-tags me-1"></i>Filter by tag:</small>
+                <small class="text-muted me-1"><i class="fa-solid fa-tags me-1"></i>@Localizer["Shifts_FilterByTag"]</small>
                 @foreach (var tag in Model.AllTags)
                 {
                     var isActive = Model.FilterTagIds.Contains(tag.Id);
@@ -150,7 +150,7 @@
     {
         <div class="mb-3">
             <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#tag-preferences-panel">
-                <i class="fa-solid fa-sliders me-1"></i>Set your preferences
+                <i class="fa-solid fa-sliders me-1"></i>@Localizer["Shifts_SetPreferences"]
                 @if (Model.UserPreferredTagIds.Count > 0)
                 {
                     <span class="badge bg-primary ms-1">@Model.UserPreferredTagIds.Count</span>
@@ -158,7 +158,7 @@
             </button>
             <div class="collapse @(Model.UserPreferredTagIds.Count == 0 ? "" : "")" id="tag-preferences-panel">
                 <div class="card card-body mt-2">
-                    <p class="small text-muted mb-2">Select tags that match the kind of work you enjoy. Matching shifts will be highlighted with a <i class="fa-solid fa-star text-warning"></i>.</p>
+                    <p class="small text-muted mb-2">@Localizer["Shifts_PreferencesHelp"] <i class="fa-solid fa-star text-warning"></i></p>
                     <form asp-action="SaveTagPreferences" method="post">
                         @Html.AntiForgeryToken()
                         <div class="d-flex flex-wrap gap-2 mb-2">
@@ -172,7 +172,7 @@
                                 </div>
                             }
                         </div>
-                        <button type="submit" class="btn btn-sm btn-primary">Save Preferences</button>
+                        <button type="submit" class="btn btn-sm btn-primary">@Localizer["Shifts_SavePreferences"]</button>
                     </form>
                 </div>
             </div>
@@ -194,12 +194,12 @@
 
     @if (!Model.EventSettings.IsShiftBrowsingOpen)
     {
-        <div class="alert alert-danger">Shifts aren't open yet. Only coordinators and admins can see this page.</div>
+        <div class="alert alert-danger">@Localizer["Shifts_NotOpenYet"]</div>
     }
 
     @if (Model.Departments.Count == 0)
     {
-        <div class="alert alert-info">No shifts available yet.</div>
+        <div class="alert alert-info">@Localizer["Shifts_NoShiftsAvailable"]</div>
     }
     else
     {
@@ -218,9 +218,9 @@
                     }
                     @foreach (var periodGroup in rotasByPeriod)
                     {
-                        var periodName = periodGroup.Key == RotaPeriod.Build ? "Set-up"
-                            : periodGroup.Key == RotaPeriod.Strike ? "Strike"
-                            : "Event";
+                        var periodName = periodGroup.Key == RotaPeriod.Build ? Localizer["Shifts_SetUp"].Value
+                            : periodGroup.Key == RotaPeriod.Strike ? Localizer["Shifts_Strike"].Value
+                            : Localizer["Shifts_Event"].Value;
                         <h5 class="mt-4 mb-2 border-bottom pb-1">
                             <span class="badge @(periodGroup.Key == RotaPeriod.Build ? "bg-info" : periodGroup.Key == RotaPeriod.Strike ? "bg-secondary" : "bg-success") me-1">@periodName</span>
                             @periodName
@@ -228,7 +228,7 @@
                         var hasAvailable = periodGroup.Any(r => r.Shifts.Any(s => s.RemainingSlots > 0));
                         @if (!hasAvailable)
                         {
-                            <p class="text-muted fst-italic">All @periodName.ToLowerInvariant() shifts are full.</p>
+                            <p class="text-muted fst-italic">@string.Format(Localizer["Shifts_AllShiftsFull"].Value, periodName.ToLowerInvariant())</p>
                         }
                     @foreach (var rotaGroup in periodGroup)
                     {
@@ -240,21 +240,21 @@
                         <h6 class="mt-3">
                             @if (rotaMatchesPreference)
                             {
-                                <i class="fa-solid fa-star text-warning me-1" title="Matches your preferences"></i>
+                                <i class="fa-solid fa-star text-warning me-1" title="@Localizer["Shifts_MatchesPrefs"].Value"></i>
                             }
                             @rotaGroup.Rota.Name
                             @if (rotaGroup.Rota.Priority == ShiftPriority.Essential)
                             {
-                                <span class="badge bg-danger ms-1">Essential</span>
+                                <span class="badge bg-danger ms-1">@Localizer["Shifts_Essential"]</span>
                             }
                             else if (rotaGroup.Rota.Priority == ShiftPriority.Important)
                             {
-                                <span class="badge bg-warning text-dark ms-1">Important</span>
+                                <span class="badge bg-warning text-dark ms-1">@Localizer["Shifts_Important"]</span>
                             }
-                            <span class="badge @(rotaGroup.Rota.Period switch { RotaPeriod.Build => "bg-info", RotaPeriod.Strike => "bg-secondary", RotaPeriod.All => "bg-primary", _ => "bg-success" }) ms-1">@(rotaGroup.Rota.Period switch { RotaPeriod.Build => "Set-up", RotaPeriod.All => "All Phases", _ => rotaGroup.Rota.Period.ToString() })</span>
+                            <span class="badge @(rotaGroup.Rota.Period switch { RotaPeriod.Build => "bg-info", RotaPeriod.Strike => "bg-secondary", RotaPeriod.All => "bg-primary", _ => "bg-success" }) ms-1">@(rotaGroup.Rota.Period switch { RotaPeriod.Build => Localizer["Shifts_SetUp"].Value, RotaPeriod.All => Localizer["Shifts_AllPhases"].Value, _ => rotaGroup.Rota.Period.ToString() })</span>
                             @if (!rotaGroup.Rota.IsVisibleToVolunteers)
                             {
-                                <span class="badge bg-warning text-dark ms-1"><i class="fa-solid fa-eye-slash me-1"></i>Hidden</span>
+                                <span class="badge bg-warning text-dark ms-1"><i class="fa-solid fa-eye-slash me-1"></i>@Localizer["Shifts_HiddenBadge"]</span>
                             }
                             @foreach (var tag in rotaGroup.Rota.Tags.OrderBy(t => t.Name, StringComparer.Ordinal))
                             {
@@ -286,7 +286,7 @@
                                     @if (!string.IsNullOrEmpty(Model.FilterPeriod)) { <input type="hidden" name="period" value="@Model.FilterPeriod" /> }
                                     @foreach (var tagId in Model.FilterTagIds) { <input type="hidden" name="tags" value="@tagId" /> }
                                     <div class="col-auto">
-                                        <label class="form-label form-label-sm">Start</label>
+                                        <label class="form-label form-label-sm">@Localizer["Shifts_Start"]</label>
                                         <select name="startDayOffset" class="form-select form-select-sm">
                                             @foreach (var s in availableShifts)
                                             {
@@ -295,7 +295,7 @@
                                         </select>
                                     </div>
                                     <div class="col-auto">
-                                        <label class="form-label form-label-sm">End</label>
+                                        <label class="form-label form-label-sm">@Localizer["Shifts_End"]</label>
                                         <select name="endDayOffset" class="form-select form-select-sm">
                                             @foreach (var s in availableShifts)
                                             {
@@ -304,7 +304,7 @@
                                         </select>
                                     </div>
                                     <div class="col-auto">
-                                        <button type="submit" class="btn btn-sm btn-success">Sign up for @(rotaGroup.Rota.Period == RotaPeriod.Build ? "set-up" : "strike") dates</button>
+                                        <button type="submit" class="btn btn-sm btn-success">@string.Format(Localizer["Shifts_SignUpForDates"].Value, rotaGroup.Rota.Period == RotaPeriod.Build ? Localizer["Shifts_SetUp"].Value.ToLowerInvariant() : Localizer["Shifts_Strike"].Value.ToLowerInvariant())</button>
                                     </div>
                                 </form>
                             }
@@ -325,7 +325,7 @@
                             <div class="table-responsive">
                                 <table class="table table-sm">
                                     <thead>
-                                        <tr><th>Date</th><th>Filled</th><th>Status</th>@if (Model.ShowSignups) {<th>@Localizer["Shifts_SignedUp"]</th>}</tr>
+                                        <tr><th>@Localizer["Shifts_Date"]</th><th>@Localizer["Shifts_Filled"]</th><th>@Localizer["Common_Status"]</th>@if (Model.ShowSignups) {<th>@Localizer["Shifts_SignedUp"]</th>}</tr>
                                     </thead>
                                     <tbody>
                                         @foreach (var range in dateRanges)
@@ -345,33 +345,33 @@
                                                     <td>
                                                         <i class="fa-solid fa-chevron-right fa-xs me-1 range-icon"></i>
                                                         @rangeStart.ToDisplayShiftDate()–@rangeEnd.ToDisplayShiftDate()
-                                                        <small class="text-muted">(@range.Count days)</small>
+                                                        <small class="text-muted">(@range.Count @Localizer["Shifts_Days"])</small>
                                                     </td>
                                                     <td>
                                                         <span class="@(anyUnderstaffed ? "text-danger fw-bold" : "")">@totalConfirmed</span>
-                                                        <small class="text-muted">/ @totalMax total</small>
+                                                        <small class="text-muted">/ @totalMax @Localizer["Shifts_Total"]</small>
                                                     </td>
                                                     <td>
                                                         @if (userSignedUpDays == range.Count)
                                                         {
-                                                            <span class="badge bg-info">Signed up (all @range.Count days)</span>
+                                                            <span class="badge bg-info">@string.Format(Localizer["Shifts_SignedUpAllDays"].Value, range.Count)</span>
                                                         }
                                                         else if (userSignedUpDays > 0)
                                                         {
-                                                            <span class="badge bg-info">Signed up (@userSignedUpDays of @range.Count)</span>
+                                                            <span class="badge bg-info">@string.Format(Localizer["Shifts_SignedUpPartial"].Value, userSignedUpDays, range.Count)</span>
                                                         }
                                                         else if (allRangeFull)
                                                         {
-                                                            <span class="badge bg-secondary">Full</span>
+                                                            <span class="badge bg-secondary">@Localizer["Shifts_Full"]</span>
                                                         }
                                                         else if (daysNeedingHelp > 0)
                                                         {
-                                                            <span class="badge bg-warning text-dark">@daysNeedingHelp @(daysNeedingHelp == 1 ? "day needs" : "days need") help</span>
+                                                            <span class="badge bg-warning text-dark">@string.Format((daysNeedingHelp == 1 ? Localizer["Shifts_DayNeedsHelp"] : Localizer["Shifts_DaysNeedHelp"]).Value, daysNeedingHelp)</span>
                                                         }
                                                     </td>
                                                     @if (Model.ShowSignups)
                                                     {
-                                                        <td><small class="text-muted fst-italic">click to expand</small></td>
+                                                        <td><small class="text-muted fst-italic">@Localizer["Shifts_ClickToExpand"]</small></td>
                                                     }
                                                 </tr>
                                                 @foreach (var item in range)
@@ -387,15 +387,15 @@
                                                         <td>
                                                             @if (Model.UserSignupShiftIds.Contains(item.Shift.Id))
                                                             {
-                                                                <span class="badge bg-info">Signed up</span>
+                                                                <span class="badge bg-info">@Localizer["Shifts_SignedUp"]</span>
                                                             }
                                                             else if (isFull)
                                                             {
-                                                                <span class="badge bg-secondary">Full</span>
+                                                                <span class="badge bg-secondary">@Localizer["Shifts_Full"]</span>
                                                             }
                                                             else if (understaffed)
                                                             {
-                                                                <span class="badge bg-warning text-dark">Needs help</span>
+                                                                <span class="badge bg-warning text-dark">@Localizer["Shifts_NeedsHelp"]</span>
                                                             }
                                                         </td>
                                                         @if (Model.ShowSignups)
@@ -438,15 +438,15 @@
                                                     <td>
                                                         @if (Model.UserSignupShiftIds.Contains(item.Shift.Id))
                                                         {
-                                                            <span class="badge bg-info">Signed up</span>
+                                                            <span class="badge bg-info">@Localizer["Shifts_SignedUp"]</span>
                                                         }
                                                         else if (isFull)
                                                         {
-                                                            <span class="badge bg-secondary">Full</span>
+                                                            <span class="badge bg-secondary">@Localizer["Shifts_Full"]</span>
                                                         }
                                                         else if (understaffed)
                                                         {
-                                                            <span class="badge bg-warning text-dark">Needs help</span>
+                                                            <span class="badge bg-warning text-dark">@Localizer["Shifts_NeedsHelp"]</span>
                                                         }
                                                     </td>
                                                     @if (Model.ShowSignups)
@@ -488,12 +488,12 @@
                                 <table class="table table-sm">
                                     <thead>
                                         <tr>
-                                            <th>Shift</th>
-                                            <th>Phase</th>
-                                            <th>Date</th>
-                                            <th>Time</th>
-                                            <th>Duration</th>
-                                            <th>Filled</th>
+                                            <th>@Localizer["Shifts_Shift"]</th>
+                                            <th>@Localizer["Shifts_Phase"]</th>
+                                            <th>@Localizer["Shifts_Date"]</th>
+                                            <th>@Localizer["Shifts_Time"]</th>
+                                            <th>@Localizer["Shifts_Duration"]</th>
+                                            <th>@Localizer["Shifts_Filled"]</th>
                                             @if (Model.ShowSignups)
                                             {
                                                 <th>@Localizer["Shifts_SignedUp"]</th>
@@ -508,17 +508,17 @@
                                             var isFull = item.RemainingSlots <= 0;
                                             var understaffed = item.ConfirmedCount < shift.MinVolunteers;
                                             <tr class="@(isFull ? "table-secondary" : "")">
-                                                <td>@(shift.IsAllDay ? "All day" : $"{shift.StartTime.ToDisplayTime()}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes).ToDisplayTime()}")</td>
+                                                <td>@(shift.IsAllDay ? Localizer["Shifts_AllDay"].Value : $"{shift.StartTime.ToDisplayTime()}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes).ToDisplayTime()}")</td>
                                                 <td><span class="badge @GetPhaseBadge(shift, es)">@GetPhase(shift, es)</span></td>
                                                 <td>@es.GateOpeningDate.PlusDays(shift.DayOffset).ToDisplayShiftDate()</td>
                                                 <td>@item.AbsoluteStart.ToDisplayTime(tz)</td>
-                                                <td>@(shift.IsAllDay ? "Full day" : $"{shift.Duration.TotalHours}h")</td>
+                                                <td>@(shift.IsAllDay ? Localizer["Shifts_FullDay"].Value : $"{shift.Duration.TotalHours}h")</td>
                                                 <td>
                                                     <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
                                                     <small class="text-muted">/ @shift.MinVolunteers–@shift.MaxVolunteers</small>
                                                     @if (understaffed)
                                                     {
-                                                        <span class="badge bg-warning text-dark">Needs help</span>
+                                                        <span class="badge bg-warning text-dark">@Localizer["Shifts_NeedsHelp"]</span>
                                                     }
                                                 </td>
                                                 @if (Model.ShowSignups)
@@ -542,7 +542,7 @@
                                                     }
                                                     else if (isFull)
                                                     {
-                                                        <span class="badge bg-secondary">Full</span>
+                                                        <span class="badge bg-secondary">@Localizer["Shifts_Full"]</span>
                                                     }
                                                     else
                                                     {
@@ -554,7 +554,7 @@
                                                             @if (!string.IsNullOrEmpty(Model.FilterToDate)) { <input type="hidden" name="toDate" value="@Model.FilterToDate" /> }
                                                             @if (!string.IsNullOrEmpty(Model.FilterPeriod)) { <input type="hidden" name="period" value="@Model.FilterPeriod" /> }
                                                             @foreach (var tagId in Model.FilterTagIds) { <input type="hidden" name="tags" value="@tagId" /> }
-                                                            <button type="submit" class="btn btn-sm btn-success">Sign Up</button>
+                                                            <button type="submit" class="btn btn-sm btn-success">@Localizer["Shifts_SignUpButton"]</button>
                                                         </form>
                                                     }
                                                 </td>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -280,6 +280,11 @@
                                 <form asp-action="SignUpRange" method="post" class="row g-2 align-items-end mb-3">
                                     @Html.AntiForgeryToken()
                                     <input type="hidden" name="rotaId" value="@rotaGroup.Rota.Id" />
+                                    @if (Model.FilterDepartmentId.HasValue) { <input type="hidden" name="departmentId" value="@Model.FilterDepartmentId" /> }
+                                    @if (!string.IsNullOrEmpty(Model.FilterFromDate)) { <input type="hidden" name="fromDate" value="@Model.FilterFromDate" /> }
+                                    @if (!string.IsNullOrEmpty(Model.FilterToDate)) { <input type="hidden" name="toDate" value="@Model.FilterToDate" /> }
+                                    @if (!string.IsNullOrEmpty(Model.FilterPeriod)) { <input type="hidden" name="period" value="@Model.FilterPeriod" /> }
+                                    @foreach (var tagId in Model.FilterTagIds) { <input type="hidden" name="tags" value="@tagId" /> }
                                     <div class="col-auto">
                                         <label class="form-label form-label-sm">Start</label>
                                         <select name="startDayOffset" class="form-select form-select-sm">
@@ -544,6 +549,11 @@
                                                         <form asp-action="SignUp" method="post" class="d-inline">
                                                             @Html.AntiForgeryToken()
                                                             <input type="hidden" name="shiftId" value="@shift.Id" />
+                                                            @if (Model.FilterDepartmentId.HasValue) { <input type="hidden" name="departmentId" value="@Model.FilterDepartmentId" /> }
+                                                            @if (!string.IsNullOrEmpty(Model.FilterFromDate)) { <input type="hidden" name="fromDate" value="@Model.FilterFromDate" /> }
+                                                            @if (!string.IsNullOrEmpty(Model.FilterToDate)) { <input type="hidden" name="toDate" value="@Model.FilterToDate" /> }
+                                                            @if (!string.IsNullOrEmpty(Model.FilterPeriod)) { <input type="hidden" name="period" value="@Model.FilterPeriod" /> }
+                                                            @foreach (var tagId in Model.FilterTagIds) { <input type="hidden" name="tags" value="@tagId" /> }
                                                             <button type="submit" class="btn btn-sm btn-success">Sign Up</button>
                                                         </form>
                                                     }

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -562,7 +562,7 @@
                                             @if (!string.IsNullOrEmpty(shift.Description))
                                             {
                                                 <tr class="@(isFull ? "table-secondary" : "")">
-                                                    <td colspan="8" class="text-muted small pt-0 pb-1 border-0">
+                                                    <td colspan="@(Model.ShowSignups ? 8 : 7)" class="text-muted small pt-0 pb-1 border-0">
                                                         @Html.SanitizedMarkdown(shift.Description)
                                                     </td>
                                                 </tr>

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -33,6 +33,13 @@
 }
 
 <div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-action="Index">Shifts</a></li>
+            <li class="breadcrumb-item active" aria-current="page">My Shifts</li>
+        </ol>
+    </nav>
+
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>@Localizer["Shifts_MyShiftsTitle"]</h2>
         <a asp-action="Index" class="btn btn-outline-primary">@Localizer["Shifts_BrowseTitle"]</a>

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -2,7 +2,7 @@
 @using NodaTime
 
 @{
-    ViewData["Title"] = "My Shifts";
+    ViewData["Title"] = Localizer["Shifts_MyShiftsTitle"].Value;
     var tz = Model.EventSettings != null ? DateTimeZoneProviders.Tzdb[Model.EventSettings.TimeZoneId] : null;
 }
 
@@ -12,9 +12,9 @@
         var period = shift.GetShiftPeriod(es);
         return period switch
         {
-            ShiftPeriod.Build => "Set-up",
-            ShiftPeriod.Event => "Event",
-            ShiftPeriod.Strike => "Strike",
+            ShiftPeriod.Build => Localizer["Shifts_SetUp"].Value,
+            ShiftPeriod.Event => Localizer["Shifts_Event"].Value,
+            ShiftPeriod.Strike => Localizer["Shifts_Strike"].Value,
             _ => ""
         };
     }
@@ -34,15 +34,15 @@
 
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>My Shifts</h2>
-        <a asp-action="Index" class="btn btn-outline-primary">Browse Volunteer Options</a>
+        <h2>@Localizer["Shifts_MyShiftsTitle"]</h2>
+        <a asp-action="Index" class="btn btn-outline-primary">@Localizer["Shifts_BrowseTitle"]</a>
     </div>
 
     <vc:temp-data-alerts />
 
     @if (Model.EventSettings == null)
     {
-        <div class="alert alert-info">No active event configured.</div>
+        <div class="alert alert-info">@Localizer["Shifts_NoActiveEventConfigured"]</div>
     }
     else
     {
@@ -51,7 +51,7 @@
         @if (Model.Upcoming.Count > 0)
         {
             <div class="card mb-4">
-                <div class="card-header"><h5 class="mb-0">Upcoming Shifts</h5></div>
+                <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_UpcomingShifts"]</h5></div>
                 <div class="card-body">
                     @{
                         // Group build/strike range signups by SignupBlockId, show individual signups separately
@@ -83,7 +83,7 @@
                                     @Html.AntiForgeryToken()
                                     <input type="hidden" name="signupBlockId" value="@block.Key" />
                                     <button type="submit" class="btn btn-sm btn-outline-danger"
-                                            data-confirm="Bail from all @block.Count() days?">Bail</button>
+                                            data-confirm="@string.Format(Localizer["Shifts_BailRangeConfirm"].Value, block.Count())">@Localizer["Shifts_Bail"]</button>
                                 </form>
                             </div>
                         }
@@ -94,7 +94,7 @@
                         <div class="table-responsive">
                             <table class="table table-sm">
                                 <thead>
-                                    <tr><th>Department</th><th>Shift</th><th>Phase</th><th>Date</th><th>Time</th><th>Duration</th><th></th></tr>
+                                    <tr><th>@Localizer["Shifts_Department"]</th><th>@Localizer["Shifts_Shift"]</th><th>@Localizer["Shifts_Phase"]</th><th>@Localizer["Shifts_Date"]</th><th>@Localizer["Shifts_Time"]</th><th>@Localizer["Shifts_Duration"]</th><th></th></tr>
                                 </thead>
                                 <tbody>
                                     @foreach (var item in individualItems)
@@ -112,7 +112,7 @@
                                                     @Html.AntiForgeryToken()
                                                     <input type="hidden" name="signupId" value="@item.Signup.Id" />
                                                     <button type="submit" class="btn btn-sm btn-outline-danger"
-                                                            data-confirm="Are you sure you want to bail?">Bail</button>
+                                                            data-confirm="@Localizer["Shifts_BailConfirm"].Value">@Localizer["Shifts_Bail"]</button>
                                                 </form>
                                             </td>
                                         </tr>
@@ -128,12 +128,12 @@
         @if (Model.Pending.Count > 0)
         {
             <div class="card mb-4">
-                <div class="card-header"><h5 class="mb-0">Pending Approval</h5></div>
+                <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_PendingApproval"]</h5></div>
                 <div class="card-body">
                     <div class="table-responsive">
                         <table class="table table-sm">
                             <thead>
-                                <tr><th>Department</th><th>Shift</th><th>Phase</th><th>Date</th><th>Time</th><th>Duration</th><th></th></tr>
+                                <tr><th>@Localizer["Shifts_Department"]</th><th>@Localizer["Shifts_Shift"]</th><th>@Localizer["Shifts_Phase"]</th><th>@Localizer["Shifts_Date"]</th><th>@Localizer["Shifts_Time"]</th><th>@Localizer["Shifts_Duration"]</th><th></th></tr>
                             </thead>
                             <tbody>
                                 @foreach (var item in Model.Pending)
@@ -150,7 +150,7 @@
                                             <form asp-action="Bail" method="post" class="d-inline">
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="signupId" value="@item.Signup.Id" />
-                                                <button type="submit" class="btn btn-sm btn-outline-secondary">Withdraw</button>
+                                                <button type="submit" class="btn btn-sm btn-outline-secondary">@Localizer["Shifts_WithdrawButton"]</button>
                                             </form>
                                         </td>
                                     </tr>
@@ -165,12 +165,12 @@
         @if (Model.Past.Count > 0)
         {
             <div class="card mb-4">
-                <div class="card-header"><h5 class="mb-0">Past</h5></div>
+                <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_Past"]</h5></div>
                 <div class="card-body">
                     <div class="table-responsive">
                         <table class="table table-sm">
                             <thead>
-                                <tr><th>Department</th><th>Shift</th><th>Phase</th><th>Date</th><th>Time</th><th>Duration</th><th>Status</th></tr>
+                                <tr><th>@Localizer["Shifts_Department"]</th><th>@Localizer["Shifts_Shift"]</th><th>@Localizer["Shifts_Phase"]</th><th>@Localizer["Shifts_Date"]</th><th>@Localizer["Shifts_Time"]</th><th>@Localizer["Shifts_Duration"]</th><th>@Localizer["Common_Status"]</th></tr>
                             </thead>
                             <tbody>
                                 @foreach (var item in Model.Past)
@@ -195,14 +195,14 @@
 
         @if (Model.Upcoming.Count == 0 && Model.Pending.Count == 0 && Model.Past.Count == 0)
         {
-            <div class="alert alert-info">No shift signups yet. <a asp-action="Index">Browse available shifts</a>.</div>
+            <div class="alert alert-info">@Localizer["Shifts_NoSignups"] <a asp-action="Index">@Localizer["Shifts_BrowseAvailable"]</a>.</div>
         }
 
         @* General Availability *@
         <div class="card mb-4">
-            <div class="card-header"><h5 class="mb-0">General Availability</h5></div>
+            <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_GeneralAvailability"]</h5></div>
             <div class="card-body">
-                <p class="text-muted small">Mark which days you're available to help. Coordinators can see who's in the pool when assigning shifts.</p>
+                <p class="text-muted small">@Localizer["Shifts_AvailabilityHelp"]</p>
                 <form asp-action="SaveAvailability" method="post">
                     @Html.AntiForgeryToken()
                     <div class="row row-cols-auto g-2 mb-3">
@@ -220,7 +220,7 @@
                             </div>
                         }
                     </div>
-                    <button type="submit" class="btn btn-sm btn-primary">Save Availability</button>
+                    <button type="submit" class="btn btn-sm btn-primary">@Localizer["Shifts_SaveAvailability"]</button>
                 </form>
             </div>
         </div>

--- a/src/Humans.Web/Views/Shifts/NoActiveEvent.cshtml
+++ b/src/Humans.Web/Views/Shifts/NoActiveEvent.cshtml
@@ -1,9 +1,9 @@
 @{
-    ViewData["Title"] = "Shifts";
+    ViewData["Title"] = Localizer["Shifts_Title"].Value;
 }
 
 <div class="container py-4 text-center">
-    <h2>Shifts</h2>
-    <p class="text-muted mt-4">No active event is configured. An admin needs to set up event settings first.</p>
-    <a asp-action="Settings" class="btn btn-primary mt-2" authorize-policy="AdminOnly">Configure Event Settings <i class="fa-solid fa-lock auth-lock-icon"></i></a>
+    <h2>@Localizer["Shifts_Title"]</h2>
+    <p class="text-muted mt-4">@Localizer["Shifts_NoActiveEvent"]</p>
+    <a asp-action="Settings" class="btn btn-primary mt-2" authorize-policy="AdminOnly">@Localizer["Shifts_ConfigureEvent"] <i class="fa-solid fa-lock auth-lock-icon"></i></a>
 </div>

--- a/src/Humans.Web/Views/Shifts/Settings.cshtml
+++ b/src/Humans.Web/Views/Shifts/Settings.cshtml
@@ -5,6 +5,13 @@
 }
 
 <div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-action="Index">Shifts</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Event Settings</li>
+        </ol>
+    </nav>
+
     <h2>Event Settings</h2>
     <hr />
 

--- a/src/Humans.Web/Views/Team/MyTeams.cshtml
+++ b/src/Humans.Web/Views/Team/MyTeams.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = Localizer["MyTeams_Title"].Value;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Teams_Title"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["MyTeams_Title"]</li>
+    </ol>
+</nav>
+
 <h1>@Localizer["MyTeams_Title"]</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Team/Roster.cshtml
+++ b/src/Humans.Web/Views/Team/Roster.cshtml
@@ -4,6 +4,13 @@
     ViewData["Title"] = "Team Roster";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Teams_Title"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Team Roster</li>
+    </ol>
+</nav>
+
 <h2>Team Roster</h2>
 
 <div class="mb-3 d-flex gap-2">

--- a/src/Humans.Web/Views/Team/Roster.cshtml
+++ b/src/Humans.Web/Views/Team/Roster.cshtml
@@ -119,7 +119,7 @@ else
                 @if (isFirstSlotForRole)
                 {
                     <tr class="collapse" id="@collapseId">
-                        <td colspan="5">
+                        <td colspan="6">
                             <div class="role-description small text-muted">
                                 @Html.SanitizedMarkdown(slot.RoleDescription)
                             </div>

--- a/src/Humans.Web/Views/Team/Summary.cshtml
+++ b/src/Humans.Web/Views/Team/Summary.cshtml
@@ -6,6 +6,13 @@
     ViewData["Title"] = "Teams Summary";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Teams_Title"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Teams Summary</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Teams Summary</h1>
     <a asp-action="CreateTeam" class="btn btn-primary" authorize-policy="BoardOrAdmin">@Localizer["Teams_CreateTeam"]</a>

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -128,6 +128,45 @@
         </div>
     }
 
+    <!-- Participation Breakdown -->
+    @{
+        var participationTotal = Model.ParticipationNotAttending + Model.ParticipationNoTicket + Model.ParticipationHasTicket;
+    }
+    @if (participationTotal > 0)
+    {
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-chart-pie"></i> Participation Breakdown
+            </div>
+            <div class="card-body">
+                <div class="row align-items-center">
+                    <div class="col-md-6">
+                        <canvas id="participationChart" height="200"></canvas>
+                    </div>
+                    <div class="col-md-6">
+                        <ul class="list-unstyled">
+                            <li class="mb-2">
+                                <span class="badge bg-success">&nbsp;&nbsp;</span>
+                                <strong>Has Ticket:</strong> @Model.ParticipationHasTicket
+                                (@(participationTotal > 0 ? Math.Round((decimal)Model.ParticipationHasTicket / participationTotal * 100) : 0)%)
+                            </li>
+                            <li class="mb-2">
+                                <span class="badge bg-warning">&nbsp;&nbsp;</span>
+                                <strong>No Ticket:</strong> @Model.ParticipationNoTicket
+                                (@(participationTotal > 0 ? Math.Round((decimal)Model.ParticipationNoTicket / participationTotal * 100) : 0)%)
+                            </li>
+                            <li class="mb-2">
+                                <span class="badge bg-secondary">&nbsp;&nbsp;</span>
+                                <strong>Not Coming:</strong> @Model.ParticipationNotAttending
+                                (@(participationTotal > 0 ? Math.Round((decimal)Model.ParticipationNotAttending / participationTotal * 100) : 0)%)
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+
     <!-- Daily Sales Chart -->
     @if (Model.DailySales.Count > 0)
     {
@@ -312,46 +351,74 @@
     </div>
 </div>
 
-@if (Model.DailySales.Count > 0)
+@if (Model.DailySales.Count > 0 || participationTotal > 0)
 {
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
             integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
             crossorigin="anonymous"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            var data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.DailySales, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
-            var ctx = document.getElementById('dailySalesChart').getContext('2d');
-            new Chart(ctx, {
-                type: 'bar',
-                data: {
-                    labels: data.map(d => d.date),
-                    datasets: [
-                        {
-                            label: 'Tickets Sold',
-                            data: data.map(d => d.ticketsSold),
-                            backgroundColor: 'rgba(54, 162, 235, 0.6)',
-                            order: 2
-                        },
-                        {
-                            label: '7-day Avg',
-                            data: data.map(d => d.rollingAverage),
-                            type: 'line',
-                            borderColor: 'rgba(255, 99, 132, 1)',
-                            borderWidth: 2,
-                            fill: false,
-                            pointRadius: 0,
-                            order: 1
+            @if (Model.DailySales.Count > 0)
+            {
+                <text>
+                var salesData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.DailySales, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
+                var salesCtx = document.getElementById('dailySalesChart').getContext('2d');
+                new Chart(salesCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: salesData.map(d => d.date),
+                        datasets: [
+                            {
+                                label: 'Tickets Sold',
+                                data: salesData.map(d => d.ticketsSold),
+                                backgroundColor: 'rgba(54, 162, 235, 0.6)',
+                                order: 2
+                            },
+                            {
+                                label: '7-day Avg',
+                                data: salesData.map(d => d.rollingAverage),
+                                type: 'line',
+                                borderColor: 'rgba(255, 99, 132, 1)',
+                                borderWidth: 2,
+                                fill: false,
+                                pointRadius: 0,
+                                order: 1
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        scales: {
+                            x: { display: true },
+                            y: { beginAtZero: true, title: { display: true, text: 'Tickets' } }
                         }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    scales: {
-                        x: { display: true },
-                        y: { beginAtZero: true, title: { display: true, text: 'Tickets' } }
                     }
-                }
-            });
+                });
+                </text>
+            }
+
+            @if (participationTotal > 0)
+            {
+                <text>
+                var partCtx = document.getElementById('participationChart').getContext('2d');
+                new Chart(partCtx, {
+                    type: 'doughnut',
+                    data: {
+                        labels: ['Has Ticket', 'No Ticket', 'Not Coming'],
+                        datasets: [{
+                            data: [@Model.ParticipationHasTicket, @Model.ParticipationNoTicket, @Model.ParticipationNotAttending],
+                            backgroundColor: ['#198754', '#ffc107', '#6c757d']
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        plugins: {
+                            legend: { position: 'bottom' }
+                        }
+                    }
+                });
+                </text>
+            }
         });
     </script>
 }

--- a/src/Humans.Web/Views/Ticket/Orders.cshtml
+++ b/src/Humans.Web/Views/Ticket/Orders.cshtml
@@ -146,7 +146,7 @@
                 }
                 @if (Model.Orders.Count == 0)
                 {
-                    <tr><td colspan="15" class="text-muted text-center">No orders found</td></tr>
+                    <tr><td colspan="14" class="text-muted text-center">No orders found</td></tr>
                 }
             </tbody>
         </table>

--- a/src/Humans.Web/Views/Ticket/ParticipationBackfill.cshtml
+++ b/src/Humans.Web/Views/Ticket/ParticipationBackfill.cshtml
@@ -1,0 +1,44 @@
+@model Humans.Web.Models.ParticipationBackfillViewModel
+@{
+    ViewData["Title"] = "Backfill Participation Data";
+}
+
+<div class="container-fluid px-4">
+    <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
+        <h1 class="mb-0">Backfill Participation Data</h1>
+    </div>
+
+    <partial name="_TicketNav" />
+
+    <vc:temp-data-alerts />
+
+    <div class="card">
+        <div class="card-body">
+            <p class="text-muted">
+                Paste CSV data with <code>UserId,Status</code> columns to bulk-import historical participation records.
+                Valid statuses: <code>NotAttending</code>, <code>Ticketed</code>, <code>Attended</code>, <code>NoShow</code>.
+                Existing Attended records will not be overwritten (permanent).
+            </p>
+
+            <form asp-action="ParticipationBackfill" method="post">
+                @Html.AntiForgeryToken()
+
+                <div class="mb-3">
+                    <label asp-for="Year" class="form-label">Year</label>
+                    <input asp-for="Year" class="form-control" style="max-width: 200px;" />
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="CsvData" class="form-label">CSV Data</label>
+                    <textarea asp-for="CsvData" class="form-control font-monospace" rows="10"
+                              placeholder="UserId,Status&#10;3fa85f64-5717-4562-b3fc-2c963f66afa6,Attended&#10;..."></textarea>
+                </div>
+
+                <button type="submit" class="btn btn-primary">
+                    <i class="fa-solid fa-upload me-1"></i> Import
+                </button>
+                <a asp-action="Index" class="btn btn-outline-secondary ms-2">Cancel</a>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Ticket/_TicketNav.cshtml
+++ b/src/Humans.Web/Views/Ticket/_TicketNav.cshtml
@@ -23,4 +23,7 @@
     <li class="nav-item">
         <a class="nav-link @(controller == "GateList" ? "active" : "")" asp-action="GateList">Gate List</a>
     </li>
+    <li class="nav-item" authorize-policy="AdminOnly">
+        <a class="nav-link @(controller == "ParticipationBackfill" ? "active" : "")" asp-action="ParticipationBackfill">Backfill</a>
+    </li>
 </ul>

--- a/src/Humans.Web/Views/Unsubscribe/Done.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Done.cshtml
@@ -8,8 +8,7 @@
 <p>You will no longer receive @categoryName emails from Humans.</p>
 
 <p>
-    You can manage all your communication preferences from your
-    <a asp-controller="Account" asp-action="Login">communication preferences</a>.
+    <a asp-controller="Account" asp-action="Login">Sign in to manage your communication preferences</a>.
 </p>
 
 <p><a asp-controller="Home" asp-action="Index">Back to home</a></p>

--- a/src/Humans.Web/Views/Unsubscribe/Done.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Done.cshtml
@@ -1,14 +1,15 @@
 @{
-    ViewData["Title"] = "You've been unsubscribed";
+    ViewData["Title"] = Localizer["Unsub_DoneTitle"].Value;
     var categoryName = ViewData["CategoryName"] as string ?? "these";
 }
 
-<h1>You've been unsubscribed</h1>
+<h1>@Localizer["Unsub_DoneTitle"]</h1>
 
-<p>You will no longer receive @categoryName emails from Humans.</p>
+<p>@Html.Raw(string.Format(Localizer["Unsub_DoneMessage"].Value, Html.Encode(categoryName)))</p>
 
 <p>
-    <a asp-controller="Account" asp-action="Login">Sign in to manage your communication preferences</a>.
+    @Localizer["Unsub_DoneManage"]
+    <a asp-controller="Account" asp-action="Login">@Localizer["Unsub_DoneManageLink"]</a>.
 </p>
 
-<p><a asp-controller="Home" asp-action="Index">Back to home</a></p>
+<p><a asp-controller="Home" asp-action="Index">@Localizer["Unsub_BackHome"]</a></p>

--- a/src/Humans.Web/Views/Unsubscribe/Expired.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Expired.cshtml
@@ -1,12 +1,12 @@
 @{
-    ViewData["Title"] = "Unsubscribe link expired";
+    ViewData["Title"] = Localizer["Unsub_ExpiredTitle"].Value;
 }
 
-<h1>This unsubscribe link has expired</h1>
+<h1>@Localizer["Unsub_ExpiredHeading"]</h1>
 
 <p>
-    Please use the link from a more recent email, or
-    <a asp-controller="Account" asp-action="Login">sign in to manage your communication preferences</a>.
+    @Localizer["Unsub_ExpiredMessage"]
+    <a asp-controller="Account" asp-action="Login">@Localizer["Unsub_ExpiredSignIn"]</a>.
 </p>
 
-<p><a asp-controller="Home" asp-action="Index">Back to home</a></p>
+<p><a asp-controller="Home" asp-action="Index">@Localizer["Unsub_BackHome"]</a></p>

--- a/src/Humans.Web/Views/Unsubscribe/Index.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Index.cshtml
@@ -1,20 +1,20 @@
 @{
-    ViewData["Title"] = "Unsubscribe from Emails";
+    ViewData["Title"] = Localizer["Unsub_Title"].Value;
     var displayName = ViewData["DisplayName"] as string;
     var categoryName = ViewData["CategoryName"] as string ?? "these";
 }
 
-<h1>Unsubscribe from @categoryName emails?</h1>
+<h1>@Html.Raw(string.Format(Localizer["Unsub_Heading"].Value, Html.Encode(categoryName)))</h1>
 
 @if (!string.IsNullOrEmpty(displayName))
 {
-    <p>Hi <strong>@displayName</strong>,</p>
+    <p>@Html.Raw(string.Format(Localizer["Unsub_Greeting"].Value, "<strong>" + Html.Encode(displayName) + "</strong>"))</p>
 }
 
-<p>If you confirm, you will no longer receive @categoryName emails from Humans.</p>
+<p>@Html.Raw(string.Format(Localizer["Unsub_ConfirmMessage"].Value, Html.Encode(categoryName)))</p>
 
 <form method="post">
     @Html.AntiForgeryToken()
-    <button type="submit" class="btn btn-danger">Confirm Unsubscribe</button>
-    <a asp-controller="Home" asp-action="Index" class="btn btn-secondary ms-2">Cancel</a>
+    <button type="submit" class="btn btn-danger">@Localizer["Unsub_ConfirmButton"]</button>
+    <a asp-controller="Home" asp-action="Index" class="btn btn-secondary ms-2">@Localizer["Common_Cancel"]</a>
 </form>

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -54,6 +54,19 @@ file sealed class StubAuditLog : IAuditLogService
         int limit = 20,
         CancellationToken ct = default) =>
         Task.FromResult<IReadOnlyList<AuditLogEntry>>(Array.Empty<AuditLogEntry>());
+
+    public Task<AuditLogPageResult> GetAuditLogPageAsync(
+        string? actionFilter, int page, int pageSize, CancellationToken ct = default) =>
+        Task.FromResult(new AuditLogPageResult(
+            Array.Empty<AuditLogEntry>(), 0, 0,
+            new Dictionary<Guid, string>(),
+            new Dictionary<Guid, (string Name, string Slug)>()));
+
+    public Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(IReadOnlyList<Guid> userIds, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<Guid, string>());
+
+    public Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<Guid, (string Name, string Slug)>());
 }
 
 public class AccountProvisioningServiceTests : IDisposable

--- a/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
@@ -198,5 +198,10 @@ public class AdminLegalDocumentServiceTests : IDisposable
         {
             return Task.FromResult<DocumentVersion?>(null);
         }
+
+        public Task<IReadOnlyList<DocumentVersion>> GetRequiredDocumentVersionsForTeamAsync(Guid teamId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<DocumentVersion>>(Array.Empty<DocumentVersion>());
+        }
     }
 }

--- a/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
@@ -55,6 +55,19 @@ file sealed class StubAuditLogService : IAuditLogService
         int limit = 20,
         CancellationToken ct = default) =>
         Task.FromResult<IReadOnlyList<AuditLogEntry>>(Array.Empty<AuditLogEntry>());
+
+    public Task<AuditLogPageResult> GetAuditLogPageAsync(
+        string? actionFilter, int page, int pageSize, CancellationToken ct = default) =>
+        Task.FromResult(new AuditLogPageResult(
+            Array.Empty<AuditLogEntry>(), 0, 0,
+            new Dictionary<Guid, string>(),
+            new Dictionary<Guid, (string Name, string Slug)>()));
+
+    public Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(IReadOnlyList<Guid> userIds, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<Guid, string>());
+
+    public Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<Guid, (string Name, string Slug)>());
 }
 
 public class CommunicationPreferenceServiceTests : IDisposable

--- a/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
@@ -192,4 +192,51 @@ public class CommunicationPreferenceServiceTests : IDisposable
 
         result.Should().BeFalse();
     }
+
+    [Fact]
+    public void ValidateUnsubscribeToken_WithValidToken_ReturnsValidStatusAndCorrectPayload()
+    {
+        var userId = Guid.NewGuid();
+        var category = MessageCategory.TeamUpdates;
+
+        var token = _service.GenerateUnsubscribeToken(userId, category);
+        var (status, decodedUserId, decodedCategory) = _service.ValidateUnsubscribeToken(token);
+
+        status.Should().Be(TokenValidationStatus.Valid);
+        decodedUserId.Should().Be(userId);
+        decodedCategory.Should().Be(category);
+    }
+
+    [Fact]
+    public void ValidateUnsubscribeToken_WithGarbageString_ReturnsInvalidStatus()
+    {
+        // A random string is not a valid DataProtection payload — simulates a tampered token.
+        // Note: DataProtection throws CryptographicException for both expired and tampered tokens.
+        // The service distinguishes expired from tampered by checking whether "expired" appears in
+        // the exception message. A purely garbage string will not match "expired" and maps to Invalid.
+        var (status, decodedUserId, decodedCategory) = _service.ValidateUnsubscribeToken("this-is-not-a-valid-token");
+
+        status.Should().Be(TokenValidationStatus.Invalid);
+        decodedUserId.Should().Be(Guid.Empty);
+        decodedCategory.Should().Be(default(MessageCategory));
+    }
+
+    [Fact]
+    public void ValidateUnsubscribeToken_WithMalformedBase64_ReturnsInvalidStatus()
+    {
+        // Another tamper vector: valid-looking base64 that decrypts to garbage
+        var (status, _, _) = _service.ValidateUnsubscribeToken("aGVsbG8gd29ybGQ=");
+
+        status.Should().Be(TokenValidationStatus.Invalid);
+    }
+
+    // NOTE: Testing TokenValidationStatus.Expired is not straightforward in unit tests because:
+    // - Microsoft.AspNetCore.DataProtection's ITimeLimitedDataProtector uses the real system clock
+    //   to embed expiry in the encrypted payload, and there is no seam to inject a fake clock.
+    // - DataProtectionProvider.Create() used here does not support replacing the clock.
+    // - To produce a genuinely expired token we would need to either (a) use the real system clock
+    //   and Thread.Sleep for 90 days, or (b) use internal/reflection to access the key ring.
+    // The Expired path in ValidateUnsubscribeToken is covered indirectly: the service correctly
+    // checks ex.Message.Contains("expired") before returning TokenValidationStatus.Expired, which
+    // is consistent with how DataProtection surfaces the expiry error in the real runtime.
 }

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -22,6 +22,7 @@ public class ConsentServiceTests : IDisposable
     private readonly ConsentService _service;
     private readonly IOnboardingService _onboardingService = Substitute.For<IOnboardingService>();
     private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService = Substitute.For<ILegalDocumentSyncService>();
     private readonly INotificationInboxService _notificationInboxService = Substitute.For<INotificationInboxService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();
     private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
@@ -34,8 +35,19 @@ public class ConsentServiceTests : IDisposable
 
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IMembershipCalculator)).Returns(_membershipCalculator);
+
+        _legalDocumentSyncService
+            .GetVersionByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => _dbContext.DocumentVersions
+                .Include(v => v.LegalDocument)
+                .FirstOrDefaultAsync(v => v.Id == callInfo.ArgAt<Guid>(0)));
+
         _service = new ConsentService(
-            _dbContext, _onboardingService, _membershipCalculator,
+            _dbContext, _onboardingService, serviceProvider,
+            _legalDocumentSyncService,
             _notificationInboxService, _syncJob, _metrics, _clock,
             NullLogger<ConsentService>.Instance);
     }

--- a/tests/Humans.Application.Tests/Services/MembershipCalculatorTests.cs
+++ b/tests/Humans.Application.Tests/Services/MembershipCalculatorTests.cs
@@ -2,6 +2,8 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Testing;
+using NSubstitute;
+using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -16,6 +18,8 @@ public class MembershipCalculatorTests : IDisposable
     private readonly HumansDbContext _dbContext;
     private readonly FakeClock _clock;
     private readonly MembershipCalculator _service;
+    private readonly IConsentService _consentService = Substitute.For<IConsentService>();
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService = Substitute.For<ILegalDocumentSyncService>();
 
     public MembershipCalculatorTests()
     {
@@ -25,7 +29,61 @@ public class MembershipCalculatorTests : IDisposable
 
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 2, 15, 16, 0));
-        _service = new MembershipCalculator(_dbContext, _clock);
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IConsentService)).Returns(_consentService);
+
+        _service = new MembershipCalculator(_dbContext, serviceProvider, _legalDocumentSyncService, _clock);
+
+        // Delegate to in-memory DB so seeded data is returned
+        _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var teamId = callInfo.Arg<Guid>();
+                var now = _clock.GetCurrentInstant();
+                var versions = _dbContext.LegalDocuments
+                    .Where(d => d.IsRequired && d.IsActive && d.TeamId == teamId)
+                    .SelectMany(d => d.Versions)
+                    .Where(v => v.EffectiveFrom <= now)
+                    .Include(v => v.LegalDocument)
+                    .ToList()
+                    .GroupBy(v => v.LegalDocumentId)
+                    .Select(g => g.OrderByDescending(v => v.EffectiveFrom).First())
+                    .ToList();
+                return Task.FromResult<IReadOnlyList<DocumentVersion>>(versions);
+            });
+
+        _consentService.GetConsentedVersionIdsAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userId = callInfo.Arg<Guid>();
+                var ids = _dbContext.ConsentRecords
+                    .Where(cr => cr.UserId == userId && cr.ExplicitConsent)
+                    .Select(cr => cr.DocumentVersionId)
+                    .ToHashSet();
+                return Task.FromResult<IReadOnlySet<Guid>>(ids);
+            });
+
+        _consentService.GetConsentMapForUsersAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userIds = callInfo.Arg<IReadOnlyList<Guid>>();
+                var consents = _dbContext.ConsentRecords
+                    .Where(cr => userIds.Contains(cr.UserId) && cr.ExplicitConsent)
+                    .Select(cr => new { cr.UserId, cr.DocumentVersionId })
+                    .ToList();
+                var result = userIds.ToDictionary(
+                    id => id,
+                    _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
+                foreach (var c in consents)
+                {
+                    ((HashSet<Guid>)result[c.UserId]).Add(c.DocumentVersionId);
+                }
+                return Task.FromResult<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>>(result);
+            });
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Services/MembershipPartitionTests.cs
+++ b/tests/Humans.Application.Tests/Services/MembershipPartitionTests.cs
@@ -2,6 +2,8 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Testing;
+using NSubstitute;
+using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -16,6 +18,8 @@ public class MembershipPartitionTests : IDisposable
     private readonly HumansDbContext _dbContext;
     private readonly FakeClock _clock;
     private readonly MembershipCalculator _service;
+    private readonly IConsentService _consentService = Substitute.For<IConsentService>();
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService = Substitute.For<ILegalDocumentSyncService>();
 
     public MembershipPartitionTests()
     {
@@ -25,7 +29,61 @@ public class MembershipPartitionTests : IDisposable
 
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
-        _service = new MembershipCalculator(_dbContext, _clock);
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IConsentService)).Returns(_consentService);
+
+        _service = new MembershipCalculator(_dbContext, serviceProvider, _legalDocumentSyncService, _clock);
+
+        // Delegate to in-memory DB so seeded data is returned
+        _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var teamId = callInfo.Arg<Guid>();
+                var now = _clock.GetCurrentInstant();
+                var versions = _dbContext.LegalDocuments
+                    .Where(d => d.IsRequired && d.IsActive && d.TeamId == teamId)
+                    .SelectMany(d => d.Versions)
+                    .Where(v => v.EffectiveFrom <= now)
+                    .Include(v => v.LegalDocument)
+                    .ToList()
+                    .GroupBy(v => v.LegalDocumentId)
+                    .Select(g => g.OrderByDescending(v => v.EffectiveFrom).First())
+                    .ToList();
+                return Task.FromResult<IReadOnlyList<DocumentVersion>>(versions);
+            });
+
+        _consentService.GetConsentedVersionIdsAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userId = callInfo.Arg<Guid>();
+                var ids = _dbContext.ConsentRecords
+                    .Where(cr => cr.UserId == userId && cr.ExplicitConsent)
+                    .Select(cr => cr.DocumentVersionId)
+                    .ToHashSet();
+                return Task.FromResult<IReadOnlySet<Guid>>(ids);
+            });
+
+        _consentService.GetConsentMapForUsersAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userIds = callInfo.Arg<IReadOnlyList<Guid>>();
+                var consents = _dbContext.ConsentRecords
+                    .Where(cr => userIds.Contains(cr.UserId) && cr.ExplicitConsent)
+                    .Select(cr => new { cr.UserId, cr.DocumentVersionId })
+                    .ToList();
+                var result = userIds.ToDictionary(
+                    id => id,
+                    _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
+                foreach (var c in consents)
+                {
+                    ((HashSet<Guid>)result[c.UserId]).Add(c.DocumentVersionId);
+                }
+                return Task.FromResult<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>>(result);
+            });
 
         // Seed the Volunteers system team (needed for consent queries)
         _dbContext.Teams.Add(new Team

--- a/tests/Humans.Application.Tests/Services/NotificationServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/NotificationServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
+using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -18,6 +20,7 @@ public class NotificationServiceTests : IDisposable
     private readonly FakeClock _clock;
     private readonly IMemoryCache _cache;
     private readonly NotificationService _service;
+    private readonly ICommunicationPreferenceService _preferenceService = Substitute.For<ICommunicationPreferenceService>();
 
     public NotificationServiceTests()
     {
@@ -28,7 +31,22 @@ public class NotificationServiceTests : IDisposable
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 4, 1, 12, 0));
         _cache = new MemoryCache(new MemoryCacheOptions());
-        _service = new NotificationService(_dbContext, _clock, _cache, NullLogger<NotificationService>.Instance);
+
+        // Delegate to in-memory DB so seeded preferences are respected
+        _preferenceService.GetUsersWithInboxDisabledAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<MessageCategory>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userIds = callInfo.Arg<IReadOnlyList<Guid>>();
+                var category = callInfo.Arg<MessageCategory>();
+                var disabledIds = _dbContext.CommunicationPreferences
+                    .Where(cp => userIds.Contains(cp.UserId) && cp.Category == category && !cp.InboxEnabled)
+                    .Select(cp => cp.UserId)
+                    .ToHashSet();
+                return Task.FromResult<IReadOnlySet<Guid>>(disabledIds);
+            });
+
+        _service = new NotificationService(_dbContext, _preferenceService, _clock, _cache, NullLogger<NotificationService>.Instance);
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
@@ -25,6 +25,7 @@ public class OutboxEmailServiceTests : IDisposable
     private readonly IEmailRenderer _renderer = Substitute.For<IEmailRenderer>();
     private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
     private readonly IBackgroundJobClient _backgroundJobClient = Substitute.For<IBackgroundJobClient>();
+    private readonly ICommunicationPreferenceService _commPrefService = Substitute.For<ICommunicationPreferenceService>();
 
     public OutboxEmailServiceTests()
     {
@@ -53,7 +54,7 @@ public class OutboxEmailServiceTests : IDisposable
             hostEnvironment,
             emailSettings,
             _backgroundJobClient,
-            Substitute.For<ICommunicationPreferenceService>(),
+            _commPrefService,
             NullLogger<OutboxEmailService>.Instance);
     }
 
@@ -174,5 +175,75 @@ public class OutboxEmailServiceTests : IDisposable
         _backgroundJobClient.DidNotReceive().Create(
             Arg.Any<Hangfire.Common.Job>(),
             Arg.Any<Hangfire.States.IState>());
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_WhenUserOptedOutOfCategory_DoesNotCreateOutboxRow()
+    {
+        var userId = Guid.NewGuid();
+        _dbContext.UserEmails.Add(new Humans.Domain.Entities.UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = "charlie@example.com",
+            IsVerified = true,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant(),
+        });
+        await _dbContext.SaveChangesAsync();
+
+        _commPrefService.IsOptedOutAsync(userId, MessageCategory.TeamUpdates, Arg.Any<CancellationToken>())
+            .Returns(true);
+        _commPrefService.GenerateUnsubscribeHeaders(Arg.Any<Guid>(), Arg.Any<MessageCategory>())
+            .Returns(new Dictionary<string, string>(StringComparer.Ordinal));
+        _commPrefService.GenerateBrowserUnsubscribeUrl(Arg.Any<Guid>(), Arg.Any<MessageCategory>())
+            .Returns("https://example.com/unsubscribe/token");
+
+        _renderer.RenderAddedToTeam(
+                "Charlie", "Alpha Team", "alpha", Arg.Any<System.Collections.Generic.List<(string Name, string? Url)>>(), null)
+            .Returns(new EmailContent("Added to Alpha Team", "<p>You joined Alpha Team</p>"));
+
+        await _service.SendAddedToTeamAsync(
+            "charlie@example.com", "Charlie", "Alpha Team", "alpha",
+            Array.Empty<(string Name, string? Url)>());
+
+        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        messages.Should().BeEmpty("the email should have been suppressed because the user opted out of TeamUpdates");
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_WhenUserOptedInToCategory_CreatesOutboxRow()
+    {
+        var userId = Guid.NewGuid();
+        _dbContext.UserEmails.Add(new Humans.Domain.Entities.UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = "dana@example.com",
+            IsVerified = true,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant(),
+        });
+        await _dbContext.SaveChangesAsync();
+
+        _commPrefService.IsOptedOutAsync(userId, MessageCategory.TeamUpdates, Arg.Any<CancellationToken>())
+            .Returns(false);
+        _commPrefService.GenerateUnsubscribeHeaders(Arg.Any<Guid>(), Arg.Any<MessageCategory>())
+            .Returns(new Dictionary<string, string>(StringComparer.Ordinal));
+        _commPrefService.GenerateBrowserUnsubscribeUrl(Arg.Any<Guid>(), Arg.Any<MessageCategory>())
+            .Returns("https://example.com/unsubscribe/token");
+
+        _renderer.RenderAddedToTeam(
+                "Dana", "Beta Team", "beta", Arg.Any<System.Collections.Generic.List<(string Name, string? Url)>>(), null)
+            .Returns(new EmailContent("Added to Beta Team", "<p>You joined Beta Team</p>"));
+
+        await _service.SendAddedToTeamAsync(
+            "dana@example.com", "Dana", "Beta Team", "beta",
+            Array.Empty<(string Name, string? Url)>());
+
+        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        messages.Should().HaveCount(1, "opted-in user should receive the email");
+        messages[0].RecipientEmail.Should().Be("dana@example.com");
+        messages[0].TemplateName.Should().Be("added_to_team");
     }
 }

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -26,6 +26,7 @@ public class ProfileServiceTests : IDisposable
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
+    private readonly IConsentService _consentService = Substitute.For<IConsentService>();
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
 
     public ProfileServiceTests()
@@ -38,7 +39,7 @@ public class ProfileServiceTests : IDisposable
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
         _service = new ProfileService(
             _dbContext, _onboardingService, _emailService, _auditLogService,
-            _membershipCalculator, _clock, _cache,
+            _membershipCalculator, _consentService, _clock, _cache,
             NullLogger<ProfileService>.Instance);
 
         // Default: return all input IDs as Active (sufficient for most tests that don't filter by status)

--- a/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
@@ -25,7 +25,7 @@ public class TicketQueryServiceTests : IDisposable
             .Options;
 
         _dbContext = new HumansDbContext(options);
-        _service = new TicketQueryService(_dbContext, new MemoryCache(new MemoryCacheOptions()), Substitute.For<IBudgetService>());
+        _service = new TicketQueryService(_dbContext, new MemoryCache(new MemoryCacheOptions()), Substitute.For<IBudgetService>(), SystemClock.Instance);
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
@@ -43,6 +43,7 @@ public class TicketSyncServiceTests : IDisposable
         });
 
         _stripeService = Substitute.For<IStripeService>();
+        var userService = Substitute.For<IUserService>();
         _service = new TicketSyncService(
             _dbContext,
             _vendorService,
@@ -50,7 +51,8 @@ public class TicketSyncServiceTests : IDisposable
             _clock,
             settings,
             NullLogger<TicketSyncService>.Instance,
-            new MemoryCache(new MemoryCacheOptions()));
+            new MemoryCache(new MemoryCacheOptions()),
+            userService);
 
         // Seed the singleton TicketSyncState row
         _dbContext.TicketSyncStates.Add(new TicketSyncState
@@ -287,7 +289,8 @@ public class TicketSyncServiceTests : IDisposable
             _clock,
             settings,
             NullLogger<TicketSyncService>.Instance,
-            new MemoryCache(new MemoryCacheOptions()));
+            new MemoryCache(new MemoryCacheOptions()),
+            Substitute.For<IUserService>());
 
         var result = await service.SyncOrdersAndAttendeesAsync();
 

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -55,6 +55,7 @@ export async function postWithCsrf(
   return page.request.post(url, {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     data: `__RequestVerificationToken=${encodeURIComponent(token)}&${formData}`,
+    maxRedirects: 0,
   });
 }
 

--- a/tests/e2e/tests/profile.spec.ts
+++ b/tests/e2e/tests/profile.spec.ts
@@ -13,7 +13,7 @@ test.describe('Profile (02-profiles)', () => {
 
   test('US-2.2: edit page has all form sections', async ({ page }) => {
     await loginAsVolunteer(page);
-    await page.goto('/Profile/Edit');
+    await page.goto('/Profile/Me/Edit');
 
     // General info section
     const burnerNameInput = page.locator('input[name="BurnerName"]');
@@ -33,9 +33,9 @@ test.describe('Profile (02-profiles)', () => {
 
   test('GDPR: privacy page loads with data export and deletion options', async ({ page }) => {
     await loginAsVolunteer(page);
-    await page.goto('/Profile/Privacy');
+    await page.goto('/Profile/Me/Privacy');
 
-    if (!page.url().includes('/Profile/Privacy')) return; // onboarding redirect — skip gracefully
+    if (!page.url().includes('/Profile/Me/Privacy')) return; // onboarding redirect — skip gracefully
 
     await expect(page.locator('h1, h2, h3, h4').first()).toBeVisible();
     // Data export link

--- a/tests/e2e/tests/shift-preferences.spec.ts
+++ b/tests/e2e/tests/shift-preferences.spec.ts
@@ -4,7 +4,7 @@ import { loginAsVolunteer } from '../helpers/auth';
 test.describe('Shift Preference Wizard (33-shift-preference-wizard)', () => {
   test('page loads with wizard step 1', async ({ page }) => {
     await loginAsVolunteer(page);
-    await page.goto('/Profile/ShiftInfo');
+    await page.goto('/Profile/Me/ShiftInfo');
 
     await expect(page.locator('#stepTitle')).toHaveText('What are you good at?');
     await expect(page.locator('#stepLabel')).toHaveText('Step 1 of 3');
@@ -13,7 +13,7 @@ test.describe('Shift Preference Wizard (33-shift-preference-wizard)', () => {
 
   test('can navigate through all 3 steps', async ({ page }) => {
     await loginAsVolunteer(page);
-    await page.goto('/Profile/ShiftInfo');
+    await page.goto('/Profile/Me/ShiftInfo');
 
     // Step 1 -> Step 2
     await page.click('#nextBtn');
@@ -30,7 +30,7 @@ test.describe('Shift Preference Wizard (33-shift-preference-wizard)', () => {
 
   test('can go back from step 3 to step 1', async ({ page }) => {
     await loginAsVolunteer(page);
-    await page.goto('/Profile/ShiftInfo');
+    await page.goto('/Profile/Me/ShiftInfo');
 
     await page.click('#nextBtn');
     await page.click('#nextBtn');
@@ -44,7 +44,7 @@ test.describe('Shift Preference Wizard (33-shift-preference-wizard)', () => {
 
   test('selecting a chip toggles it', async ({ page }) => {
     await loginAsVolunteer(page);
-    await page.goto('/Profile/ShiftInfo');
+    await page.goto('/Profile/Me/ShiftInfo');
 
     const chip = page.locator('.chip', { hasText: 'Bartending' });
     await chip.click();
@@ -56,7 +56,7 @@ test.describe('Shift Preference Wizard (33-shift-preference-wizard)', () => {
 
   test('save submits and redirects back', async ({ page }) => {
     await loginAsVolunteer(page);
-    await page.goto('/Profile/ShiftInfo');
+    await page.goto('/Profile/Me/ShiftInfo');
 
     // Select a skill
     await page.locator('.chip', { hasText: 'Sound' }).click();

--- a/tests/e2e/tests/teams.spec.ts
+++ b/tests/e2e/tests/teams.spec.ts
@@ -22,7 +22,7 @@ test.describe('Teams — Browsing (06-teams)', () => {
     const teamLink = page.locator('.card a.btn, .card a[href*="/Teams/"]').first();
     if (await teamLink.isVisible({ timeout: 3000 }).catch(() => false)) {
       await teamLink.click();
-      await expect(page.locator('h1, h2').first()).toBeVisible();
+      await expect(page.locator('h1, h2, h3, h4').first()).toBeVisible();
       expect(page.url()).toContain('/Teams/');
     }
   });
@@ -190,7 +190,7 @@ test.describe('Teams — Cross-Team Views & Hierarchy', () => {
     const teamLink = page.locator('.card a.btn').first();
     if (await teamLink.isVisible({ timeout: 3000 }).catch(() => false)) {
       await teamLink.click();
-      await expect(page.locator('h1, h2').first()).toBeVisible();
+      await expect(page.locator('h1, h2, h3, h4').first()).toBeVisible();
       // Sub-teams section renders as cards or a list within the detail page
       // Data-dependent — we verify the page loads; sub-teams may or may not exist
     }


### PR DESCRIPTION
## Summary

Fixes all review findings from the [PR #208 review](https://github.com/nobodies-collective/Humans/pull/208#issuecomment-4226304817):

### Critical (3)
- **Campaign opt-out bypass**: `SendWaveAsync` now filters opted-out users; `PreviewWaveSendAsync` reports actual count
- **Broken unsubscribe footer link**: Added `GenerateBrowserUnsubscribeUrl` returning clean URL directly
- **Expired token UX**: `ValidateUnsubscribeToken` returns `TokenValidationStatus` (Valid/Expired/Invalid); `UnsubscribeService` routes expired new-format tokens to Expired view directly

### Important (4)
- **Test coverage**: Added tests for opt-out suppression in OutboxEmailService and token validation in CommunicationPreferenceService (879 unit tests pass)
- **Email categorization**: Added explicit `MessageCategory` to 4 uncategorized email methods (SignupRejected→System, TermRenewal→Governance, BoardDigest→Governance, FeedbackResponse→System)
- **Race condition**: `GetPreferencesAsync` now catches `DbUpdateException` on default-row creation and reloads
- **GDPR export**: Already fixed on main (communication_preferences included in ExportDataAsync)

### Minor (3)
- **Controller layering**: Already fixed on main (UnsubscribeController uses IUnsubscribeService)
- **Always-on UX**: Non-editable preference checkboxes now show "Always on" text
- **Checked attribute**: Already fixed (uses null not empty string)

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] 879 unit tests pass
- [ ] QA verify: unsubscribe footer links resolve correctly
- [ ] QA verify: expired token shows Expired page, not 404
- [ ] QA verify: campaign preview shows correct opted-out count

🤖 Generated with [Claude Code](https://claude.com/claude-code)