### PR TITLE
Avoid full userinfo cache rebuilds for participation updates

### DIFF
--- a/src/Humans.Application/Interfaces/Users/IUserInfoInvalidator.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserInfoInvalidator.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Humans.Domain.Entities;
 
 namespace Humans.Application.Interfaces.Users;
 
@@ -20,6 +21,42 @@ namespace Humans.Application.Interfaces.Users;
 public interface IUserInfoInvalidator
 {
     Task InvalidateAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "");
+
+    Task RefreshUserFieldsAsync(
+        User user,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "");
+
+    Task RemoveAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "");
+
+    Task RefreshUserEmailsAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "");
+
+    Task RefreshEventParticipationsAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "");
+
+    Task RefreshExternalLoginsAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "");
+
+    Task RefreshCommunicationPreferencesAsync(
         Guid userId,
         CancellationToken ct = default,
         [CallerMemberName] string memberName = "",

--- a/src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs
+++ b/src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs
@@ -21,7 +21,7 @@ public sealed class UserInfoSaveChangesInterceptor : SaveChangesInterceptor
     private readonly ILogger<UserInfoSaveChangesInterceptor> _logger;
 
     // Snapshot collected pre-commit (Deleted still tracked) and consumed post-commit.
-    private readonly ConditionalWeakTable<DbContext, HashSet<Guid>> _pending = new();
+    private readonly ConditionalWeakTable<DbContext, PendingUserInfoInvalidations> _pending = new();
 
     public UserInfoSaveChangesInterceptor(
         IServiceProvider services,
@@ -38,8 +38,8 @@ public sealed class UserInfoSaveChangesInterceptor : SaveChangesInterceptor
     {
         if (eventData.Context is { } context)
         {
-            var affected = CollectAffectedUserIds(context);
-            if (affected.Count > 0)
+            var affected = CollectAffected(context);
+            if (affected.HasWork)
             {
                 _pending.AddOrUpdate(context, affected);
             }
@@ -56,10 +56,7 @@ public sealed class UserInfoSaveChangesInterceptor : SaveChangesInterceptor
             var invalidator = _services.GetService<IUserInfoInvalidator>();
             if (invalidator is not null)
             {
-                foreach (var userId in affected)
-                {
-                    await SafeInvalidate(invalidator, userId, cancellationToken);
-                }
+                await SafeApply(invalidator, affected, cancellationToken);
             }
         }
         return await base.SavedChangesAsync(eventData, result, cancellationToken);
@@ -78,23 +75,54 @@ public sealed class UserInfoSaveChangesInterceptor : SaveChangesInterceptor
         return base.SaveChangesFailedAsync(eventData, cancellationToken);
     }
 
-    private async Task SafeInvalidate(IUserInfoInvalidator invalidator, Guid userId, CancellationToken ct)
+    private async Task SafeApply(
+        IUserInfoInvalidator invalidator,
+        PendingUserInfoInvalidations affected,
+        CancellationToken ct)
     {
         try
         {
-            await invalidator.InvalidateAsync(userId, ct);
+            foreach (var userId in affected.DeletedUserIds)
+            {
+                await invalidator.RemoveAsync(userId, ct);
+            }
+
+            foreach (var user in affected.Users.Values.Where(u => !affected.DeletedUserIds.Contains(u.Id)))
+            {
+                await invalidator.RefreshUserFieldsAsync(user, ct);
+            }
+
+            foreach (var userId in affected.UserEmailUserIds.Except(affected.DeletedUserIds))
+            {
+                await invalidator.RefreshUserEmailsAsync(userId, ct);
+            }
+
+            foreach (var userId in affected.EventParticipationUserIds.Except(affected.DeletedUserIds))
+            {
+                await invalidator.RefreshEventParticipationsAsync(userId, ct);
+            }
+
+            foreach (var userId in affected.ExternalLoginUserIds.Except(affected.DeletedUserIds))
+            {
+                await invalidator.RefreshExternalLoginsAsync(userId, ct);
+            }
+
+            foreach (var userId in affected.CommunicationPreferenceUserIds.Except(affected.DeletedUserIds))
+            {
+                await invalidator.RefreshCommunicationPreferencesAsync(userId, ct);
+            }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(
-                "UserInfoSaveChangesInterceptor invalidation failed for {UserId}: {ExType}",
-                userId, ex.GetType().Name);
+                "UserInfoSaveChangesInterceptor invalidation failed: {ExType}",
+                ex.GetType().Name);
         }
     }
 
-    private static HashSet<Guid> CollectAffectedUserIds(DbContext context)
+    private static PendingUserInfoInvalidations CollectAffected(DbContext context)
     {
-        var affected = new HashSet<Guid>();
+        var affected = new PendingUserInfoInvalidations();
 
         foreach (var entry in context.ChangeTracker.Entries())
         {
@@ -104,22 +132,76 @@ public sealed class UserInfoSaveChangesInterceptor : SaveChangesInterceptor
             switch (entry.Entity)
             {
                 case User u:
-                    affected.Add(u.Id);
+                    if (entry.State == EntityState.Deleted)
+                    {
+                        affected.DeletedUserIds.Add(u.Id);
+                    }
+                    else
+                    {
+                        affected.Users[u.Id] = CloneUserInfoFields(u);
+                    }
                     break;
                 case UserEmail ue:
-                    affected.Add(ue.UserId);
+                    affected.UserEmailUserIds.Add(ue.UserId);
                     break;
                 case EventParticipation ep:
-                    affected.Add(ep.UserId);
+                    affected.EventParticipationUserIds.Add(ep.UserId);
                     break;
                 case IdentityUserLogin<Guid> uil:
-                    affected.Add(uil.UserId);
+                    affected.ExternalLoginUserIds.Add(uil.UserId);
                     break;
                 case CommunicationPreference cp:
-                    affected.Add(cp.UserId);
+                    affected.CommunicationPreferenceUserIds.Add(cp.UserId);
                     break;
             }
         }
         return affected;
+    }
+
+    private static User CloneUserInfoFields(User user)
+    {
+#pragma warning disable CS0618 // DisplayName is part of the cached legacy user-column mirror.
+        return new User
+        {
+            Id = user.Id,
+            DisplayName = user.DisplayName,
+            PreferredLanguage = user.PreferredLanguage,
+            ProfilePictureUrl = user.ProfilePictureUrl,
+            CreatedAt = user.CreatedAt,
+            LastLoginAt = user.LastLoginAt,
+            LastConsentReminderSentAt = user.LastConsentReminderSentAt,
+            DeletionRequestedAt = user.DeletionRequestedAt,
+            DeletionScheduledFor = user.DeletionScheduledFor,
+            DeletionEligibleAfter = user.DeletionEligibleAfter,
+            UnsubscribedFromCampaigns = user.UnsubscribedFromCampaigns,
+            ICalToken = user.ICalToken,
+            SuppressScheduleChangeEmails = user.SuppressScheduleChangeEmails,
+            MagicLinkSentAt = user.MagicLinkSentAt,
+            GoogleEmailStatus = user.GoogleEmailStatus,
+            ContactSource = user.ContactSource,
+            ExternalSourceId = user.ExternalSourceId,
+            MergedToUserId = user.MergedToUserId,
+            MergedAt = user.MergedAt,
+            Email = user.IdentityEmailColumn,
+        };
+#pragma warning restore CS0618
+    }
+
+    private sealed class PendingUserInfoInvalidations
+    {
+        public Dictionary<Guid, User> Users { get; } = new();
+        public HashSet<Guid> DeletedUserIds { get; } = [];
+        public HashSet<Guid> UserEmailUserIds { get; } = [];
+        public HashSet<Guid> EventParticipationUserIds { get; } = [];
+        public HashSet<Guid> ExternalLoginUserIds { get; } = [];
+        public HashSet<Guid> CommunicationPreferenceUserIds { get; } = [];
+
+        public bool HasWork =>
+            Users.Count > 0 ||
+            DeletedUserIds.Count > 0 ||
+            UserEmailUserIds.Count > 0 ||
+            EventParticipationUserIds.Count > 0 ||
+            ExternalLoginUserIds.Count > 0 ||
+            CommunicationPreferenceUserIds.Count > 0;
     }
 }

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -433,6 +433,193 @@ public sealed class CachingUserService : TrackedCache<Guid, UserInfo>, IUserServ
         await ReplaceAsync(userId, ct).ConfigureAwait(false);
     }
 
