### PR TITLE
Promote: issue-474 + EmailProblems human-link

### DIFF
--- a/docs/sections/Profiles.md
+++ b/docs/sections/Profiles.md
@@ -425,5 +425,4 @@ Account deletion cascades (user-requested / admin-initiated / expiry-triggered) 
 
 ### Touch-and-clean guidance
 
-- `SetConsentCheckPendingIfEligibleAsync` does not currently invalidate the `FullProfile` dict (§15i). Pre-existing behavior; to be addressed when Shifts migrates (§15 NEW-B).
 - Cross-section reads for `Profile.User` / `UserEmail.User` / `CommunicationPreference.User` must go through `IUserService.GetByIdsAsync` — do not re-add nav properties to the entities.

--- a/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevPersonaSeeder.cs
@@ -167,12 +167,17 @@ public sealed class DevPersonaSeeder
         var profileId = await _profileService.SaveProfileAsync(id, displayName, saveRequest, "en");
 
         // Mark approved + cleared so the dev persona skips the consent gate
-        // and lands on the dashboard. This was the original behavior of the
-        // direct-add path.
-        var approvedProfile = await _db.Profiles.FirstAsync(p => p.Id == profileId);
-        approvedProfile.IsApproved = true;
-        approvedProfile.ConsentCheckStatus = ConsentCheckStatus.Cleared;
-        approvedProfile.UpdatedAt = now;
+        // and lands on the dashboard. Routes through ProfileService so the
+        // CachingProfileService decorator handles the FullProfile cache
+        // refresh atomically with the DB write (issue #474 — Profiles is the
+        // single writer to the profile state fields).
+        var consentCheckResult = await _profileService.RecordConsentCheckAsync(
+            id, reviewerId: id, ConsentCheckStatus.Cleared,
+            notes: "Dev persona — auto-seeded");
+        if (!consentCheckResult.Success)
+            _logger.LogWarning(
+                "DEV: consent-check approval failed for persona {UserId}: {ErrorKey}",
+                id, consentCheckResult.ErrorKey);
 
         // Seed sample contact fields so profile page exercises the contact rendering path.
         // ContactFields are Profile-section auxiliary data with no public service write
@@ -230,12 +235,6 @@ public sealed class DevPersonaSeeder
 
         await _db.SaveChangesAsync();
         _cache.InvalidateUserAccess(id);
-        // SaveProfileAsync (above) refreshed FullProfile while IsApproved=false /
-        // ConsentCheckStatus=Pending. We then patched both directly on the EF entity
-        // and saved — that bypasses CachingProfileService, leaving the FullProfile
-        // dict stale (persona looks unapproved, gets routed to onboarding).
-        // Re-invalidate so the dict picks up the post-patch row.
-        await _fullProfileInvalidator.InvalidateAsync(id);
 
         _logger.LogInformation("DEV: seeded persona {Email} with roles [{Roles}] and teams [{Teams}]",
             email, string.Join(", ", roles), string.Join(", ", teams.Select(t => t)));

