### PR TITLE
Drop CC approval as the gate for Volunteers admission

### DIFF
--- a/docs/features/06-teams.md
+++ b/docs/features/06-teams.md
@@ -295,11 +295,11 @@ Teams are either **departments** (top-level, no parent) or **sub-teams** (have a
 
 | Team | Auto-Add Trigger | Auto-Remove Trigger |
 |------|------------------|---------------------|
-| **Volunteers** | Approved + all required consents signed | Missing consent, suspended, or approval revoked |
+| **Volunteers** | Profile + all required consents signed (no CC approval required) | Missing consent, suspended, CC-flagged, or rejected |
 | **Coordinators** | Become Coordinator of any team + team consents | No longer Coordinator anywhere |
 | **Board** | Active "Board" RoleAssignment + team consents | RoleAssignment expires |
 
-Volunteers team membership is the source of truth for "active volunteer" status. Both approval (`AdminController.ApproveVolunteer`) and consent completion (`ConsentController.Submit`) trigger an immediate single-user sync via `SyncVolunteersMembershipForUserAsync` -- the user doesn't wait for the scheduled job.
+Volunteers team membership is the source of truth for "active volunteer" status. Consent completion (`ConsentController.Submit`) triggers an immediate single-user sync via `SyncVolunteersMembershipForUserAsync` so the user doesn't wait for the scheduled job. CC approval (`ProfileController.ApproveVolunteer`) also fires a single-user sync as an audit-track no-op for users already admitted.
 
 ### System Team Properties
 - `RequiresApproval = false` (auto-managed)
@@ -314,9 +314,10 @@ Volunteers team membership is the source of truth for "active volunteer" status.
 SystemTeamSyncJob (scheduled hourly, currently disabled; also triggered inline):
 
   1. SyncVolunteersTeamAsync()
-     - Get all users where IsApproved = true AND !IsSuspended
+     - Get all users with a profile where !IsSuspended, ConsentCheckStatus != Flagged, RejectedAt is null
      - Filter to those with all required Volunteers-team consents
      - Add missing members, remove ineligible
+     - (Profile.IsApproved is the CC's audit annotation; not consulted here)
 
   2. SyncCoordinatorsTeamAsync()
      - Get all users with TeamMember.Role = Coordinator (non-system teams)

--- a/docs/features/08-background-jobs.md
+++ b/docs/features/08-background-jobs.md
@@ -171,17 +171,18 @@ See [Profiles — Account Deletion](02-profiles.md#account-deletion-right-to-era
 **Schedule**: Hourly (**CURRENTLY DISABLED** for scheduled runs — modifies Google permissions). Can be triggered manually from Admin dashboard via "Sync System Teams" button.
 
 **Inline Triggers**: In addition to the scheduled job, single-user sync is triggered immediately by:
-- `AdminController.ApproveVolunteer` — after setting `IsApproved = true`
-- `ConsentController.Submit` — after recording a consent
+- `ProfileController.ApproveVolunteer` — after a Consent Coordinator clears the consent check (audit annotation; admission may already have happened via consent submit)
+- `ConsentController.Submit` — after recording a consent (this is the path that admits a new human to Volunteers)
 
 Both call `SyncVolunteersMembershipForUserAsync(userId)`, which evaluates a single user without affecting other members.
 
 **Process**:
 ```
 1. SyncVolunteersTeamAsync()
-   - Eligible: Approved (IsApproved), non-suspended, with all required Volunteers-team consents
+   - Eligible: Has a profile, !IsSuspended, ConsentCheckStatus != Flagged, RejectedAt is null, with all required Volunteers-team consents
    - Add: New eligible users
-   - Remove: Users who lost eligibility
+   - Remove: Users who lost eligibility (suspended, flagged, rejected, or consent lapsed)
+   - (Profile.IsApproved is the CC audit annotation; not consulted)
 
 2. SyncCoordinatorsTeamAsync()
    - Eligible: Users who are Coordinator of any user-created team + Coordinators-team consents
@@ -201,7 +202,7 @@ Both call `SyncVolunteersMembershipForUserAsync(userId)`, which evaluates a sing
 **System Teams**:
 | Team | Eligibility Criteria |
 |------|---------------------|
-| Volunteers | IsApproved AND !IsSuspended AND HasAllRequiredConsentsForTeam(Volunteers) |
+| Volunteers | HasProfile AND !IsSuspended AND ConsentCheckStatus != Flagged AND RejectedAt is null AND HasAllRequiredConsentsForTeam(Volunteers) |
 | Coordinators | TeamMember.Role = Coordinator (non-system teams) AND HasAllRequiredConsentsForTeam(Coordinators) |
 | Board | RoleAssignment.RoleName = "Board" AND active AND HasAllRequiredConsentsForTeam(Board) |
 

--- a/docs/sections/LegalAndConsent.md
+++ b/docs/sections/LegalAndConsent.md
@@ -10,19 +10,19 @@
   src/Humans.Web/Controllers/AdminLegalDocumentsController.cs
 -->
 <!-- freshness:flag-on-change
-  ConsentRecord append-only DB-trigger invariant, document sync from GitHub, and consent-coordinator review gate — review when Legal/Consent services/entities/controllers change.
+  ConsentRecord append-only DB-trigger invariant, document sync from GitHub, and the Consent Coordinator review queue (audit-only, NOT a gate for Volunteers admission) — review when Legal/Consent services/entities/controllers change.
 -->
 
 # Legal & Consent — Section Invariants
 
-Legal documents synced from GitHub, per-version consent records (append-only), the Consent Coordinator review gate.
+Legal documents synced from GitHub, per-version consent records (append-only), the Consent Coordinator audit/review queue.
 
 ## Concepts
 
 - A **Legal Document** is a named, team-scoped document (e.g., "Privacy Policy", "Volunteer Agreement"). Documents on the Volunteers system team apply to every active human. Each document points at a folder in the configured GitHub repository and is synced from there by `LegalDocumentSyncService` / `SyncLegalDocumentsJob`.
 - A **Document Version** is a specific revision of a legal document with an `EffectiveFrom` instant and a multi-language `Content` dictionary keyed by language code (Spanish `"es"` is canonical/legally binding). When the GitHub commit SHA for the canonical file changes, the sync produces a new version; if `RequiresReConsent` is true, affected users are re-notified.
 - A **Consent Record** is an append-only audit entry linking a user to a specific document version with timestamp, IP, user-agent, content hash, and an `ExplicitConsent` flag. Consent records can never be updated or deleted — only new records can be inserted.
-- **Consent Check** is the safety gate in the onboarding pipeline. After a human signs all required documents, a Consent Coordinator reviews and either clears or flags the check.
+- **Consent Check** is an audit/annotation track maintained on the profile (`Profile.ConsentCheckStatus`). After a human signs all required documents, the status flips to `Pending` and the human appears in the Consent Coordinator review queue. CC actions (Clear / Flag / Reject) maintain the annotation but do NOT gate admission to the Volunteers team — admission is automatic once profile + consents are complete.
 - The **Statutes** page (`/Legal`) is a separate, anonymous read of the association's statutes pulled directly from GitHub by `LegalDocumentService` (with in-memory caching) — it does not go through the `legal_documents` table.
 
 ## Data Model
@@ -76,9 +76,9 @@ Cross-aggregate nav `ConsentRecord.DocumentVersion` — still declared and walke
 
 ## Triggers
 
-- When a human signs all required global documents: their consent check status transitions to Pending.
-- When a Consent Coordinator clears a consent check: the human is auto-approved as a Volunteer and added to the Volunteers system team.
-- When a Consent Coordinator flags a consent check: the human's Volunteer activation is blocked until Board or Admin review.
+- When a human signs all required global documents: their consent check status transitions to Pending AND `ISystemTeamSync.SyncVolunteersMembershipForUserAsync` admits them to the Volunteers system team. Admission does not depend on Consent Coordinator review.
+- When a Consent Coordinator clears a consent check: `Profile.IsApproved` is set to true and `ConsentCheckStatus = Cleared`. This is an audit annotation; the human is already a Volunteer.
+- When a Consent Coordinator flags a consent check: `Profile.IsApproved` is set to false, `ConsentCheckStatus = Flagged`, and `DeprovisionApprovalGatedSystemTeamsAsync` removes the user from Volunteers / Colaborador / Asociado teams. The Volunteers admission criteria explicitly exclude `ConsentCheckStatus == Flagged`, so the user stays out until Board or Admin resolves via `ProfileController.ApproveVolunteer`.
 - When a new document version is published: affected humans are notified to re-consent. A background job sends re-consent reminders.
 - A background job suspends humans who no longer have valid consents for required documents.
 

--- a/docs/sections/Onboarding.md
+++ b/docs/sections/Onboarding.md
@@ -20,10 +20,10 @@ Pure orchestrator over Profiles, Legal & Consent, Teams, and Governance. Owns no
 
 ## Concepts
 
-- **Onboarding** is the process a new human goes through to become an active Volunteer: sign up via Google OAuth, complete their profile, consent to all required legal documents, and pass a profile review by a Consent Coordinator. The last two steps can happen in any order.
+- **Onboarding** is the process a new human goes through to become an active Volunteer: sign up via Google OAuth, complete their profile, and consent to all required legal documents. Once both are done, admission to the Volunteers team is automatic — no Consent Coordinator approval is required for entry.
 - The **Membership Gate** restricts most of the application to active Volunteers. Humans still onboarding are limited to their profile, consent, feedback, legal documents, camps (public), and the home dashboard. All admin and coordinator roles bypass this gate entirely.
 - **Profileless accounts** are authenticated users with no Profile record (e.g., ticket holders, newsletter subscribers created by imports). They are redirected to the Guest dashboard instead of the Home dashboard and see a reduced nav: Guest Dashboard, Camps, Teams (public), Calendar, Legal. They can create a profile to enter the standard onboarding flow.
-- The **Profile Review** (consent check) and **Legal Document Signing** are independent, parallel tracks. A Consent Coordinator can clear the profile review before or after legal documents are signed. Admission to the Volunteers team only happens when both are complete.
+- The **Consent Coordinator review** (`Profile.ConsentCheckStatus`) is an audit/annotation track that runs in parallel with admission. When all required consents are signed, `ConsentCheckStatus` flips to `Pending` and the human appears in the CC review queue. CC actions (Clear / Flag / Reject) maintain the audit annotation and still flip `Profile.IsApproved`, but admission to the Volunteers team is decoupled from CC review — admission happens on profile-complete + consents-complete regardless of `IsApproved`.
 
 ## Data Model
 
@@ -43,9 +43,10 @@ The only onboarding-specific value type is the narrow `IOnboardingEligibilityQue
 
 ## Invariants
 
-- Onboarding steps: (1) complete profile, (2a) consent to all required global legal documents, (2b) profile review by a Consent Coordinator — these two can happen in any order, (3) auto-approval as Volunteer when both 2a and 2b are complete.
+- Onboarding steps: (1) complete profile, (2) consent to all required global legal documents, (3) automatic admission to the Volunteers system team. CC review of the consent check is an independent audit track that runs in parallel — it does not gate admission.
 - Volunteer onboarding is never blocked by tier applications — they are separate, parallel paths.
 - The ActiveMember status is derived from membership in the Volunteers system team.
+- Volunteers admission is `!IsSuspended && ConsentCheckStatus != Flagged && RejectedAt is null && HasAllRequiredConsentsForTeam(Volunteers)`. `Profile.IsApproved` is the CC's audit annotation and is NOT consulted for admission. The `Flagged` and `RejectedAt` exclusions preserve the CC's kick-out levers — `FlagConsentCheckAsync` and `RejectSignupAsync` set those fields before calling `DeprovisionApprovalGatedSystemTeamsAsync`, so the deprovision actually removes the user from Volunteers.
 - All admin and coordinator roles bypass the membership gate entirely — they can access the full application regardless of membership status.
 - OAuth login checks verified UserEmails, unverified UserEmails, and User.Email before creating a new account — preventing duplicate accounts when the same email exists on another user in any form.
 - `OnboardingService` depends only on interfaces (plus `IClock`) — no `DbContext`, `IDbContextFactory`, `DbSet<T>`, `IMemoryCache`, `IFullProfileInvalidator`, or repository. Enforced by `OnboardingArchitectureTests`.
@@ -60,9 +61,9 @@ The only onboarding-specific value type is the narrow `IOnboardingEligibilityQue
 
 ## Triggers
 
-- When a human completes their profile and signs all required documents: `OnboardingService.SetConsentCheckPendingIfEligibleAsync` flips `Profile.ConsentCheckStatus` to `Pending` (only if not already approved and `IMembershipCalculator.HasAllRequiredConsentsForTeamAsync(Volunteers)` returns true), and notifies the ConsentCoordinator role.
-- When a profile review is cleared: `Profile.IsApproved` is set to true and `ConsentCheckStatus = Cleared`. `ISystemTeamSync.SyncVolunteersMembershipForUserAsync` runs — it adds the user to the Volunteers system team only if `IsApproved && !IsSuspended && HasAllRequiredConsentsForTeam(Volunteers)` is true, so admission happens whenever the last condition is met (cleared first then last consent signed, or all consents signed first then cleared). If the user already has approved Colaborador/Asociado tiers, those team syncs run too. No email is sent on this auto-approval path.
-- When a legal document is signed: `ConsentService.SubmitConsentAsync` calls `SetConsentCheckPendingIfEligibleAsync` (flipping the consent check to Pending if all consents are now in) and `SyncVolunteersMembershipForUserAsync` (which admits the user iff `IsApproved` is also true).
+- When a human completes their profile and signs all required documents: `OnboardingService.SetConsentCheckPendingIfEligibleAsync` flips `Profile.ConsentCheckStatus` to `Pending` (only if not already approved and `IMembershipCalculator.HasAllRequiredConsentsForTeamAsync(Volunteers)` returns true), and notifies the ConsentCoordinator role. This is the audit/annotation track — admission to Volunteers happens automatically and does not depend on this flow.
+- When a legal document is signed: `ConsentService.SubmitConsentAsync` calls `SetConsentCheckPendingIfEligibleAsync` (flipping the consent check to Pending if all consents are now in) and `SyncVolunteersMembershipForUserAsync`, which admits the user to the Volunteers system team if `!IsSuspended && ConsentCheckStatus != Flagged && RejectedAt is null && HasAllRequiredConsentsForTeam(Volunteers)`. `Profile.IsApproved` is not consulted.
+- When a profile review is cleared by a CC: `Profile.IsApproved` is set to true and `ConsentCheckStatus = Cleared`. `ISystemTeamSync.SyncVolunteersMembershipForUserAsync` runs but is a no-op for admission if the user is already a Volunteer team member. No email is sent on this audit-track path.
 - When a consent check is flagged: `Profile.IsApproved` is set to false, `ConsentCheckStatus = Flagged`, and Volunteers / Colaborador / Asociado memberships are de-provisioned via `DeprovisionApprovalGatedSystemTeamsAsync`. Board or Admin must resolve via `ProfileController.ApproveVolunteer` (manual override).
 - When a signup is rejected: `Profile.RejectedAt`, `RejectionReason`, and `RejectedByUserId` are recorded; `IsApproved` is set to false; system team memberships are de-provisioned; a `SignupRejected` email and `ProfileRejected` notification are dispatched. (`Profile` has no `IsRejected` boolean — rejection is detected by `RejectedAt is not null`.)
 - When a Board+Admin manually `ApproveVolunteerAsync` (override path used after a flag is resolved): `IsApproved` is set to true, Volunteers team sync runs, and a `VolunteerApproved` notification ("Welcome! You have been approved") is dispatched.

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -234,15 +234,26 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        // All users with profiles that are approved and not suspended.
-        var allApprovedIds = await ProfileService.GetActiveApprovedUserIdsAsync(cancellationToken);
+        // Volunteers admission no longer requires Profile.IsApproved (CC clearance) —
+        // any human with a profile, not suspended, not flagged, not rejected, and
+        // with all required consents signed is admitted. Profile.IsApproved is
+        // maintained as the CC's audit annotation but is not consulted here. The
+        // Flagged + RejectedAt exclusions preserve the CC's existing kick-out
+        // levers (FlagConsentCheckAsync and RejectSignupAsync set those fields
+        // before calling DeprovisionApprovalGatedSystemTeamsAsync).
+        var allUserIds = await _userService.GetAllUserIdsAsync(cancellationToken);
+        var profiles = await ProfileService.GetByUserIdsAsync(allUserIds, cancellationToken);
+        var candidateIds = allUserIds
+            .Where(id => profiles.TryGetValue(id, out var p)
+                && !p.IsSuspended
+                && p.ConsentCheckStatus != ConsentCheckStatus.Flagged
+                && p.RejectedAt is null)
+            .ToList();
 
-        // Use shared partition to determine eligibility (Active = approved +
-        // not suspended + all consents signed).
-        var partition = await MembershipCalculator.PartitionUsersAsync(allApprovedIds, cancellationToken);
-        var eligibleUserIds = partition.Active.ToList();
+        var eligibleSet = await MembershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
+            candidateIds, SystemTeamIds.Volunteers, cancellationToken);
 
-        await SyncTeamMembershipAsync(team, eligibleUserIds, cancellationToken, step: step);
+        await SyncTeamMembershipAsync(team, eligibleSet.ToList(), cancellationToken, step: step);
         report?.Steps.Add(step);
     }
 
@@ -396,7 +407,14 @@ public class SystemTeamSyncJob : ISystemTeamSync
         var profiles = await ProfileService.GetByUserIdsAsync([userId], cancellationToken);
         profiles.TryGetValue(userId, out var profile);
 
-        var isEligible = profile is { IsApproved: true, IsSuspended: false }
+        // Volunteers admission no longer requires Profile.IsApproved (CC clearance).
+        // Profile.IsApproved is tracked as the CC's audit annotation but is not
+        // consulted for team admission. Flagged consent checks and rejected
+        // signups remain excluded so DeprovisionApprovalGatedSystemTeamsAsync
+        // (called from FlagConsentCheckAsync / RejectSignupAsync after those
+        // mutations) actually removes the user from Volunteers.
+        var isEligible = profile is { IsSuspended: false, RejectedAt: null }
+            && profile.ConsentCheckStatus != ConsentCheckStatus.Flagged
             && await MembershipCalculator.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, cancellationToken);
 
         // Build a single-user eligible list and let the existing sync logic handle add/remove


### PR DESCRIPTION
Restores the CC-approval-gate drop originally merged as peterdrier#368 (commit `3147d752`).

The original commit was wiped from `peterdrier/main` by an unrelated force-push incident on 2026-04-30. The content was later inadvertently re-bundled into peterdrier#370 (the Store design PR), so it's currently on `peterdrier/main` only as part of an unrelated squash commit. This PR restores it as a standalone, properly-attributed commit on production.

## Original context

Admission to the Volunteers system team is now: `HasProfile && !IsSuspended && ConsentCheckStatus != Flagged && RejectedAt is null && HasAllRequiredConsentsForTeam(Volunteers)`. `Profile.IsApproved` is no longer consulted by the team sync — it remains as the CC's audit annotation. CC review queue, Clear / Flag / Reject actions, and the existing deprovision-on-flag behavior are all unchanged.

- `SyncVolunteersMembershipForUserAsync`: drop `IsApproved` from eligibility, exclude flagged + rejected.
- `SyncVolunteersTeamAsync`: bypass the `IsApproved`-filtered partition seed.
- Section invariants (Onboarding, Legal & Consent) and feature docs (06-teams, 08-background-jobs) updated.

No backfill — existing humans in the CC review queue will be admitted automatically by the next bulk sync run.

Cherry-picked from `3147d752` directly onto `upstream/main`.