+    public async Task RefreshUserFieldsAsync(
+        User user,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "")
+    {
+        _logger.LogDebug(
+            "UserInfo refresh user fields userId={UserId} caller={CallerMember} file={CallerFile}",
+            user.Id, memberName, Path.GetFileName(filePath));
+
+        if (TryGet(user.Id, out var current))
+        {
+            Replace(user.Id, WithUserFields(current, user));
+            return;
+        }
+
+        if (!IsWarmedUp)
+        {
+            await ReplaceAsync(user.Id, ct).ConfigureAwait(false);
+            return;
+        }
+
+        Set(user.Id, UserInfo.Create(
+            user,
+            user.UserEmails.ToList(),
+            user.EventParticipations.ToList(),
+            externalLogins: [],
+            profile: null,
+            contactFields: [],
+            profileLanguages: [],
+            volunteerHistory: [],
+            communicationPreferences: []));
+    }
+
+    public Task RemoveAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "")
+    {
+        _logger.LogDebug(
+            "UserInfo remove userId={UserId} caller={CallerMember} file={CallerFile}",
+            userId, memberName, Path.GetFileName(filePath));
+        DeleteKey(userId);
+        return Task.CompletedTask;
+    }
+
+    public async Task RefreshUserEmailsAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "")
+    {
+        _logger.LogDebug(
+            "UserInfo refresh user-emails userId={UserId} caller={CallerMember} file={CallerFile}",
+            userId, memberName, Path.GetFileName(filePath));
+
+        if (!TryGet(userId, out var current))
+        {
+            await ReplaceAsync(userId, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var rows = await _userEmailRepository.GetByUserIdReadOnlyAsync(userId, ct);
+        Replace(userId, current with { UserEmails = ToUserEmailInfos(rows) });
+    }
+
+    public async Task RefreshEventParticipationsAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "")
+    {
+        _logger.LogDebug(
+            "UserInfo refresh event-participations userId={UserId} caller={CallerMember} file={CallerFile}",
+            userId, memberName, Path.GetFileName(filePath));
+
+        if (!TryGet(userId, out var current))
+        {
+            await ReplaceAsync(userId, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var rows = await _userRepository.GetEventParticipationsByUserIdAsync(userId, ct);
+        Replace(userId, current with { EventParticipations = ToEventParticipationInfos(rows) });
+    }
+
+    public async Task RefreshExternalLoginsAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "")
+    {
+        _logger.LogDebug(
+            "UserInfo refresh external-logins userId={UserId} caller={CallerMember} file={CallerFile}",
+            userId, memberName, Path.GetFileName(filePath));
+
+        if (!TryGet(userId, out var current))
+        {
+            await ReplaceAsync(userId, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var loginsByUser = await _userRepository.GetExternalLoginsByUserIdsAsync([userId], ct);
+        var rows = loginsByUser.TryGetValue(userId, out var logins) ? logins : [];
+        Replace(userId, current with { ExternalLogins = ToExternalLoginInfos(rows) });
+    }
+
+    public async Task RefreshCommunicationPreferencesAsync(
+        Guid userId,
+        CancellationToken ct = default,
+        [CallerMemberName] string memberName = "",
+        [CallerFilePath] string filePath = "")
+    {
+        _logger.LogDebug(
+            "UserInfo refresh communication-preferences userId={UserId} caller={CallerMember} file={CallerFile}",
+            userId, memberName, Path.GetFileName(filePath));
+
+        if (!TryGet(userId, out var current))
+        {
+            await ReplaceAsync(userId, ct).ConfigureAwait(false);
+            return;
+        }
+
+        var rows = await _communicationPreferenceRepository.GetByUserIdReadOnlyAsync(userId, ct);
+        Replace(userId, current with { CommunicationPreferences = ToCommunicationPreferenceInfos(rows) });
+    }
+
+    private static IReadOnlyList<UserEmailInfo> ToUserEmailInfos(IEnumerable<UserEmail> rows) =>
+        rows
+            .OrderByDescending(e => e.IsPrimary)
+            .ThenBy(e => e.Email, StringComparer.OrdinalIgnoreCase)
+            .Select(e => new UserEmailInfo(
+                e.Id, e.Email, e.IsVerified, e.IsPrimary, e.IsGoogle,
+                e.Provider, e.ProviderKey, e.Visibility))
+            .ToList();
+
+    private static IReadOnlyList<EventParticipationInfo> ToEventParticipationInfos(IEnumerable<EventParticipation> rows) =>
+        rows
+            .OrderBy(p => p.Year)
+            .Select(p => new EventParticipationInfo(
+                p.Id, p.Year, p.Status, p.Source, p.DeclaredAt))
+            .ToList();
+
+    private static IReadOnlyList<UserExternalLoginInfo> ToExternalLoginInfos(
+        IEnumerable<(string Provider, string ProviderKey)> rows) =>
+        rows
+            .Select(l => new UserExternalLoginInfo(l.Provider, l.ProviderKey))
+            .ToList();
+
+    private static IReadOnlyList<CommunicationPreferenceInfo> ToCommunicationPreferenceInfos(
+        IEnumerable<CommunicationPreference> rows) =>
+        rows
+            .OrderBy(c => c.Category)
+            .Select(c => new CommunicationPreferenceInfo(
+                c.Id, c.Category, c.OptedOut, c.InboxEnabled,
+                c.UpdatedAt, c.UpdateSource, c.SubscribedAt))
+            .ToList();
+
+    private static UserInfo WithUserFields(UserInfo current, User user)
+    {
+#pragma warning disable CS0618 // DisplayName is part of the cached legacy user-column mirror.
+        return current with
+        {
+            DisplayName = user.DisplayName,
+            PreferredLanguage = user.PreferredLanguage,
+            ProfilePictureUrl = user.ProfilePictureUrl,
+            CreatedAt = user.CreatedAt,
+            LastLoginAt = user.LastLoginAt,
+            LastConsentReminderSentAt = user.LastConsentReminderSentAt,
+            DeletionRequestedAt = user.DeletionRequestedAt,
+            DeletionScheduledFor = user.DeletionScheduledFor,
+            DeletionEligibleAfter = user.DeletionEligibleAfter,
+            UnsubscribedFromCampaigns = user.UnsubscribedFromCampaigns,
+            ICalToken = user.ICalToken,
+            SuppressScheduleChangeEmails = user.SuppressScheduleChangeEmails,
+            MagicLinkSentAt = user.MagicLinkSentAt,
+            GoogleEmailStatus = user.GoogleEmailStatus,
+            ContactSource = user.ContactSource,
+            ExternalSourceId = user.ExternalSourceId,
+            MergedToUserId = user.MergedToUserId,
+            MergedAt = user.MergedAt,
+            IdentityEmailColumn = user.IdentityEmailColumn,
+        };
+#pragma warning restore CS0618
+    }
+
     // ==========================================================================
     // Inner delegation — every other IUserService method passes through and
     // refreshes the affected entry on writes.
@@ -685,14 +872,50 @@ public sealed class CachingUserService : TrackedCache<Guid, UserInfo>, IUserServ
     public async Task SetParticipationFromTicketSyncAsync(
         Guid userId, int year, ParticipationStatus status, CancellationToken ct = default)
     {
+        if (!TryGet(userId, out var current))
+        {
+            await EnsureWarmedAsync(ct).ConfigureAwait(false);
+            TryGet(userId, out current);
+        }
+
+        if (current is not null)
+        {
+            var existing = current.EventParticipations.FirstOrDefault(p => p.Year == year);
+            if (existing is not null &&
+                (existing.Status == ParticipationStatus.Attended ||
+                 (existing.Status == status &&
+                  existing.Source == ParticipationSource.TicketSync &&
+                  existing.DeclaredAt is null)))
+            {
+                return;
+            }
+        }
+
         await WithInnerAsync(inner => inner.SetParticipationFromTicketSyncAsync(userId, year, status, ct));
-        await RefreshEntryAsync(userId, ct);
+        await RefreshEventParticipationsAsync(userId, ct);
     }
 
     public async Task RemoveTicketSyncParticipationAsync(Guid userId, int year, CancellationToken ct = default)
     {
+        if (!TryGet(userId, out var current))
+        {
+            await EnsureWarmedAsync(ct).ConfigureAwait(false);
+            TryGet(userId, out current);
+        }
+
+        if (current is not null)
+        {
+            var existing = current.EventParticipations.FirstOrDefault(p => p.Year == year);
+            if (existing is null ||
+                existing.Source != ParticipationSource.TicketSync ||
+                existing.Status == ParticipationStatus.Attended)
+            {
+                return;
+            }
+        }
+
         await WithInnerAsync(inner => inner.RemoveTicketSyncParticipationAsync(userId, year, ct));
-        await RefreshEntryAsync(userId, ct);
+        await RefreshEventParticipationsAsync(userId, ct);
     }
 
     public async Task<int> BackfillParticipationsAsync(
@@ -701,7 +924,8 @@ public sealed class CachingUserService : TrackedCache<Guid, UserInfo>, IUserServ
         CancellationToken ct = default)
     {
         var count = await WithInnerAsync(inner => inner.BackfillParticipationsAsync(year, entries, ct));
-        foreach (var (userId, _) in entries) await RefreshEntryAsync(userId, ct);
+        foreach (var userId in entries.Select(e => e.UserId).Distinct())
+            await RefreshEventParticipationsAsync(userId, ct);
         return count;
     }
 

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -46,11 +46,14 @@ public class CachingUserServiceTests
         CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
     };
 
-    private static UserInfo SampleUserInfo(Guid userId, string displayName = "Alice") =>
+    private static UserInfo SampleUserInfo(
+        Guid userId,
+        string displayName = "Alice",
+        IReadOnlyList<EventParticipation>? eventParticipations = null) =>
         UserInfo.Create(
             new User { Id = userId, DisplayName = displayName, PreferredLanguage = "en" },
             userEmails: [],
-            eventParticipations: [],
+            eventParticipations: eventParticipations ?? [],
             externalLogins: [],
             profile: null,
             contactFields: [],
@@ -613,6 +616,80 @@ public class CachingUserServiceTests
             .Returns(new ValueTask<UserInfo?>((UserInfo?)null));
         (await sut.GetUserInfoAsync(u1)).Should().BeNull();
         (await sut.GetUserInfoAsync(u2)).Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task SetParticipationFromTicketSyncAsync_WhenCachedValueIsUnchanged_DoesNotHitInner()
+    {
+        var userId = Guid.NewGuid();
+        var participation = new EventParticipation
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Year = 2026,
+            Status = ParticipationStatus.Ticketed,
+            Source = ParticipationSource.TicketSync,
+            DeclaredAt = null,
+        };
+
+        _inner.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(SampleUserInfo(userId, eventParticipations: [participation])));
+
+        var sut = CreateSut();
+        await sut.GetUserInfoAsync(userId);
+
+        await sut.SetParticipationFromTicketSyncAsync(userId, 2026, ParticipationStatus.Ticketed);
+
+        await _inner.DidNotReceive().SetParticipationFromTicketSyncAsync(
+            Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<ParticipationStatus>(), Arg.Any<CancellationToken>());
+        await _userRepo.DidNotReceive().GetEventParticipationsByUserIdAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SetParticipationFromTicketSyncAsync_WhenCachedValueDiffers_RefreshesOnlyParticipationSlice()
+    {
+        var userId = Guid.NewGuid();
+        var stale = new EventParticipation
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Year = 2026,
+            Status = ParticipationStatus.NotAttending,
+            Source = ParticipationSource.UserDeclared,
+            DeclaredAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        };
+        var fresh = new EventParticipation
+        {
+            Id = stale.Id,
+            UserId = userId,
+            Year = 2026,
+            Status = ParticipationStatus.Ticketed,
+            Source = ParticipationSource.TicketSync,
+            DeclaredAt = null,
+        };
+
+        _inner.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(SampleUserInfo(userId, eventParticipations: [stale])));
+        _userRepo.GetEventParticipationsByUserIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns([fresh]);
+
+        var sut = CreateSut();
+        await sut.GetUserInfoAsync(userId);
+
+        await sut.SetParticipationFromTicketSyncAsync(userId, 2026, ParticipationStatus.Ticketed);
+
+        await _inner.Received(1).SetParticipationFromTicketSyncAsync(
+            userId, 2026, ParticipationStatus.Ticketed, Arg.Any<CancellationToken>());
+        await _userRepo.Received(1).GetEventParticipationsByUserIdAsync(userId, Arg.Any<CancellationToken>());
+        await _userEmailRepo.DidNotReceive().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+        await _profileRepo.DidNotReceive().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+        await _contactFieldRepo.DidNotReceive().GetByProfileIdReadOnlyAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _communicationPreferenceRepo.DidNotReceive().GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>());
+
+        var info = await sut.GetUserInfoAsync(userId);
+        info!.EventParticipations.Should().ContainSingle(p =>
+            p.Year == 2026 && p.Status == ParticipationStatus.Ticketed && p.Source == ParticipationSource.TicketSync);
     }
 
     // ==========================================================================


### PR DESCRIPTION
## Summary
- add slice-level UserInfo cache refreshes for user fields, emails, participations, external logins, and communication preferences
- update the EF save interceptor to refresh only changed cache slices instead of rebuilding full UserInfo entries
- make ticket-sync participation writes no-op when the warmed cache already has the requested state

## Testing
- dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --filter CachingUserServiceTests --no-restore

Note: Full solution testing previously reached Application/Web/Domain/Analyzer tests, but integration tests failed on the existing Hangfire JobStorage.Current test-host setup issue.