### PR TITLE
Promote QA → production (1 commit)

### DIFF
--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -260,7 +260,10 @@ public sealed class MailerLiteClient : IMailerLiteService
         string? cursor = null;
         while (true)
         {
-            var url = "/api/subscribers?limit=100";
+            // include=groups is required — ML's list endpoint omits the per-subscriber
+            // groups array without it, which leaves GroupIds empty and breaks both the
+            // audience "currently in group" stat and the diff that suppresses re-assigns.
+            var url = "/api/subscribers?limit=100&include=groups";
             if (cursor is not null) url += $"&cursor={Uri.EscapeDataString(cursor)}";
             using var resp = await SendAsync(HttpMethod.Get, url, content: null, ct);
             resp.EnsureSuccessStatusCode();
@@ -317,8 +320,33 @@ public sealed class MailerLiteClient : IMailerLiteService
             throw;
         }
         if (resp.Headers.TryGetValues("X-RateLimit-Remaining", out var values)
-            && int.TryParse(values.FirstOrDefault(), CultureInfo.InvariantCulture, out var remaining) && remaining < 20)
-            _logger.LogWarning("MailerLite rate limit remaining: {Remaining}", remaining);
+            && int.TryParse(values.FirstOrDefault(), CultureInfo.InvariantCulture, out var remaining))
+        {
+            // Reactive back-off — ML allows 120 req/min and returns Remaining in every
+            // response. Sleep proportionally as the window drains so tight write loops
+            // (Assign/Unassign/BulkImport) don't slam into 429s. Tiers are intentionally
+            // wide; 429-with-Retry-After handling is a separate concern.
+            var delay = remaining switch
+            {
+                < 5 => TimeSpan.FromSeconds(5),
+                < 10 => TimeSpan.FromSeconds(2),
+                < 20 => TimeSpan.FromSeconds(1),
+                _ => TimeSpan.Zero,
+            };
+            if (delay > TimeSpan.Zero)
+            {
+                try
+                {
+                    await Task.Delay(delay, ct);
+                }
+                catch
+                {
+                    // Caller never sees this response — dispose it so we don't leak the socket.
+                    resp.Dispose();
+                    throw;
+                }
+            }
+        }
         if (!resp.IsSuccessStatusCode)
             _logger.LogWarning("MailerLite returned {StatusCode}: {Method} {Url}",
                 (int)resp.StatusCode, method, url);


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `b21c57eb3` fix(mailer): include=groups + reactive rate-limit sleep (peterdrier/Humans#545)

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly