### PR TITLE
Promote QA → production (6 commits)

### DIFF
--- a/docs/plans/2026-05-13-section-align-budget.md
+++ b/docs/plans/2026-05-13-section-align-budget.md
@@ -1,0 +1,102 @@
+# Section-align: Budget (phase 0)
+
+- **Date**: 2026-05-13
+- **Section**: Budget
+- **Branch**: `align/budget`
+- **Status**: inventory only
+
+## What exists for this section
+
+### Controllers
+- `src/Humans.Web/Controllers/BudgetController.cs`
+  - `[Route("Budget")]`
+  - `GET /Budget`, `/Budget/Summary`, `/Budget/Category/{id:guid}`
+- `src/Humans.Web/Controllers/FinanceController.cs`
+  - `[Route("Finance")]`
+  - `Index`, `Years/{id}`, `Categories/{id}`, `AuditLog/{yearId?}`, `CashFlow`, `Admin`
+  - CRUD POST endpoints for year/group/category/line-item sync, plus budget-related sync actions
+
+### Section extension / DI
+- `src/Humans.Web/Extensions/Sections/BudgetSectionExtensions.cs`
+  - Registers `IBudgetRepository` -> `BudgetRepository` (singleton)
+  - Registers `IBudgetService` -> `BudgetBudgetService` (scoped)
+  - Registers `IUserDataContributor`
+  - Registers ticketing bridge service: `ITicketingBudgetRepository` -> `TicketingBudgetRepository` and `ITicketingBudgetService` -> `TicketsTicketingBudgetService`
+
+### Views
+- Budget views:
+  - `src/Humans.Web/Views/Budget/Index.cshtml`
+  - `src/Humans.Web/Views/Budget/Summary.cshtml`
+  - `src/Humans.Web/Views/Budget/NoActiveBudget.cshtml`
+  - `src/Humans.Web/Views/Budget/CategoryDetail.cshtml`
+- Finance views consumed by budget feature:
+  - `src/Humans.Web/Views/Finance/Admin.cshtml`
+  - `src/Humans.Web/Views/Finance/AuditLog.cshtml`
+  - `src/Humans.Web/Views/Finance/CashFlow.cshtml`
+  - `src/Humans.Web/Views/Finance/CategoryDetail.cshtml`
+  - `src/Humans.Web/Views/Finance/NoActiveYear.cshtml`
+  - `src/Humans.Web/Views/Finance/YearDetail.cshtml`
+
+### Domain / data surface
+- `src/Humans.Application/Interfaces/Budget/IBudgetService.cs`
+- `src/Humans.Infrastructure/Repositories/Budget/BudgetRepository.cs`
+  - Uses `IDbContextFactory` and short-lived `DbContext` instances per call
+- Domain entities:
+  - `src/Humans.Domain/Entities/BudgetLineItem.cs`
+  - `src/Humans.Domain/Entities/BudgetCategory.cs`
+  - `src/Humans.Domain/Entities/BudgetAuditLog.cs`
+- View models:
+  - `src/Humans.Web/Models/BudgetViewModels.cs`
+
+## Boundary and invariants check
+
+### What Budget currently consumes from other sections
+- Team APIs:
+  - `ITeamService.GetBudgetableTeamsAsync()`
+  - `ITeamService.GetEffectiveBudgetCoordinatorTeamIdsAsync()`
+  - `ITeamService.GetActiveTeamOptionsAsync()`
+- User API:
+  - `IUserService` for merged source IDs and label enrichment
+
+### What other sections consume from Budget
+- Ticketing uses budget bridge interface:
+  - `ITicketingBudgetRepository`
+  - `ITicketingBudgetService`
+  - See `TicketsTicketingBudgetService` implementation path in Budget section extensions
+
+### Architectural notes
+- No `Budget`-specific architecture tests were found under `tests/Humans.Application.Tests/Architecture`.
+- No direct EF types were identified in budget application service layer during this pass.
+- Repository uses navigation includes for related entities; there is a notable TODO comment around loading team navigation on line items.
+
+## Follow-up candidates (from section-alignment pass)
+
+1. Resolve canonical route tension between `/Budget/*` and `/Finance/*` admin workflows for budget admin/audit operations.
+2. Add/confirm `[SurfaceBudget]` annotations (if expected by conventions) on exposed budget contract interfaces.
+3. Add budget-specific architecture tests and controller coverage gaps.
+4. Validate any remaining team navigation dependencies in budget line items and remove legacy references where possible.
+5. Review `BudgetAuditLog` and reporting endpoints for cross-section contract consistency.
+
+## Test coverage status
+
+- Existing tests:
+  - `tests/Humans.Application.Tests/Services/BudgetServiceTests.cs`
+  - `tests/Humans.Application.Tests/Services/TicketingBudgetServiceTests.cs`
+- No section-specific controller or architecture test suite was identified for Budget during this phase.
+
+## Files referenced
+
+- `docs/sections/Budget.md`
+- `src/Humans.Web/Controllers/BudgetController.cs`
+- `src/Humans.Web/Controllers/FinanceController.cs`
+- `src/Humans.Web/Extensions/Sections/BudgetSectionExtensions.cs`
+- `src/Humans.Web/Models/BudgetViewModels.cs`
+- `src/Humans.Infrastructure/Repositories/Budget/BudgetRepository.cs`
+- `src/Humans.Application/Interfaces/Budget/IBudgetService.cs`
+- `src/Humans.Domain/Entities/BudgetLineItem.cs`
+- `src/Humans.Domain/Entities/BudgetCategory.cs`
+- `src/Humans.Domain/Entities/BudgetAuditLog.cs`
+- `src/Humans.Web/Views/Budget/*`
+- `src/Humans.Web/Views/Finance/*`
+- `tests/Humans.Application.Tests/Services/BudgetServiceTests.cs`
+- `tests/Humans.Application.Tests/Services/TicketingBudgetServiceTests.cs`

