### PR TITLE
[codex] Show legal names in onboarding review queue

### DIFF
--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -409,6 +409,7 @@ public class OnboardingReviewController : HumansControllerBase
         {
             UserId = profile.UserId,
             DisplayName = itemUser?.DisplayName ?? "Unknown",
+            LegalName = profile.FullName,
             ProfilePictureUrl = itemUser?.ProfilePictureUrl,
             Email = itemUser?.Email ?? string.Empty,
             ConsentCheckStatus = profile.ConsentCheckStatus,

--- a/src/Humans.Web/Models/OnboardingReviewViewModels.cs
+++ b/src/Humans.Web/Models/OnboardingReviewViewModels.cs
@@ -12,6 +12,7 @@ public class OnboardingReviewItemViewModel
 {
     public Guid UserId { get; set; }
     public string DisplayName { get; set; } = string.Empty;
+    public string LegalName { get; set; } = string.Empty;
     public string? ProfilePictureUrl { get; set; }
     public string Email { get; set; } = string.Empty;
     public ConsentCheckStatus? ConsentCheckStatus { get; set; }

--- a/src/Humans.Web/Views/OnboardingReview/Index.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/Index.cshtml
@@ -31,10 +31,18 @@
                 <div class="d-flex justify-content-between align-items-center">
                     <div class="d-flex align-items-center">
                         <human-link user-id="@item.UserId" display-name="@item.DisplayName"
-                                    mode="AvatarName" size="40"
-                                    profile-picture-url="@item.ProfilePictureUrl">
-                            <small class="text-muted">@item.Email</small>
-                        </human-link>
+                                    mode="Avatar" size="40" show-popover="false"
+                                    profile-picture-url="@item.ProfilePictureUrl" />
+                        <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
+                           class="ms-2 text-decoration-none text-reset"
+                           data-human-popover="true"
+                           data-user-id="@item.UserId">
+                            <span class="fw-semibold">@item.DisplayName</span>
+                            @if (!string.IsNullOrWhiteSpace(item.LegalName))
+                            {
+                                <span class="fw-normal text-muted"> - @item.LegalName</span>
+                            }
+                        </a>
                     </div>
                     <div class="text-end">
                         @if (item.MembershipTier != MembershipTier.Volunteer)
@@ -74,10 +82,18 @@
                 <div class="d-flex justify-content-between align-items-center">
                     <div class="d-flex align-items-center">
                         <human-link user-id="@item.UserId" display-name="@item.DisplayName"
-                                    mode="AvatarName" size="40"
-                                    profile-picture-url="@item.ProfilePictureUrl">
-                            <small class="text-muted">@item.Email</small>
-                        </human-link>
+                                    mode="Avatar" size="40" show-popover="false"
+                                    profile-picture-url="@item.ProfilePictureUrl" />
+                        <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
+                           class="ms-2 text-decoration-none text-reset"
+                           data-human-popover="true"
+                           data-user-id="@item.UserId">
+                            <span class="fw-semibold">@item.DisplayName</span>
+                            @if (!string.IsNullOrWhiteSpace(item.LegalName))
+                            {
+                                <span class="fw-normal text-muted"> - @item.LegalName</span>
+                            }
+                        </a>
                     </div>
                     <div class="text-end">
                         @if (item.MembershipTier != MembershipTier.Volunteer)


### PR DESCRIPTION
## Summary
- Add legal name to onboarding review queue item view models.
- Render queue entries as `Playa name - Legal name`, keeping the playa name bold and the legal name regular muted text.
- Remove the email subtext from pending and flagged review rows.

## Why
Reviewers need to compare applicants by playa name and legal name directly in the queue, instead of seeing playa name plus email.

## Validation
- `dotnet build Humans.slnx`
- Ran the local server at `http://localhost:7101` and opened `/OnboardingReview`.
- Seeded local review applicants and verified the rendered queue rows show the expected playa/legal-name format.