--- a/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
+++ b/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
@@ -26,8 +26,8 @@ else
             {
                 <tr>
                     <td><code>@row.Email</code></td>
-                    <td>@row.User1DisplayName</td>
-                    <td>@row.User2DisplayName</td>
+                    <td><human-link user-id="@row.User1Id" display-name="@row.User1DisplayName" admin /></td>
+                    <td><human-link user-id="@row.User2Id" display-name="@row.User2DisplayName" admin /></td>
                     <td>
                         <a class="btn btn-sm btn-primary"
                            asp-action="EmailProblemsCompare"
@@ -53,7 +53,7 @@ else
             @foreach (var row in Model.SingleUserIssues)
             {
                 <tr>
-                    <td>@row.DisplayName</td>
+                    <td><human-link user-id="@row.UserId" display-name="@row.DisplayName" admin /></td>
                     <td>@string.Join(", ", row.ProblemSummaries)</td>
                     <td>
                         <a class="btn btn-sm btn-secondary"
@@ -90,7 +90,7 @@ else
             @foreach (var row in Model.LegacyEmailRows)
             {
                 <tr>
-                    <td>@row.DisplayName</td>
+                    <td><human-link user-id="@row.UserId" display-name="@row.DisplayName" admin /></td>
                     <td><code>@row.LegacyEmail</code></td>
                 </tr>
             }

--- a/tests/Humans.Application.Tests/Services/CachingProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingProfileServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Caching;
+using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Services.Profiles;
@@ -353,4 +354,210 @@ public class CachingProfileServiceTests
         IsApproved: true, IsSuspended: false,
         CVEntries: Array.Empty<CVEntry>(),
         PrimaryEmail: null);
+
+    // ==========================================================================
+    // Issue #474 — every profile-state mutation routed through ProfileService
+    // must refresh the FullProfile dict via the decorator, so cache and DB
+    // never diverge. These tests pin the decorator's refresh-after-write
+    // contract for the methods OnboardingService and ApplicationDecisionService
+    // call into.
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SetMembershipTierAsync_RefreshesDictWithLatestTier()
+    {
+        var userId = Guid.NewGuid();
+        var profileId = Guid.NewGuid();
+        var profile = new Profile
+        {
+            Id = profileId,
+            UserId = userId,
+            BurnerName = "Tier",
+            MembershipTier = Humans.Domain.Enums.MembershipTier.Colaborador,
+        };
+        var user = new User { Id = userId, DisplayName = "Tier" };
+
+        _profileRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(profile);
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userEmailRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<UserEmail>());
+
+        var sut = CreateSut();
+        // Prime dict with a stale entry so we can prove refresh fired.
+        _inner.GetFullProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<FullProfile?>(SampleFullProfile(userId)));
+        await sut.GetFullProfileAsync(userId);
+
+        await sut.SetMembershipTierAsync(userId, Humans.Domain.Enums.MembershipTier.Asociado);
+
+        // Inner write was invoked + nav badge invalidated + dict was refreshed.
+        await _inner.Received(1).SetMembershipTierAsync(
+            userId, Humans.Domain.Enums.MembershipTier.Asociado, Arg.Any<CancellationToken>());
+        _navBadge.Received(1).Invalidate();
+        await _profileRepository.Received().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task ApproveVolunteerAsync_Success_RefreshesDictAndInvalidatesNavBadge()
+    {
+        var userId = Guid.NewGuid();
+        var profile = new Profile { Id = Guid.NewGuid(), UserId = userId, IsApproved = true };
+        var user = new User { Id = userId, DisplayName = "Approved" };
+
+        _inner.ApproveVolunteerAsync(userId, Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(true));
+        _profileRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(profile);
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userEmailRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<UserEmail>());
+
+        var sut = CreateSut();
+
+        var result = await sut.ApproveVolunteerAsync(userId, Guid.NewGuid());
+
+        result.Success.Should().BeTrue();
+        _navBadge.Received(1).Invalidate();
+        _notificationMeter.Received(1).Invalidate();
+        await _profileRepository.Received().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task ApproveVolunteerAsync_Failure_DoesNotInvalidate()
+    {
+        var userId = Guid.NewGuid();
+        _inner.ApproveVolunteerAsync(userId, Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(false, "NotFound"));
+
+        var sut = CreateSut();
+        var result = await sut.ApproveVolunteerAsync(userId, Guid.NewGuid());
+
+        result.Success.Should().BeFalse();
+        _navBadge.DidNotReceive().Invalidate();
+        _notificationMeter.DidNotReceive().Invalidate();
+        await _profileRepository.DidNotReceive().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task RecordConsentCheckAsync_ClearedSuccess_RefreshesDictAndInvalidatesNavBadge()
+    {
+        var userId = Guid.NewGuid();
+        var profile = new Profile
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            IsApproved = true,
+            ConsentCheckStatus = Humans.Domain.Enums.ConsentCheckStatus.Cleared,
+        };
+        var user = new User { Id = userId, DisplayName = "Cleared" };
+
+        _inner.RecordConsentCheckAsync(
+                userId, Arg.Any<Guid>(),
+                Humans.Domain.Enums.ConsentCheckStatus.Cleared,
+                Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(true));
+        _profileRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(profile);
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userEmailRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<UserEmail>());
+
+        var sut = CreateSut();
+
+        var result = await sut.RecordConsentCheckAsync(
+            userId, Guid.NewGuid(), Humans.Domain.Enums.ConsentCheckStatus.Cleared, "ok");
+
+        result.Success.Should().BeTrue();
+        _navBadge.Received(1).Invalidate();
+        _notificationMeter.Received(1).Invalidate();
+        await _profileRepository.Received().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task RejectSignupAsync_Success_RefreshesDictAndInvalidatesNavBadge()
+    {
+        var userId = Guid.NewGuid();
+        var profile = new Profile { Id = Guid.NewGuid(), UserId = userId, IsApproved = false };
+        var user = new User { Id = userId, DisplayName = "Rejected" };
+
+        _inner.RejectSignupAsync(userId, Arg.Any<Guid>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(true));
+        _profileRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(profile);
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userEmailRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<UserEmail>());
+
+        var sut = CreateSut();
+
+        var result = await sut.RejectSignupAsync(userId, Guid.NewGuid(), "spam");
+
+        result.Success.Should().BeTrue();
+        _navBadge.Received(1).Invalidate();
+        _notificationMeter.Received(1).Invalidate();
+        await _profileRepository.Received().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SetSuspendedAsync_Success_RefreshesDict()
+    {
+        var userId = Guid.NewGuid();
+        var profile = new Profile { Id = Guid.NewGuid(), UserId = userId };
+        var user = new User { Id = userId, DisplayName = "Suspended" };
+
+        _inner.SetSuspendedAsync(userId, Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new OnboardingResult(true));
+        _profileRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(profile);
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userEmailRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<UserEmail>());
+
+        var sut = CreateSut();
+
+        var result = await sut.SetSuspendedAsync(userId, Guid.NewGuid(), suspended: true, "Disruptive");
+
+        result.Success.Should().BeTrue();
+        await _profileRepository.Received().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SetConsentCheckPendingAsync_Success_RefreshesDict()
+    {
+        var userId = Guid.NewGuid();
+        var profile = new Profile { Id = Guid.NewGuid(), UserId = userId };
+        var user = new User { Id = userId, DisplayName = "Pending" };
+
+        _inner.SetConsentCheckPendingAsync(userId, Arg.Any<CancellationToken>()).Returns(true);
+        _profileRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(profile);
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _userEmailRepository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<UserEmail>());
+
+        var sut = CreateSut();
+
+        var set = await sut.SetConsentCheckPendingAsync(userId);
+
+        set.Should().BeTrue();
+        _navBadge.Received(1).Invalidate();
+        _notificationMeter.Received(1).Invalidate();
+        await _profileRepository.Received().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SetConsentCheckPendingAsync_FalseFromInner_DoesNotInvalidateOrRefresh()
+    {
+        var userId = Guid.NewGuid();
+        _inner.SetConsentCheckPendingAsync(userId, Arg.Any<CancellationToken>()).Returns(false);
+
+        var sut = CreateSut();
+        var set = await sut.SetConsentCheckPendingAsync(userId);
+
+        set.Should().BeFalse();
+        _navBadge.DidNotReceive().Invalidate();
+        _notificationMeter.DidNotReceive().Invalidate();
+        await _profileRepository.DidNotReceive().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -1641,4 +1641,248 @@ public class ProfileServiceTests : IDisposable
 
         await fakeRepo.Received(1).AddAsync(Arg.Any<Profile>(), Arg.Any<CancellationToken>());
     }