--- a/docs/plans/2026-05-13-section-align-teams.md
+++ b/docs/plans/2026-05-13-section-align-teams.md
@@ -1,0 +1,167 @@
+# Section Align - Teams
+**Run started:** 2026-05-13 | **Mode:** existing-section | **Worktree:** `H:\source\humans\.worktrees\section-align-teams`
+**Branch:** `align/teams` (off `origin/main`)
+**Canonical section name proposal:** Teams
+
+## Axis 1 - Boundary integrity
+
+### 1.1 Section name consistency - clean
+Canonical name `Teams` is consistent across:
+- `docs/sections/Teams.md`
+- Controllers:
+  - `src/Humans.Web/Controllers/TeamController.cs`
+  - `src/Humans.Web/Controllers/TeamAdminController.cs`
+- Views:
+  - `src/Humans.Web/Views/Team/`
+  - `src/Humans.Web/Views/TeamAdmin/`
+- ViewModels:
+  - `src/Humans.Web/Models/TeamViewModels.cs`
+  - `src/Humans.Web/Models/TeamResourceViewModels.cs`
+  - `src/Humans.Web/Models/TeamSyncViewModels.cs`
+  - `src/Humans.Web/Models/TeamFormViewModelBase.cs`
+- DI extension:
+  - `src/Humans.Web/Extensions/Sections/TeamsSectionExtensions.cs`
+
+### 1.2 Controller existence/placement - clean
+Team UI and admin actions are in section-local controllers (`Team*`). No `Teams` actions were identified in unrelated controllers.
+
+### 1.3 URL surface - mostly clean
+Known routes are primarily:
+- `/Teams/*`
+- `/Team/Admin/*` (documented canonical path for team admin flow)
+
+Note: runtime route currently appears as `TeamAdminController` mounted at `Teams/{slug}` in implementation; if canonical docs require `/Team/Admin/*`, route shape should be reconciled before calling this clean.
+
+No clear section-collision was found in this pass.
+
+### 1.4 Views folder - clean
+`Team` and `TeamAdmin` view folders exist and align with controller locations.
+
+### 1.5 ViewModel placement - clean
+Team view models are section-local in `src/Humans.Web/Models`.
+
+### 1.6 Controller-base leak - clean
+No Teams-specific helpers or models were found added to `HumansControllerBase`.
+
+### 1.7 Extensions placement - clean
+`TeamsSectionExtensions` exists and contains Teams registrations in `src/Humans.Web/Extensions/Sections`.
+
+### 1.8 Role surface - partial review
+No obvious public role anomalies were found from route-level inspection.
+Needs direct review against `docs/sections/Teams.md` during runtime pass.
+
+### 1.9 / 1.10 Inbound cross-section DB access and EF navigations - action required
+Direct reads/writes to Teams-owned tables from outside the section were found:
+- `src/Humans.Infrastructure/Repositories/AuditLog/AuditLogRepository.cs` uses `ctx.Teams` for display names.
+- `src/Humans.Infrastructure/Services/HumansMetricsService.cs` reads `db.Teams` and `db.TeamJoinRequests`.
+
+Cross-section inbound Team entity navigation usage observed:
+- `src/Humans.Application/Models/Team/...` has obsolete Team references in other sections (`OwningTeam`, `Team`, `AssignedToTeam` navs documented as obsolete).
+
+These should be migrated to interface contracts or explicitly accepted/approved in follow-up section work.
+For each follow-up, validate first that each caller needs exactly what Teams currently provides, and that caller requirements are available on the Teams API surface:
+- caller field or object requirements should map to existing methods on `ITeamService`/other `Humans.Application.Interfaces.Teams` contracts
+- if missing, extend Teams service contracts before removing DB-level reads
+
+### 1.11 Outbound cross-section access - mostly clean
+No obvious Teams service direct repository access outside its section was found during this pass.
+Where cross-section data is needed, Teams services appear to use section interfaces (to verify further in Phase 2 if gaps remain).
+
+### 1.12 Controller -> DbContext - clean
+No Teams controllers inject `HumansDbContext` directly.
+
+### 1.13 Migrations - clean
+No hand-edited Teams migration paths were identified in this pass.
+
+### 1.14 Section doc shape - clean
+`docs/sections/Teams.md` exists and covers routing, ownership, and current workflow.
+
+### 1.15 Operational docs/routing gaps - none identified
+No explicit undocumented major routing exception was confirmed in this pass.
+
+## Axis 2 - Internal cohesion
+
+### 2.1 EF leakage from service layer - clean
+Team service types (`TeamService`, `TeamResourceService`, `TeamPageService`) are in `src/Humans.Application/Services/Teams` and do not take direct EF `DbContext` dependencies.
+
+### 2.2 Caching placement - clean
+Caching exists in `src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs` as a decorator around primary service.
+
+### 2.3 DI lifetimes - clean
+Team registrations in `TeamsSectionExtensions` and related infrastructure registrations follow existing singleton/scoped/service-decorator pattern.
+
+### 2.4 Repository pattern - clean
+Teams repositories are owned in `src/Humans.Infrastructure/Repositories/Teams`, interfaces are section-local, and implementation (`TeamRepository`) is a sealed concrete class.
+
+### 2.5 Shared visual components - review needed
+No obvious Teams-specific shared components were identified in this pass; need follow-up confirmation on future cross-page rendering surfaces.
+
+### 2.6 Interface budget + consolidation - action required
+Surface budget status for Teams public interfaces was not confirmed in this pass.
+Need to review for `[SurfaceBudget]` compliance and exact budget alignment.
+
+### 2.7 Architecture tests - partial coverage
+Existing architecture tests are present:
+- `tests/Humans.Application.Tests/Architecture/TeamsArchitectureTests.cs`
+- `tests/Humans.Application.Tests/Architecture/TeamResourceArchitectureTests.cs`
+- `tests/Humans.Application.Tests/Architecture/TeamPageArchitectureTests.cs`
+
+Boundary coverage should be revalidated after any interface or composition changes.
+
+## Axis 3 - Test focus
+
+### 3.1 Test placement
+Tests exist in:
+- `tests/Humans.Application.Tests/Architecture/*Teams*`
+- `tests/Humans.Application.Tests/Services/*Team*`
+- `tests/e2e/tests/teams*.spec.ts`
+
+### 3.2 Coverage map
+Service, repository, and e2e coverage exists in targeted tests.
+
+### 3.3 Redundancy
+No immediate redundant tests were flagged in initial scan.
+
+### 3.4 Mutation testing
+Baseline from `docs/testing/mutation-testing.md`: `2139` attributes.
+Teams-specific `local/stryker-runs/teams` report not confirmed; no delta recorded in this pass.
+
+## Test-attribute gate
+- Baseline from `docs/testing/mutation-testing.md`: 2139 attributes.
+- Phase 0 net delta: +0 / -0 = 0.
+
+## Stop conditions tripped
+
+None.
+
+## Follow-up /section-align targets
+
+1. [`section-align-auditLog`](../../docs/plans/2026-05-12-section-align-auditLog.md)
+   - Remove/replace `AuditLogRepository` direct `ctx.Teams` reads.
+   - Verify `AuditLogRepository` callers only need display fields already exposed by Teams service interfaces (`team name`, `slug`, `id`, and any other referenced Team metadata).
+2. [`section-align-scanner` or metrics-adjacent pass](../../docs/plans/2026-05-12-section-align-scanner.md)
+   - Remove/replace `HumansMetricsService` direct `Teams`/`TeamJoinRequests` access.
+   - Confirm `HumansMetricsService` can be satisfied via Teams API contracts (`ITeamService` reads needed by metrics) before changing any EF reads.
+3. `[section-align-docs for section owning obsolete Team navs]`
+   - Consolidate deprecated Team navigation usage in non-Team entities (`BudgetCategory.Team`, `CalendarEvent.OwningTeam`, `FeedbackReport.AssignedToTeam`) to section-owned service contracts.
+
+## Phase plan
+
+### Phase 1 - Surface alignment
+1. [ ] Validate Teams controller/model/view locations are still canonical after latest commits.
+2. [ ] Re-check all Team routes in `TeamController` and `TeamAdminController` versus `docs/sections/Teams.md`; update docs if needed.
+3. [ ] Revalidate role surface and unauthorized route exposure in section admin/user pathways.
+
+### Phase 2 - Architecture and boundary cleanup
+1. [ ] Check Teams interfaces for `[SurfaceBudget]` coverage and exactness.
+2. [ ] Verify all cross-section Team access is via section services/interfaces.
+3. [ ] Resolve or document remaining inbound Teams table reads in non-Team sections (audit log/metrics items above).
+
+### Phase 3 - Simplify / prune
+1. [ ] Reduce/decouple remaining obsolete Team nav exposures where practical.
+2. [ ] Eliminate duplicate/legacy Team-specific coupling code introduced by obsolete navs.
+3. [ ] Rework obvious `Teams` boundary leakage to service contracts.
+
+### Phase 4 - Docs
+1. [ ] Confirm `docs/sections/Teams.md` includes any intentional boundary exception found above.
+2. [ ] Add explicit follow-up references for `section-align` targets created in 1.10/2.6.

