### PR TITLE
[codex] Add bulk approval to onboarding review queue

### DIFF
--- a/src/Humans.Application/Interfaces/Onboarding/IOnboardingService.cs
+++ b/src/Humans.Application/Interfaces/Onboarding/IOnboardingService.cs
@@ -6,6 +6,7 @@ using MemberApplication = Humans.Domain.Entities.Application;
 namespace Humans.Application.Interfaces.Onboarding;
 
 public record OnboardingResult(bool Success, string? ErrorKey = null);
+public record BulkOnboardingResult(int ApprovedCount);
 
 public interface IOnboardingService : IOnboardingEligibilityQuery
 {
@@ -18,6 +19,8 @@ public interface IOnboardingService : IOnboardingEligibilityQuery
     // --- Consent check mutations ---
     Task<OnboardingResult> ClearConsentCheckAsync(
         Guid userId, Guid reviewerId, string? notes, CancellationToken ct = default);
+    Task<BulkOnboardingResult> BulkClearConsentChecksAsync(
+        IReadOnlyCollection<Guid> userIds, Guid reviewerId, CancellationToken ct = default);
     Task<OnboardingResult> FlagConsentCheckAsync(
         Guid userId, Guid reviewerId, string? notes, CancellationToken ct = default);
 

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -158,6 +158,31 @@ public sealed class OnboardingService : IOnboardingService
         return result;
     }
 
+    public async Task<BulkOnboardingResult> BulkClearConsentChecksAsync(
+        IReadOnlyCollection<Guid> userIds, Guid reviewerId, CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+            return new BulkOnboardingResult(0);
+
+        var selected = userIds.ToHashSet();
+        var data = await GetReviewQueueAsync(ct);
+        var eligibleUserIds = data.Pending
+            .Concat(data.Flagged)
+            .Where(p => selected.Contains(p.UserId) && !string.IsNullOrWhiteSpace(p.FullName))
+            .Select(p => p.UserId)
+            .ToList();
+
+        var approved = 0;
+        foreach (var userId in eligibleUserIds)
+        {
+            var result = await ClearConsentCheckAsync(userId, reviewerId, notes: null, ct);
+            if (result.Success)
+                approved++;
+        }
+
+        return new BulkOnboardingResult(approved);
+    }
+
     public async Task<OnboardingResult> FlagConsentCheckAsync(
         Guid userId, Guid reviewerId, string? notes, CancellationToken ct = default)
     {

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -409,6 +409,7 @@ public class OnboardingReviewController : HumansControllerBase
         {
             UserId = profile.UserId,
             DisplayName = itemUser?.DisplayName ?? "Unknown",
+            LegalName = profile.FullName,
             ProfilePictureUrl = itemUser?.ProfilePictureUrl,
             Email = itemUser?.Email ?? string.Empty,
             ConsentCheckStatus = profile.ConsentCheckStatus,

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -141,39 +141,11 @@ public class OnboardingReviewController : HumansControllerBase
         if (currentUser is null)
             return NotFound();
 
-        if (selectedUserIds.Count == 0)
-        {
-            SetInfo("No humans selected.");
-            return RedirectToAction(nameof(Index));
-        }
-
         try
         {
-            var selected = selectedUserIds.ToHashSet();
-            var data = await _onboardingService.GetReviewQueueAsync(ct);
-            var eligibleUserIds = data.Pending
-                .Concat(data.Flagged)
-                .Where(p => selected.Contains(p.UserId) && !string.IsNullOrWhiteSpace(p.FullName))
-                .Select(p => p.UserId)
-                .ToList();
-
-            var approved = 0;
-            foreach (var userId in eligibleUserIds)
-            {
-                var result = await _onboardingService.ClearConsentCheckAsync(
-                    userId, currentUser.Id, notes: null, ct);
-                if (result.Success)
-                    approved++;
-            }
-
-            if (approved == 0)
-            {
-                SetInfo("No selected humans were approved.");
-            }
-            else
-            {
-                SetSuccess($"Approved {approved} selected human{(approved == 1 ? "" : "s")}.");
-            }
+            var result = await _onboardingService.BulkClearConsentChecksAsync(
+                selectedUserIds, currentUser.Id, ct);
+            SetBulkClearResultMessage(result);
         }
         catch (Exception ex)
         {
@@ -182,6 +154,18 @@ public class OnboardingReviewController : HumansControllerBase
         }
 
         return RedirectToAction(nameof(Index));
+    }
+
+    private void SetBulkClearResultMessage(BulkOnboardingResult result)
+    {
+        if (result.ApprovedCount == 0)
+        {
+            SetInfo("No selected humans were approved.");
+        }
+        else
+        {
+            SetSuccess($"Approved {result.ApprovedCount} selected human{(result.ApprovedCount == 1 ? "" : "s")}.");
+        }
     }
 
     [HttpPost("{userId:guid}/Flag")]

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -132,6 +132,58 @@ public class OnboardingReviewController : HumansControllerBase
         return RedirectToAction(nameof(Index));
     }
 