+
+    // ==========================================================================
+    // Issue #474 — phase 5 service-ownership: every profile state mutation now
+    // routes through ProfileService so the §15 caching decorator can keep the
+    // FullProfile dict in sync atomically with the DB write. These tests pin
+    // the contracts the decorator relies on (return values, field updates,
+    // error keys) so future refactors can't drift the behaviour.
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SetMembershipTierAsync_UpdatesTierAndUpdatedAt()
+    {
+        var userId = Guid.NewGuid();
+        await SeedUserWithProfileAsync(userId);
+        _clock.Advance(Duration.FromHours(1));
+
+        await _service.SetMembershipTierAsync(userId, MembershipTier.Colaborador);
+
+        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        profile.MembershipTier.Should().Be(MembershipTier.Colaborador);
+        profile.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+    }
+
+    [HumansFact]
+    public async Task SetMembershipTierAsync_UnknownUser_NoOp()
+    {
+        var unknownUserId = Guid.NewGuid();
+
+        // No throw, no profile created — just a logged warning.
+        await _service.SetMembershipTierAsync(unknownUserId, MembershipTier.Asociado);
+
+        var profileExists = await _dbContext.Profiles.AsNoTracking().AnyAsync(p => p.UserId == unknownUserId);
+        profileExists.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task RecordConsentCheckAsync_Cleared_FlipsIsApprovedAndStamps()
+    {
+        var userId = Guid.NewGuid();
+        var reviewerId = Guid.NewGuid();
+        await SeedUserWithProfileAsync(userId);
+
+        var result = await _service.RecordConsentCheckAsync(
+            userId, reviewerId, ConsentCheckStatus.Cleared, "Looks good");
+
+        result.Success.Should().BeTrue();
+        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        profile.ConsentCheckStatus.Should().Be(ConsentCheckStatus.Cleared);
+        profile.IsApproved.Should().BeTrue();
+        profile.ConsentCheckAt.Should().Be(_clock.GetCurrentInstant());
+        profile.ConsentCheckedByUserId.Should().Be(reviewerId);
+        profile.ConsentCheckNotes.Should().Be("Looks good");
+    }
+
+    [HumansFact]
+    public async Task RecordConsentCheckAsync_Flagged_KeepsIsApprovedFalse()
+    {
+        var userId = Guid.NewGuid();
+        var reviewerId = Guid.NewGuid();
+        await SeedUserWithProfileAsync(userId);
+
+        var result = await _service.RecordConsentCheckAsync(
+            userId, reviewerId, ConsentCheckStatus.Flagged, "Concern X");
+
+        result.Success.Should().BeTrue();
+        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        profile.ConsentCheckStatus.Should().Be(ConsentCheckStatus.Flagged);
+        profile.IsApproved.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task RecordConsentCheckAsync_NoProfile_ReturnsNotFound()
+    {
+        var unknownUserId = Guid.NewGuid();
+
+        var result = await _service.RecordConsentCheckAsync(
+            unknownUserId, Guid.NewGuid(), ConsentCheckStatus.Cleared, null);
+
+        result.Success.Should().BeFalse();
+        result.ErrorKey.Should().Be("NotFound");
+    }
+
+    [HumansFact]
+    public async Task RecordConsentCheckAsync_AlreadyRejected_BlocksClear()
+    {
+        var userId = Guid.NewGuid();
+        var profileId = await SeedUserWithProfileAsync(userId);
+        var profile = await _dbContext.Profiles.FirstAsync(p => p.Id == profileId);
+        profile.RejectedAt = _clock.GetCurrentInstant();
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.RecordConsentCheckAsync(
+            userId, Guid.NewGuid(), ConsentCheckStatus.Cleared, null);
+
+        result.Success.Should().BeFalse();
+        result.ErrorKey.Should().Be("AlreadyRejected");
+    }
+
+    [HumansFact]
+    public async Task RecordConsentCheckAsync_PendingValue_Throws()
+    {
+        var userId = Guid.NewGuid();
+        await SeedUserWithProfileAsync(userId);
+
+        // Pending is the system-driven transition — must use SetConsentCheckPendingAsync.
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _service.RecordConsentCheckAsync(
+                userId, Guid.NewGuid(), ConsentCheckStatus.Pending, null));
+    }
+
+    [HumansFact]
+    public async Task RejectSignupAsync_StampsRejectionFields()
+    {
+        var userId = Guid.NewGuid();
+        var reviewerId = Guid.NewGuid();
+        await SeedUserWithProfileAsync(userId);
+
+        var result = await _service.RejectSignupAsync(userId, reviewerId, "Spam account");
+
+        result.Success.Should().BeTrue();
+        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        profile.RejectedAt.Should().Be(_clock.GetCurrentInstant());
+        profile.RejectedByUserId.Should().Be(reviewerId);
+        profile.RejectionReason.Should().Be("Spam account");
+        profile.IsApproved.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task RejectSignupAsync_AlreadyRejected_ReturnsErrorKey()
+    {
+        var userId = Guid.NewGuid();
+        var profileId = await SeedUserWithProfileAsync(userId);
+        var profile = await _dbContext.Profiles.FirstAsync(p => p.Id == profileId);
+        profile.RejectedAt = _clock.GetCurrentInstant();
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.RejectSignupAsync(userId, Guid.NewGuid(), null);
+
+        result.Success.Should().BeFalse();
+        result.ErrorKey.Should().Be("AlreadyRejected");
+    }
+
+    [HumansFact]
+    public async Task RejectSignupAsync_NoProfile_ReturnsNotFound()
+    {
+        var result = await _service.RejectSignupAsync(Guid.NewGuid(), Guid.NewGuid(), null);
+
+        result.Success.Should().BeFalse();
+        result.ErrorKey.Should().Be("NotFound");
+    }
+
+    [HumansFact]
+    public async Task ApproveVolunteerAsync_FlipsIsApprovedTrue()
+    {
+        var userId = Guid.NewGuid();
+        await SeedUserWithProfileAsync(userId, isApproved: false);
+
+        var result = await _service.ApproveVolunteerAsync(userId, Guid.NewGuid());
+
+        result.Success.Should().BeTrue();
+        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        profile.IsApproved.Should().BeTrue();
+        profile.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+    }
+
+    [HumansFact]
+    public async Task ApproveVolunteerAsync_NoProfile_ReturnsNotFound()
+    {
+        var result = await _service.ApproveVolunteerAsync(Guid.NewGuid(), Guid.NewGuid());
+
+        result.Success.Should().BeFalse();
+        result.ErrorKey.Should().Be("NotFound");
+    }
+
+    [HumansFact]
+    public async Task SetSuspendedAsync_True_SetsSuspendedAndState()
+    {
+        var userId = Guid.NewGuid();
+        await SeedUserWithProfileAsync(userId);
+
+        var result = await _service.SetSuspendedAsync(userId, Guid.NewGuid(), suspended: true, "Disruptive");
+
+        result.Success.Should().BeTrue();
+        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+#pragma warning disable HUM_PROFILE_ISSUSPENDED
+        profile.IsSuspended.Should().BeTrue();
+#pragma warning restore HUM_PROFILE_ISSUSPENDED
+        profile.State.Should().Be(ProfileState.Suspended);
+        profile.AdminNotes.Should().Be("Disruptive");
+    }
+
+    [HumansFact]
+    public async Task SetSuspendedAsync_FalseRestoresActiveWhenIdentityComplete()
+    {
+        var userId = Guid.NewGuid();
+        var profileId = await SeedUserWithProfileAsync(userId);
+        var profile = await _dbContext.Profiles.FirstAsync(p => p.Id == profileId);
+#pragma warning disable HUM_PROFILE_ISSUSPENDED
+        profile.IsSuspended = true;
+#pragma warning restore HUM_PROFILE_ISSUSPENDED
+        profile.State = ProfileState.Suspended;
+        // SeedUserWithProfileAsync seeds BurnerName/FirstName/LastName, so identity is complete.
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.SetSuspendedAsync(userId, Guid.NewGuid(), suspended: false, notes: null);
+
+        result.Success.Should().BeTrue();
+        var fresh = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+#pragma warning disable HUM_PROFILE_ISSUSPENDED
+        fresh.IsSuspended.Should().BeFalse();
+#pragma warning restore HUM_PROFILE_ISSUSPENDED
+        fresh.State.Should().Be(ProfileState.Active);
+    }
+
+    [HumansFact]
+    public async Task SetSuspendedAsync_NoProfile_ReturnsNotFound()
+    {
+        var result = await _service.SetSuspendedAsync(
+            Guid.NewGuid(), Guid.NewGuid(), suspended: true, notes: null);
+
+        result.Success.Should().BeFalse();
+        result.ErrorKey.Should().Be("NotFound");
+    }
+
+    [HumansFact]
+    public async Task SetConsentCheckPendingAsync_FlipsToPending()
+    {
+        var userId = Guid.NewGuid();
+        await SeedUserWithProfileAsync(userId);
+
+        var set = await _service.SetConsentCheckPendingAsync(userId);
+
+        set.Should().BeTrue();
+        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
+        profile.ConsentCheckStatus.Should().Be(ConsentCheckStatus.Pending);
+    }
+
+    [HumansFact]
+    public async Task SetConsentCheckPendingAsync_NoProfile_ReturnsFalse()
+    {
+        var set = await _service.SetConsentCheckPendingAsync(Guid.NewGuid());
+
+        set.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## Summary

Two QA-baked changes from peterdrier/Humans:main.

- **issue-474** (peterdrier#458): route the remaining `DevPersonaSeeder` direct-write through `IProfileService.RecordConsentCheckAsync` so the caching decorator handles cache refresh atomically with the DB write. Drops a stale touch-and-clean note in `docs/sections/Profiles.md` (the limitation no longer exists). Adds 24 decorator/service tests covering every profile-state mutation method. Closes #474.
- **EmailProblems human-link** (peterdrier#460): swap the four raw `@displayName` renders on `/Profile/Admin/EmailProblems` (cross-user conflicts × 2, single-user issues, legacy-email rows) to the `<human-link>` tag helper in `admin` mode. View-template change only — gives admins avatar popover + click-through to the admin profile.

## Test plan

- [x] CI green on each peterdrier PR before merge to QA
- [x] QA smoke (Coolify auto-deploy from peterdrier/main)
- [ ] Verify dev persona seeding still lands on dashboard with `IsApproved = true`
- [ ] Verify `/Profile/Admin/EmailProblems` rows show clickable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)