--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -372,7 +372,7 @@ public record UrgentShift(
     int ConfirmedCount,
     int RemainingSlots,
     string DepartmentName,
-    IReadOnlyList<(Guid UserId, string DisplayName, SignupStatus Status, bool HasProfilePicture)> Signups);
+    IReadOnlyList<(Guid UserId, string DisplayName, SignupStatus Status)> Signups);
 
 /// <summary>
 /// Per-day staffing data for set-up/event/strike visualization.

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -638,8 +638,7 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
                             return (
                                 ss.UserId,
                                 DisplayName: user?.DisplayName ?? string.Empty,
-                                ss.Status,
-                                HasProfilePicture: user?.ProfilePictureUrl is not null);
+                                ss.Status);
                         })
                         .OrderBy(ss => ss.Status == SignupStatus.Confirmed ? 0 : 1)
                         .ThenBy(ss => ss.DisplayName, StringComparer.OrdinalIgnoreCase)

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -954,7 +954,7 @@ public sealed class TicketRepository : ITicketRepository
         // EF can't translate a Where over a Select-projected DTO's properties
         // (it tries to re-evaluate the constructor inside SQL and fails). Push
         // the IssuedCount > ValidCount predicate upstream as a subquery on the
-        // attendee collection.
+        // attendee collection. Sort is the controller's job — see TicketTransferAdminController.
         return await ctx.TicketOrders
             .AsNoTracking()
             .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
@@ -969,7 +969,6 @@ public sealed class TicketRepository : ITicketRepository
                 o.Attendees.Count(a => a.Status == TicketAttendeeStatus.Valid
                                        || a.Status == TicketAttendeeStatus.CheckedIn),
                 o.VendorDashboardUrl))
-            .OrderByDescending(r => r.IssuedCount - r.ValidCount) // arch:db-sort-ok — diagnostic prioritisation, not display sort
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Infrastructure/Services/HumansMetricsService.cs
+++ b/src/Humans.Infrastructure/Services/HumansMetricsService.cs
@@ -233,6 +233,7 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
             var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
             var membershipCalc = scope.ServiceProvider.GetRequiredService<IMembershipCalculator>();
             var applicationDecisionService = scope.ServiceProvider.GetRequiredService<IApplicationDecisionService>();