+    [HttpPost("BulkClear")]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = PolicyNames.ConsentCoordinatorBoardOrAdmin)]
+    public async Task<IActionResult> BulkClear([FromForm] List<Guid> selectedUserIds, CancellationToken ct)
+    {
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null)
+            return NotFound();
+
+        if (selectedUserIds.Count == 0)
+        {
+            SetInfo("No humans selected.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        try
+        {
+            var selected = selectedUserIds.ToHashSet();
+            var data = await _onboardingService.GetReviewQueueAsync(ct);
+            var eligibleUserIds = data.Pending
+                .Concat(data.Flagged)
+                .Where(p => selected.Contains(p.UserId) && !string.IsNullOrWhiteSpace(p.FullName))
+                .Select(p => p.UserId)
+                .ToList();
+
+            var approved = 0;
+            foreach (var userId in eligibleUserIds)
+            {
+                var result = await _onboardingService.ClearConsentCheckAsync(
+                    userId, currentUser.Id, notes: null, ct);
+                if (result.Success)
+                    approved++;
+            }
+
+            if (approved == 0)
+            {
+                SetInfo("No selected humans were approved.");
+            }
+            else
+            {
+                SetSuccess($"Approved {approved} selected human{(approved == 1 ? "" : "s")}.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to bulk clear consent checks for selected users");
+            SetError(_localizer["Common_Error"].Value);
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
     [HttpPost("{userId:guid}/Flag")]
     [ValidateAntiForgeryToken]
     [Authorize(Policy = PolicyNames.ConsentCoordinatorBoardOrAdmin)]

--- a/src/Humans.Web/Models/OnboardingReviewViewModels.cs
+++ b/src/Humans.Web/Models/OnboardingReviewViewModels.cs
@@ -12,6 +12,7 @@ public class OnboardingReviewItemViewModel
 {
     public Guid UserId { get; set; }
     public string DisplayName { get; set; } = string.Empty;
+    public string LegalName { get; set; } = string.Empty;
     public string? ProfilePictureUrl { get; set; }
     public string Email { get; set; } = string.Empty;
     public ConsentCheckStatus? ConsentCheckStatus { get; set; }

--- a/src/Humans.Web/Views/OnboardingReview/Index.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/Index.cshtml
@@ -31,10 +31,18 @@
                 <div class="d-flex justify-content-between align-items-center">
                     <div class="d-flex align-items-center">
                         <human-link user-id="@item.UserId" display-name="@item.DisplayName"
-                                    mode="AvatarName" size="40"
-                                    profile-picture-url="@item.ProfilePictureUrl">
-                            <small class="text-muted">@item.Email</small>
-                        </human-link>
+                                    mode="Avatar" size="40" show-popover="false"
+                                    profile-picture-url="@item.ProfilePictureUrl" />
+                        <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
+                           class="ms-2 text-decoration-none text-reset"
+                           data-human-popover="true"
+                           data-user-id="@item.UserId">
+                            <span class="fw-semibold">@item.DisplayName</span>
+                            @if (!string.IsNullOrWhiteSpace(item.LegalName))
+                            {
+                                <span class="fw-normal text-muted"> - @item.LegalName</span>
+                            }
+                        </a>
                     </div>
                     <div class="text-end">
                         @if (item.MembershipTier != MembershipTier.Volunteer)
@@ -74,10 +82,18 @@
                 <div class="d-flex justify-content-between align-items-center">
                     <div class="d-flex align-items-center">
                         <human-link user-id="@item.UserId" display-name="@item.DisplayName"
-                                    mode="AvatarName" size="40"
-                                    profile-picture-url="@item.ProfilePictureUrl">
-                            <small class="text-muted">@item.Email</small>
-                        </human-link>
+                                    mode="Avatar" size="40" show-popover="false"
+                                    profile-picture-url="@item.ProfilePictureUrl" />
+                        <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
+                           class="ms-2 text-decoration-none text-reset"
+                           data-human-popover="true"
+                           data-user-id="@item.UserId">
+                            <span class="fw-semibold">@item.DisplayName</span>
+                            @if (!string.IsNullOrWhiteSpace(item.LegalName))
+                            {
+                                <span class="fw-normal text-muted"> - @item.LegalName</span>
+                            }
+                        </a>
                     </div>
                     <div class="text-end">
                         @if (item.MembershipTier != MembershipTier.Volunteer)

--- a/src/Humans.Web/Views/OnboardingReview/Index.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/Index.cshtml
@@ -1,6 +1,9 @@
 @model Humans.Web.Models.OnboardingReviewIndexViewModel
 @{
     ViewData["Title"] = Localizer["OnboardingReview_Title"].Value;
+    var hasSelectableReviews = Model.PendingReviews
+        .Concat(Model.FlaggedReviews)
+        .Any(item => !string.IsNullOrWhiteSpace(item.LegalName));
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -17,105 +20,136 @@
     </div>
 }
 
-@if (Model.PendingReviews.Count > 0)
+@if (Model.PendingReviews.Count > 0 || Model.FlaggedReviews.Count > 0)
 {
-    <h4 class="mt-4 mb-3">
-        @Localizer["OnboardingReview_PendingSection"]
-        <span class="badge bg-warning">@Model.PendingReviews.Count</span>
-    </h4>
-
-    <div class="list-group mb-4">
-        @foreach (var item in Model.PendingReviews)
+    <form asp-action="BulkClear" method="post">
+        @if (Model.PendingReviews.Count > 0)
         {
-            <div class="list-group-item">
-                <div class="d-flex justify-content-between align-items-center">
-                    <div class="d-flex align-items-center">
-                        <human-link user-id="@item.UserId" display-name="@item.DisplayName"
-                                    mode="Avatar" size="40" show-popover="false"
-                                    profile-picture-url="@item.ProfilePictureUrl" />
-                        <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
-                           class="ms-2 text-decoration-none text-reset"
-                           data-human-popover="true"
-                           data-user-id="@item.UserId">
-                            <span class="fw-semibold">@item.DisplayName</span>
-                            @if (!string.IsNullOrWhiteSpace(item.LegalName))
-                            {
-                                <span class="fw-normal text-muted"> - @item.LegalName</span>
-                            }
-                        </a>
+            <h4 class="mt-4 mb-3">
+                @Localizer["OnboardingReview_PendingSection"]
+                <span class="badge bg-warning">@Model.PendingReviews.Count</span>
+            </h4>
+
+            <div class="list-group mb-4">
+                @foreach (var item in Model.PendingReviews)
+                {
+                    var hasLegalName = !string.IsNullOrWhiteSpace(item.LegalName);
+                    <div class="list-group-item">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center">
+                                @if (hasLegalName)
+                                {
+                                    <input class="form-check-input me-3" type="checkbox" name="selectedUserIds"
+                                           value="@item.UserId" aria-label="Select @item.DisplayName" />
+                                }
+                                else
+                                {
+                                    <span class="form-check-input me-3 invisible" aria-hidden="true"></span>
+                                }
+                                <human-link user-id="@item.UserId" display-name="@item.DisplayName"
+                                            mode="Avatar" size="40" show-popover="false"
+                                            profile-picture-url="@item.ProfilePictureUrl" />
+                                <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
+                                   class="ms-2 text-decoration-none text-reset"
+                                   data-human-popover="true"
+                                   data-user-id="@item.UserId">
+                                    <span class="fw-semibold">@item.DisplayName</span>
+                                    @if (hasLegalName)
+                                    {
+                                        <span class="fw-normal text-muted"> - @item.LegalName</span>
+                                    }
+                                </a>
+                            </div>
+                            <div class="text-end">
+                                @if (item.MembershipTier != MembershipTier.Volunteer)
+                                {
+                                    <span class="badge bg-info me-1">@item.MembershipTier</span>
+                                }
+                                @if (item.RequiredConsentCount > 0)
+                                {
+                                    var allSigned = item.ConsentCount >= item.RequiredConsentCount;
+                                    <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
+                                        <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
+                                    </span>
+                                }
+                                <br />
+                                <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
+                                <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
+                                    <i class="fa-solid fa-eye me-1"></i>Review
+                                </a>
+                            </div>
+                        </div>
                     </div>
-                    <div class="text-end">
-                        @if (item.MembershipTier != MembershipTier.Volunteer)
-                        {
-                            <span class="badge bg-info me-1">@item.MembershipTier</span>
-                        }
-                        @if (item.RequiredConsentCount > 0)
-                        {
-                            var allSigned = item.ConsentCount >= item.RequiredConsentCount;
-                            <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
-                                <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
-                            </span>
-                        }
-                        <br />
-                        <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
-                        <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
-                            <i class="fa-solid fa-eye me-1"></i>Review
-                        </a>
-                    </div>
-                </div>
+                }
             </div>
         }
-    </div>
-}
 
-@if (Model.FlaggedReviews.Count > 0)
-{
-    <h4 class="mt-4 mb-3">
-        @Localizer["OnboardingReview_FlaggedSection"]
-        <span class="badge bg-danger">@Model.FlaggedReviews.Count</span>
-    </h4>
-
-    <div class="list-group mb-4">
-        @foreach (var item in Model.FlaggedReviews)
+        @if (Model.FlaggedReviews.Count > 0)
         {
-            <div class="list-group-item list-group-item-danger">
-                <div class="d-flex justify-content-between align-items-center">
-                    <div class="d-flex align-items-center">
-                        <human-link user-id="@item.UserId" display-name="@item.DisplayName"
-                                    mode="Avatar" size="40" show-popover="false"
-                                    profile-picture-url="@item.ProfilePictureUrl" />
-                        <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
-                           class="ms-2 text-decoration-none text-reset"
-                           data-human-popover="true"
-                           data-user-id="@item.UserId">
-                            <span class="fw-semibold">@item.DisplayName</span>
-                            @if (!string.IsNullOrWhiteSpace(item.LegalName))
-                            {
-                                <span class="fw-normal text-muted"> - @item.LegalName</span>
-                            }
-                        </a>
+            <h4 class="mt-4 mb-3">
+                @Localizer["OnboardingReview_FlaggedSection"]
+                <span class="badge bg-danger">@Model.FlaggedReviews.Count</span>
+            </h4>
+
+            <div class="list-group mb-4">
+                @foreach (var item in Model.FlaggedReviews)
+                {
+                    var hasLegalName = !string.IsNullOrWhiteSpace(item.LegalName);
+                    <div class="list-group-item list-group-item-danger">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center">
+                                @if (hasLegalName)
+                                {
+                                    <input class="form-check-input me-3" type="checkbox" name="selectedUserIds"
+                                           value="@item.UserId" aria-label="Select @item.DisplayName" />
+                                }
+                                else
+                                {
+                                    <span class="form-check-input me-3 invisible" aria-hidden="true"></span>
+                                }
+                                <human-link user-id="@item.UserId" display-name="@item.DisplayName"
+                                            mode="Avatar" size="40" show-popover="false"
+                                            profile-picture-url="@item.ProfilePictureUrl" />
+                                <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
+                                   class="ms-2 text-decoration-none text-reset"
+                                   data-human-popover="true"
+                                   data-user-id="@item.UserId">
+                                    <span class="fw-semibold">@item.DisplayName</span>
+                                    @if (hasLegalName)
+                                    {
+                                        <span class="fw-normal text-muted"> - @item.LegalName</span>
+                                    }
+                                </a>
+                            </div>
+                            <div class="text-end">
+                                @if (item.MembershipTier != MembershipTier.Volunteer)
+                                {
+                                    <span class="badge bg-info me-1">@item.MembershipTier</span>
+                                }
+                                <span class="badge bg-danger">@Localizer["OnboardingReview_FlaggedBadge"]</span>
+                                @if (item.RequiredConsentCount > 0)
+                                {
+                                    var allSigned = item.ConsentCount >= item.RequiredConsentCount;
+                                    <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
+                                        <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
+                                    </span>
+                                }
+                                <br />
+                                <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
+                                <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
+                                    <i class="fa-solid fa-eye me-1"></i>Review
+                                </a>
+                            </div>
+                        </div>
                     </div>
-                    <div class="text-end">
-                        @if (item.MembershipTier != MembershipTier.Volunteer)
-                        {
-                            <span class="badge bg-info me-1">@item.MembershipTier</span>
-                        }
-                        <span class="badge bg-danger">@Localizer["OnboardingReview_FlaggedBadge"]</span>
-                        @if (item.RequiredConsentCount > 0)
-                        {
-                            var allSigned = item.ConsentCount >= item.RequiredConsentCount;
-                            <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
-                                <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
-                            </span>
-                        }
-                        <br />
-                        <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
-                        <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
-                            <i class="fa-solid fa-eye me-1"></i>Review
-                        </a>
-                    </div>
-                </div>
+                }
             </div>
         }
-    </div>
+
+        <div class="d-flex justify-content-end mb-4">
+            <button type="submit" class="btn btn-success" disabled="@(!hasSelectableReviews)">
+                <i class="fa-solid fa-check me-1"></i>Approve all selected
+            </button>
+        </div>
+    </form>
 }


### PR DESCRIPTION
## Summary
- Add selectable checkboxes before onboarding review queue avatars when an applicant has a legal name.
- Add invisible checkbox-sized spacers for rows without a legal name so avatars and names stay aligned while those rows remain unselectable.
- Add a green `Approve all selected` action at the bottom of the queue.
- Add a bulk clear endpoint that rechecks selected rows against the current review queue and only approves entries that still have a legal name.

## Dependency
This is stacked on #670 (`[codex] Show legal names in onboarding review queue`). Until #670 lands, this PR will include that foundational commit in its comparison.

## Validation
- `dotnet build Humans.slnx`
- Ran the local server at `http://localhost:7101` and loaded `/OnboardingReview` as the dev consent coordinator.
- Seeded local applicants with and without legal names; verified rows with legal names show checkboxes, rows without legal names show aligned invisible spacers, and the `Approve all selected` button renders.