### PR TITLE
fix(city-planning): make note optional (only used for imports)

### DIFF
--- a/src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs
+++ b/src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs
@@ -73,4 +73,4 @@ public record CampPolygonHistoryEntryDto(
 public record SaveCampPolygonRequest(
     string GeoJson,
     double AreaSqm,
-    [property: StringLength(512, ErrorMessage = "Note cannot exceed 512 characters")] string? Note = null);
+    [StringLength(512, ErrorMessage = "Note cannot exceed 512 characters")] string? Note = null);


### PR DESCRIPTION
A quick hotfix (sorry for the mistake ><) for today's problem: ppl can't save edited polygons because we don't send the Note parameter outside exports