+            var teamService = scope.ServiceProvider.GetRequiredService<ITeamService>();
             var clock = scope.ServiceProvider.GetRequiredService<IClock>();
             var now = clock.GetCurrentInstant();
 
@@ -282,12 +283,12 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
                 .ToListAsync();
 
             // teams
-            var teamsActive = await db.Teams.CountAsync(t => t.IsActive);
-            var teamsInactive = await db.Teams.CountAsync(t => !t.IsActive);
+            var teams = await teamService.GetTeamsAsync(CancellationToken.None);
+            var teamsActive = teams.Values.Count(t => t.IsActive);
+            var teamsInactive = teams.Count - teamsActive;
 
             // team_join_requests_pending
-            var teamJoinRequestsPending = await db.TeamJoinRequests
-                .CountAsync(r => r.Status == TeamJoinRequestStatus.Pending);
+            var teamJoinRequestsPending = await teamService.GetTotalPendingJoinRequestCountAsync();
 
             // google_resources
             var teamResourceService = scope.ServiceProvider.GetRequiredService<ITeamResourceService>();

--- a/src/Humans.Infrastructure/Services/TicketTailorService.cs
+++ b/src/Humans.Infrastructure/Services/TicketTailorService.cs
@@ -139,7 +139,7 @@ public class TicketTailorService : ITicketVendorService
                     VendorTicketId: ticket.Id,
                     VendorOrderId: ticket.OrderId,
                     AttendeeName: ticket.FullName ?? $"{ticket.FirstName} {ticket.LastName}".Trim(),
-                    AttendeeEmail: ticket.Email,
+                    AttendeeEmail: ResolveAttendeeEmail(ticket),
                     TicketTypeName: ticket.Description ?? "Unknown",
                     Price: (ticket.ListedPrice ?? 0) / 100m,
                     Status: ticket.Status ?? "valid"));
@@ -351,7 +351,29 @@ public class TicketTailorService : ITicketVendorService
         [property: JsonPropertyName("description")] string? Description,
         [property: JsonPropertyName("listed_price")] int? ListedPrice,
         [property: JsonPropertyName("status")] string? Status,
-        [property: JsonPropertyName("order_id")] string? OrderId);
+        [property: JsonPropertyName("order_id")] string? OrderId,
+        [property: JsonPropertyName("custom_questions")] List<TtCustomQuestion>? CustomQuestions);
+
+    internal sealed record TtCustomQuestion(
+        [property: JsonPropertyName("question")] string? Question,
+        [property: JsonPropertyName("answer")] string? Answer);
+
+    // TT's issued_ticket.email is the buyer/account email replicated onto every
+    // ticket in the order — useless for matching the actual attendee. The real
+    // attendee email is collected via a custom checkout question whose text is
+    // exactly "Email" (see order or_76148796). Match the question string
+    // verbatim; fall back to the top-level field when absent.
+    internal static string? ResolveAttendeeEmail(TtIssuedTicket ticket)
+    {
+        var customEmail = ticket.CustomQuestions?
+            .FirstOrDefault(q =>
+                string.Equals(q.Question, "Email", StringComparison.Ordinal) &&
+                !string.IsNullOrWhiteSpace(q.Answer))
+            ?.Answer
+            ?.Trim();
+
+        return !string.IsNullOrEmpty(customEmail) ? customEmail : ticket.Email;
+    }
 
     internal sealed record TtEvent(
         [property: JsonPropertyName("name")] string? Name,
@@ -455,7 +477,7 @@ public class TicketTailorService : ITicketVendorService
             VendorTicketId: body.Id,
             VendorOrderId: body.OrderId,
             AttendeeName: body.FullName ?? $"{body.FirstName} {body.LastName}".Trim(),
-            AttendeeEmail: body.Email,
+            AttendeeEmail: ResolveAttendeeEmail(body),
             TicketTypeName: body.Description ?? "Unknown",
             Price: (body.ListedPrice ?? 0) / 100m,
             Status: body.Status ?? "valid");

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1695,7 +1695,9 @@ public class ProfileController : HumansControllerBase
             if (user is null)
                 return NotFound();
 
-            return View(await BuildCommunicationPreferencesViewModelAsync(user.Id));
+            // Panel rendering moved to CommunicationPreferencesPanelViewComponent (issue #706).
+            // The view invokes the VC with the current user's id; no model needed.
+            return View(model: user.Id);
         }
         catch (Exception ex)
         {
@@ -2724,40 +2726,6 @@ public class ProfileController : HumansControllerBase
                 ? user.IdentityEmailColumn
                 : null,
         };
-    }
-
-    private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)
-    {
-        var prefs = await _commPrefService.GetPreferencesAsync(userId);
-        var prefsByCategory = prefs.ToDictionary(p => p.Category);
-
-        // Check if user is a matched ticket attendee (locks ticketing preference)
-        var hasTicketOrder = await _ticketQueryService.HasTicketAttendeeMatchAsync(userId);
-
-        var categories = new List<CategoryPreferenceItem>();
-
-        foreach (var category in MessageCategoryExtensions.ActiveCategories)
-        {
-            var pref = prefsByCategory.GetValueOrDefault(category);
-            var isAlwaysOn = category.IsAlwaysOn();
-            var isTicketingLocked = category == MessageCategory.Ticketing && hasTicketOrder;
-
-            categories.Add(new CategoryPreferenceItem
-            {
-                Category = category,
-                DisplayName = category == MessageCategory.Ticketing
-                    ? $"Ticketing — {_clock.GetCurrentInstant().InUtc().Year}"
-                    : category.ToDisplayName(),
-                Description = category.ToDescription(),
-                EmailEnabled = pref is null || !pref.OptedOut,
-                AlertEnabled = pref?.InboxEnabled ?? true,
-                EmailEditable = !isAlwaysOn && !isTicketingLocked,
-                AlertEditable = !isAlwaysOn && !isTicketingLocked,
-                Note = isTicketingLocked ? "Locked — you have a ticket for this year" : null,
-            });
-        }
-
-        return new CommunicationPreferencesViewModel { Categories = categories };
     }
 
 }

--- a/src/Humans.Web/Controllers/TicketTransferAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketTransferAdminController.cs
@@ -53,7 +53,9 @@ public sealed class TicketTransferAdminController : HumansControllerBase
             _ => pending,
         };
 
-        var drift = await _ticketQueryService.GetOrderDriftAsync(ct);
+        var drift = (await _ticketQueryService.GetOrderDriftAsync(ct))
+            .OrderByDescending(r => r.IssuedCount - r.ValidCount)
+            .ToList();
 
         return View(new TicketTransferIndexViewModel(
             ActiveTab: tab,

--- a/src/Humans.Web/Controllers/WidgetGalleryController.cs
+++ b/src/Humans.Web/Controllers/WidgetGalleryController.cs
@@ -213,9 +213,7 @@ public sealed class WidgetGalleryController : HumansControllerBase
             RemainingSlots = u.RemainingSlots,
             UrgencyScore = u.UrgencyScore,
             Signups = u.Signups
-                .Select(s => new ShiftSignupInfo(
-                    s.UserId, s.DisplayName, s.Status,
-                    s.HasProfilePicture ? $"/Profile/Picture?id={s.UserId}" : null))
+                .Select(s => new ShiftSignupInfo(s.UserId, s.DisplayName, s.Status))
                 .ToList(),
         };
     }

--- a/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
+++ b/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
@@ -1,4 +1,5 @@
 using Humans.Domain.Enums;
+using NodaTime;
 
 namespace Humans.Web.Models;
 
@@ -17,6 +18,13 @@ public class CommunicationPreferencesViewModel
     /// "Unsubscribe from <category>" banner and pre-focuses that row in the matrix.
     /// </summary>
     public MessageCategory? HighlightCategory { get; set; }
+
+    /// <summary>
+    /// When true, the panel renders values only (no toggles, no POST forms) and exposes
+    /// <see cref="CategoryPreferenceItem.UpdateSource"/> / <see cref="CategoryPreferenceItem.UpdatedAt"/>
+    /// for admin attribution. False on self-service.
+    /// </summary>
+    public bool ReadOnly { get; set; }
 }
 
 public class CategoryPreferenceItem
@@ -52,4 +60,16 @@ public class CategoryPreferenceItem
     /// Optional note shown below the category (e.g., "Locked — you have a ticket order for 2026").
     /// </summary>
     public string? Note { get; set; }
+
+    /// <summary>
+    /// Who/what last changed this preference (e.g. "Profile", "MailerLiteSync", "MagicLink").
+    /// Surfaced in admin read-only view; null on self-service.
+    /// </summary>
+    public string? UpdateSource { get; set; }
+
+    /// <summary>
+    /// When this preference was last changed. Null if no preference row exists yet
+    /// (i.e. the user has never touched this category and we're showing defaults).
+    /// </summary>
+    public Instant? UpdatedAt { get; set; }
 }

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -263,7 +263,7 @@ public class RotaShiftGroup
     public int TotalSlots { get; set; }
 }
 
-public record ShiftSignupInfo(Guid UserId, string DisplayName, SignupStatus Status, string? ProfilePictureUrl);
+public record ShiftSignupInfo(Guid UserId, string DisplayName, SignupStatus Status);
 
 public class ShiftDisplayItem
 {

--- a/src/Humans.Web/Models/Shifts/ShiftBrowseMapper.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftBrowseMapper.cs
@@ -31,9 +31,7 @@ internal static class ShiftBrowseMapper
             RemainingSlots = u.RemainingSlots,
             UrgencyScore = u.UrgencyScore,
             Signups = u.Signups
-                .Select(s => new ShiftSignupInfo(
-                    s.UserId, s.DisplayName, s.Status,
-                    s.HasProfilePicture ? $"/Profile/Picture?id={s.UserId}" : null))
+                .Select(s => new ShiftSignupInfo(s.UserId, s.DisplayName, s.Status))
                 .ToList(),
         };
     }

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1656,6 +1656,8 @@
   <data name="CommPrefs_OneClick_Hint" xml:space="preserve"><value>One-click unsubscribe, or fine-tune the matrix below.</value></data>
   <data name="CommPrefs_OneClick_Button" xml:space="preserve"><value>Unsubscribe from {0}</value></data>
   <data name="CommPrefs_OneClick_Done" xml:space="preserve"><value>Unsubscribed. You can re-enable any category below.</value></data>
+  <data name="CommPrefs_UpdateSource" xml:space="preserve"><value>Source</value></data>
+  <data name="CommPrefs_UpdatedAt" xml:space="preserve"><value>Updated</value></data>
 
   <data name="Emails_Header_Email" xml:space="preserve"><value>Email</value></data>
   <data name="Emails_Header_Status" xml:space="preserve"><value>Status</value></data>

--- a/src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs
@@ -1,0 +1,72 @@
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Domain.Enums;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Mvc;
+using NodaTime;
+
+namespace Humans.Web.ViewComponents;
+
+/// <summary>
+/// Renders the communication-preferences matrix for a given user.
+/// Two modes:
+///   - <c>readonly: false</c> (self-service, default): toggle checkboxes that POST to
+///     <c>/Profile/Me/CommunicationPreferences/Update</c>.
+///   - <c>readonly: true</c> (admin view on <c>/Profile/{id}/Admin</c>): values only,
+///     plus per-category <c>UpdateSource</c> and <c>UpdatedAt</c> for attribution.
+///     No POST forms, no anti-forgery, no submit buttons.
+/// </summary>
+public sealed class CommunicationPreferencesPanelViewComponent : ViewComponent
+{
+    private readonly ICommunicationPreferenceService _commPrefService;
+    private readonly ITicketQueryService _ticketQueryService;
+    private readonly IClock _clock;
+
+    public CommunicationPreferencesPanelViewComponent(
+        ICommunicationPreferenceService commPrefService,
+        ITicketQueryService ticketQueryService,
+        IClock clock)
+    {
+        _commPrefService = commPrefService;
+        _ticketQueryService = ticketQueryService;
+        _clock = clock;
+    }
+
+    public async Task<IViewComponentResult> InvokeAsync(Guid userId, bool readOnly = false)
+    {
+        var prefs = await _commPrefService.GetPreferencesAsync(userId);
+        var prefsByCategory = prefs.ToDictionary(p => p.Category);
+
+        var hasTicketOrder = await _ticketQueryService.HasTicketAttendeeMatchAsync(userId);
+
+        var categories = new List<CategoryPreferenceItem>();
+        foreach (var category in MessageCategoryExtensions.ActiveCategories)
+        {
+            var pref = prefsByCategory.GetValueOrDefault(category);
+            var isAlwaysOn = category.IsAlwaysOn();
+            var isTicketingLocked = category == MessageCategory.Ticketing && hasTicketOrder;
+
+            categories.Add(new CategoryPreferenceItem
+            {
+                Category = category,
+                DisplayName = category == MessageCategory.Ticketing
+                    ? $"Ticketing — {_clock.GetCurrentInstant().InUtc().Year}"
+                    : category.ToDisplayName(),
+                Description = category.ToDescription(),
+                EmailEnabled = pref is null || !pref.OptedOut,
+                AlertEnabled = pref?.InboxEnabled ?? true,
+                EmailEditable = !isAlwaysOn && !isTicketingLocked,
+                AlertEditable = !isAlwaysOn && !isTicketingLocked,
+                Note = isTicketingLocked ? "Locked — you have a ticket for this year" : null,
+                UpdateSource = pref?.UpdateSource,
+                UpdatedAt = pref?.UpdatedAt,
+            });
+        }
+
+        return View(new CommunicationPreferencesViewModel
+        {
+            Categories = categories,
+            ReadOnly = readOnly,
+        });
+    }
+}

--- a/src/Humans.Web/Views/Profile/AdminDetail.cshtml
+++ b/src/Humans.Web/Views/Profile/AdminDetail.cshtml
@@ -215,6 +215,9 @@
 
         <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Admin" display-name="@Model.DisplayName" />
 
+        <h5 class="mt-4 mb-2">@Localizer["CommPrefs_Title"]</h5>
+        <vc:communication-preferences-panel user-id="@Model.UserId" read-only="true" />
+
         <vc:audit-log user-id="@Model.UserId" limit="50" title="@Localizer["AdminHuman_AuditHistory"].Value" />
 
         @if (campaignGrants != null && campaignGrants.Any())

--- a/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
@@ -1,6 +1,7 @@
-@model Humans.Web.Models.CommunicationPreferencesViewModel
+@model Guid
 @{
     ViewData["Title"] = Localizer["CommPrefs_Title"].Value;
+    var userId = Model;
 }
 
 <div class="row">
@@ -17,74 +18,7 @@
 
         <vc:temp-data-alerts />
 
-        <div class="card mb-4">
-            <div class="table-responsive">
-                <table class="table table-hover mb-0 align-middle">
-                    <thead>
-                        <tr>
-                            <th style="min-width: 250px;">@Localizer["CommPrefs_Category"]</th>
-                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Email"]</th>
-                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Alert"]</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @for (var i = 0; i < Model.Categories.Count; i++)
-                        {
-                            var item = Model.Categories[i];
-
-                            <tr class="@(!item.EmailEditable ? "table-light" : "")">
-                                <td>
-                                    <div class="fw-semibold">@item.DisplayName</div>
-                                    <div class="form-text mb-0">@item.Description</div>
-                                    @if (item.Note is not null)
-                                    {
-                                        <div class="form-text text-warning-emphasis mb-0">
-                                            <i class="fa-solid fa-lock fa-xs me-1"></i>@item.Note
-                                        </div>
-                                    }
-                                </td>
-                                <td class="text-center">
-                                    @if (item.EmailEditable)
-                                    {
-                                        <input type="checkbox"
-                                               class="form-check-input pref-toggle"
-                                               data-category="@item.Category"
-                                               data-channel="email"
-                                               @(item.EmailEnabled ? "checked" : null) />
-                                    }
-                                    else
-                                    {
-                                        <input type="checkbox"
-                                               class="form-check-input"
-                                               checked
-                                               disabled />
-                                        <span class="text-muted small">Always on</span>
-                                    }
-                                </td>
-                                <td class="text-center">
-                                    @if (item.AlertEditable)
-                                    {
-                                        <input type="checkbox"
-                                               class="form-check-input pref-toggle"
-                                               data-category="@item.Category"
-                                               data-channel="alert"
-                                               @(item.AlertEnabled ? "checked" : null) />
-                                    }
-                                    else
-                                    {
-                                        <input type="checkbox"
-                                               class="form-check-input"
-                                               checked
-                                               disabled />
-                                        <span class="text-muted small">Always on</span>
-                                    }
-                                </td>
-                            </tr>
-                        }
-                    </tbody>
-                </table>
-            </div>
-        </div>
+        <vc:communication-preferences-panel user-id="@userId" read-only="false" />
 
         <a asp-action="Index" class="btn btn-outline-secondary">@Localizer["CommPrefs_BackToProfile"]</a>
     </div>
@@ -134,6 +68,3 @@
     });
 </script>
 }
-
-@* Anti-forgery token for AJAX posts *@
-<form id="__AjaxAntiForgeryForm" asp-antiforgery="true" style="display:none;"></form>

--- a/src/Humans.Web/Views/Shared/Components/CommunicationPreferencesPanel/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/CommunicationPreferencesPanel/Default.cshtml
@@ -1,0 +1,129 @@
+@model Humans.Web.Models.CommunicationPreferencesViewModel
+@{
+    var isReadOnly = Model.ReadOnly;
+}
+
+<div class="card mb-4">
+    <div class="table-responsive">
+        <table class="table table-hover mb-0 align-middle">
+            <thead>
+                <tr>
+                    <th style="min-width: 250px;">@Localizer["CommPrefs_Category"]</th>
+                    <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Email"]</th>
+                    <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Alert"]</th>
+                    @if (isReadOnly)
+                    {
+                        <th style="min-width: 140px;">@Localizer["CommPrefs_UpdateSource"]</th>
+                        <th style="min-width: 160px;">@Localizer["CommPrefs_UpdatedAt"]</th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @for (var i = 0; i < Model.Categories.Count; i++)
+                {
+                    var item = Model.Categories[i];
+
+                    <tr class="@(!item.EmailEditable ? "table-light" : "")">
+                        <td>
+                            <div class="fw-semibold">@item.DisplayName</div>
+                            <div class="form-text mb-0">@item.Description</div>
+                            @if (item.Note is not null)
+                            {
+                                <div class="form-text text-warning-emphasis mb-0">
+                                    <i class="fa-solid fa-lock fa-xs me-1"></i>@item.Note
+                                </div>
+                            }
+                        </td>
+                        <td class="text-center">
+                            @if (isReadOnly)
+                            {
+                                if (item.EmailEnabled)
+                                {
+                                    <input type="checkbox" class="form-check-input" checked disabled />
+                                }
+                                else
+                                {
+                                    <input type="checkbox" class="form-check-input" disabled />
+                                }
+                            }
+                            else if (item.EmailEditable)
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input pref-toggle"
+                                       data-category="@item.Category"
+                                       data-channel="email"
+                                       @(item.EmailEnabled ? "checked" : null) />
+                            }
+                            else
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input"
+                                       checked
+                                       disabled />
+                                <span class="text-muted small">Always on</span>
+                            }
+                        </td>
+                        <td class="text-center">
+                            @if (isReadOnly)
+                            {
+                                if (item.AlertEnabled)
+                                {
+                                    <input type="checkbox" class="form-check-input" checked disabled />
+                                }
+                                else
+                                {
+                                    <input type="checkbox" class="form-check-input" disabled />
+                                }
+                            }
+                            else if (item.AlertEditable)
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input pref-toggle"
+                                       data-category="@item.Category"
+                                       data-channel="alert"
+                                       @(item.AlertEnabled ? "checked" : null) />
+                            }
+                            else
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input"
+                                       checked
+                                       disabled />
+                                <span class="text-muted small">Always on</span>
+                            }
+                        </td>
+                        @if (isReadOnly)
+                        {
+                            <td>
+                                @if (!string.IsNullOrEmpty(item.UpdateSource))
+                                {
+                                    <code class="small">@item.UpdateSource</code>
+                                }
+                                else
+                                {
+                                    <span class="text-muted small">—</span>
+                                }
+                            </td>
+                            <td>
+                                @if (item.UpdatedAt is { } updatedAt)
+                                {
+                                    <span class="small">@updatedAt.ToDisplayDateTime()</span>
+                                }
+                                else
+                                {
+                                    <span class="text-muted small">—</span>
+                                }
+                            </td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@if (!isReadOnly)
+{
+    @* Anti-forgery token for AJAX posts. Read by the toggle script on the host view. *@
+    <form id="__AjaxAntiForgeryForm" asp-antiforgery="true" style="display:none;"></form>
+}

--- a/src/Humans.Web/Views/WidgetGallery/Index.cshtml
+++ b/src/Humans.Web/Views/WidgetGallery/Index.cshtml
@@ -331,6 +331,34 @@
                 <div class="wg-card">
                     <div class="wg-card-header">
                         <div>
+                            <span class="wg-card-name">&lt;vc:communication-preferences-panel&gt;</span>
+                            <span class="wg-card-kind kind-vc">ViewComponent</span>
+                        </div>
+                        <span class="wg-card-path">src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs</span>
+                    </div>
+                    <div class="wg-card-note">
+                        Per-user communication-preferences matrix. Write mode (default) renders toggle checkboxes that POST to <code>/Profile/Me/CommunicationPreferences/Update</code>. Read-only mode hides the form and surfaces <code>UpdateSource</code> + <code>UpdatedAt</code> per category — used on <code>/Profile/{id}/Admin</code>.
+                    </div>
+                    @ParamsBlock(
+                        ("user-id", "<code>Guid</code> — required"),
+                        ("read-only", "<code>bool</code> — default <code>false</code>; <code>true</code> hides forms and adds attribution columns")
+                    )
+                    <div class="wg-variants">
+                        <div class="wg-variant-label">read-only="false"<span class="wg-variant-sub">default — toggleable</span></div>
+                        <div class="wg-variant-render" style="display:block;">
+                            <vc:communication-preferences-panel user-id="@Model.CurrentUserId" />
+                        </div>
+
+                        <div class="wg-variant-label">read-only="true"<span class="wg-variant-sub">admin view</span></div>
+                        <div class="wg-variant-render" style="display:block;">
+                            <vc:communication-preferences-panel user-id="@Model.CurrentUserId" read-only="true" />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="wg-card">
+                    <div class="wg-card-header">
+                        <div>
                             <span class="wg-card-name">_HumanPopover.cshtml</span>
                             <span class="wg-card-kind kind-pa">Partial</span>
                         </div>

--- a/tests/Humans.Application.Tests/Services/TicketTailorServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketTailorServiceTests.cs
@@ -142,9 +142,155 @@ public class TicketTailorServiceTests
 
         tickets.Should().HaveCount(1);
         tickets[0].AttendeeName.Should().Be("Jane Doe");
+        tickets[0].AttendeeEmail.Should().Be("jane@example.com");
         tickets[0].Price.Should().Be(150m);
         tickets[0].TicketTypeName.Should().Be("Full Week");
         tickets[0].VendorOrderId.Should().Be("ord_001");
+    }
+
+    [HumansFact]
+    public async Task GetIssuedTicketsAsync_PrefersCustomQuestionEmailOverTopLevelEmail()
+    {
+        // Real-world TT shape (order or_75997215, ticket it_124025964): the
+        // top-level `email` is the buyer's account email replicated onto each
+        // ticket; the actual attendee email lives in custom_questions where
+        // question == "Email".
+        var handler = new MockHttpHandler();
+        handler.EnqueueResponse(HttpStatusCode.OK, new
+        {
+            data = new[]
+            {
+                new
+                {
+                    id = "it_124025964",
+                    first_name = "Daniel",
+                    last_name = "Paiva De Miranda",
+                    full_name = "Daniel Paiva De Miranda",
+                    email = "yulia.kisd@gmail.com",
+                    custom_questions = new[]
+                    {
+                        new { question = "Email", answer = "dpmirandadp@gmail.com" }
+                    },
+                    description = "Main tickets - Wave 2 Tickets",
+                    listed_price = 29500,
+                    status = "valid",
+                    order_id = "or_75997215"
+                }
+            },
+            links = new { next = (string?)null }
+        });
+
+        var service = CreateService(handler);
+        var tickets = await service.GetIssuedTicketsAsync(null, "ev_test");
+
+        tickets[0].AttendeeEmail.Should().Be("dpmirandadp@gmail.com");
+    }
+
+    [HumansFact]
+    public async Task GetIssuedTicketsAsync_FallsBackToTopLevelEmailWhenCustomAnswerBlank()
+    {
+        var handler = new MockHttpHandler();
+        handler.EnqueueResponse(HttpStatusCode.OK, new
+        {
+            data = new[]
+            {
+                new
+                {
+                    id = "it_002",
+                    first_name = "Jane",
+                    last_name = "Doe",
+                    full_name = "Jane Doe",
+                    email = "jane@example.com",
+                    custom_questions = new[]
+                    {
+                        new { question = "Email", answer = "   " }
+                    },
+                    description = "Full Week",
+                    listed_price = 15000,
+                    status = "valid",
+                    order_id = "ord_001"
+                }
+            },
+            links = new { next = (string?)null }
+        });
+
+        var service = CreateService(handler);
+        var tickets = await service.GetIssuedTicketsAsync(null, "ev_test");
+
+        tickets[0].AttendeeEmail.Should().Be("jane@example.com");
+    }
+
+    [HumansFact]
+    public async Task GetIssuedTicketsAsync_IgnoresNonEmailCustomQuestions()
+    {
+        var handler = new MockHttpHandler();
+        handler.EnqueueResponse(HttpStatusCode.OK, new
+        {
+            data = new[]
+            {
+                new
+                {
+                    id = "it_003",
+                    first_name = "Jane",
+                    last_name = "Doe",
+                    full_name = "Jane Doe",
+                    email = "jane@example.com",
+                    custom_questions = new[]
+                    {
+                        new { question = "Dietary restrictions", answer = "vegan" },
+                        new { question = "T-shirt size", answer = "M" }
+                    },
+                    description = "Full Week",
+                    listed_price = 15000,
+                    status = "valid",
+                    order_id = "ord_001"
+                }
+            },
+            links = new { next = (string?)null }
+        });
+
+        var service = CreateService(handler);
+        var tickets = await service.GetIssuedTicketsAsync(null, "ev_test");
+
+        tickets[0].AttendeeEmail.Should().Be("jane@example.com");
+    }
+
+    [HumansFact]
+    public async Task GetIssuedTicketsAsync_RequiresExactEmailQuestionString()
+    {
+        // Match is case-sensitive and exact: "email" / "Email Address" / "Your Email"
+        // must not match. Only a question whose text is exactly "Email" qualifies.
+        var handler = new MockHttpHandler();
+        handler.EnqueueResponse(HttpStatusCode.OK, new
+        {
+            data = new[]
+            {
+                new
+                {
+                    id = "it_004",
+                    first_name = "Jane",
+                    last_name = "Doe",
+                    full_name = "Jane Doe",
+                    email = "jane@example.com",
+                    custom_questions = new[]
+                    {
+                        new { question = "email", answer = "lower@example.com" },
+                        new { question = "Email Address", answer = "labelled@example.com" },
+                        new { question = "Your Email", answer = "phrased@example.com" }
+                    },
+                    description = "Full Week",
+                    listed_price = 15000,
+                    status = "valid",
+                    order_id = "ord_001"
+                }
+            },
+            links = new { next = (string?)null }
+        });
+
+        var service = CreateService(handler);
+        var tickets = await service.GetIssuedTicketsAsync(null, "ev_test");
+
+        tickets[0].AttendeeEmail.Should().Be("jane@example.com");
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `82d5226c2` docs: add section-align phase 0 plan for Budget (peterdrier/Humans#520)
- `b9cd47dee` Prefer TicketTailor custom-question 'Email' over issued_ticket.email (peterdrier/Humans#522)
- `50c1525fc` Fix /Tickets/Admin/Transfers 500: sort order drift in service (peterdrier/Humans#523)
- `29dd5d146` Extract comm-prefs panel into ViewComponent; show on admin profile (peterdrier/Humans#519)
- `56ba830f2` Remove dead ShiftSignupInfo.ProfilePictureUrl + HasProfilePicture plumbing (peterdrier/Humans#518)
- `5be24c267` section-align teams: fix metrics boundary and publish phase plan (peterdrier/Humans#517)

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly