### PR TITLE
Promote QA → production (1 commit)

### DIFF
--- a/src/Humans.Application/Services/Mailer/MailerImportService.cs
+++ b/src/Humans.Application/Services/Mailer/MailerImportService.cs
@@ -129,7 +129,7 @@ public sealed class MailerImportService(
             return SubscriberOutcome.VerifiedPrefsAlreadyMatch;
 
         // No pref row + ML opt-out: Marketing defaults to opted-out (see
-        // CommunicationPreferenceService.DefaultOptedOut), so already in sync.
+        // MessageCategoryExtensions.DefaultOptedOut), so already in sync.
         if (existingMarketing is null && mlOptedOut)
             return SubscriberOutcome.VerifiedPrefsAlreadyMatch;
 

--- a/src/Humans.Application/Services/Profiles/CommunicationPreferenceService.cs
+++ b/src/Humans.Application/Services/Profiles/CommunicationPreferenceService.cs
@@ -22,18 +22,6 @@ public sealed class CommunicationPreferenceService(
     IAuditLogService auditLog,
     ILogger<CommunicationPreferenceService> logger) : ICommunicationPreferenceService, IUserMerge
 {
-    private static readonly Dictionary<MessageCategory, bool> DefaultOptedOut = new()
-    {
-        [MessageCategory.System] = false,
-        [MessageCategory.CampaignCodes] = false,
-        [MessageCategory.FacilitatedMessages] = false,
-        [MessageCategory.Ticketing] = false,
-        [MessageCategory.VolunteerUpdates] = false,
-        [MessageCategory.TeamUpdates] = false,
-        [MessageCategory.Governance] = false,
-        [MessageCategory.Marketing] = true,
-    };
-
     public async Task<IReadOnlyList<CommunicationPreferenceSnapshot>> GetPreferencesAsync(
         Guid userId, CancellationToken cancellationToken = default)
     {
@@ -42,7 +30,7 @@ public sealed class CommunicationPreferenceService(
         var now = clock.GetCurrentInstant();
         var toAdd = new List<CommunicationPreference>();
 
-        foreach (var category in DefaultOptedOut.Keys)
+        foreach (var category in MessageCategoryExtensions.ActiveCategories)
         {
             if (existing.Any(cp => cp.Category == category))
                 continue;
@@ -52,7 +40,7 @@ public sealed class CommunicationPreferenceService(
                 Id = Guid.NewGuid(),
                 UserId = userId,
                 Category = category,
-                OptedOut = DefaultOptedOut[category],
+                OptedOut = category.DefaultOptedOut(),
                 UpdatedAt = now,
                 UpdateSource = "Default",
             };
@@ -115,7 +103,7 @@ public sealed class CommunicationPreferenceService(
 
         var info = await userService.GetUserInfoAsync(userId, cancellationToken);
         var pref = info?.CommunicationPreferences.FirstOrDefault(p => p.Category == category);
-        return pref?.OptedOut ?? DefaultOptedOut.GetValueOrDefault(category, false);
+        return pref?.OptedOut ?? category.DefaultOptedOut();
     }
 
     public async Task UpdatePreferenceAsync(

--- a/src/Humans.Domain/Enums/MessageCategory.cs
+++ b/src/Humans.Domain/Enums/MessageCategory.cs
@@ -73,6 +73,17 @@ public static class MessageCategoryExtensions
         MessageCategory.System or MessageCategory.CampaignCodes;
 
     /// <summary>
+    /// Whether a category is opted-out when the user has no preference row.
+    /// Marketing is the only opt-in-required category (GDPR); every other category
+    /// defaults to on. Single source of truth consumed by
+    /// <c>CommunicationPreferenceService</c> (default-row seeding +
+    /// <c>IsOptedOutAsync</c> fallback) and the preferences UI (rendering a missing
+    /// row) — so a category with no row reads the same everywhere.
+    /// </summary>
+    public static bool DefaultOptedOut(this MessageCategory category) =>
+        category is MessageCategory.Marketing;
+
+    /// <summary>
     /// The active categories shown in the Communication Preferences UI, in display order.
     /// </summary>
     public static IReadOnlyList<MessageCategory> ActiveCategories { get; } =

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -290,7 +290,9 @@ public class GuestController(
                     ? $"Ticketing — {clock.GetCurrentInstant().InUtc().Year}"
                     : category.ToDisplayName(),
                 Description = category.ToDescription(),
-                EmailEnabled = pref is null || !pref.OptedOut,
+                // No row → category's domain default (Marketing is opt-out-by-default,
+                // so a missing row renders unchecked). Matches the panel view component.
+                EmailEnabled = pref is null ? !category.DefaultOptedOut() : !pref.OptedOut,
                 AlertEnabled = pref?.InboxEnabled ?? true,
                 EmailEditable = !isAlwaysOn && !isTicketingLocked,
                 AlertEditable = !isAlwaysOn && !isTicketingLocked,

--- a/src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs
@@ -42,7 +42,10 @@ public sealed class CommunicationPreferencesPanelViewComponent(
                     ? $"Ticketing — {clock.GetCurrentInstant().InUtc().Year}"
                     : category.ToDisplayName(),
                 Description = category.ToDescription(),
-                EmailEnabled = pref is null || !pref.OptedOut,
+                // No row → fall back to the category's domain default (Marketing is
+                // opt-out-by-default, so a missing row renders unchecked, matching what
+                // the send path treats null as). Other categories default on.
+                EmailEnabled = pref is null ? !category.DefaultOptedOut() : !pref.OptedOut,
                 AlertEnabled = pref?.InboxEnabled ?? true,
                 EmailEditable = !isAlwaysOn && !isTicketingLocked,
                 AlertEditable = !isAlwaysOn && !isTicketingLocked,

--- a/tests/Humans.Application.Tests/ViewComponents/CommunicationPreferencesPanelViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/CommunicationPreferencesPanelViewComponentTests.cs
@@ -1,0 +1,88 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Domain.Enums;
+using Humans.Web.Models;
+using Humans.Web.ViewComponents;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+
+namespace Humans.Application.Tests.ViewComponents;
+
+public class CommunicationPreferencesPanelViewComponentTests
+{
+    [HumansFact]
+    public async Task MissingMarketingRow_RendersUnchecked()
+    {
+        // Regression: a deleted/never-set Marketing pref (null) must render as
+        // opted-out — matching what the send path treats null as — not checked.
+        var model = await InvokeWith(prefs: []);
+
+        Item(model, MessageCategory.Marketing).EmailEnabled.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task MissingNonMarketingRow_RendersChecked()
+    {
+        // Every other category is opt-in-by-default, so a missing row stays checked.
+        var model = await InvokeWith(prefs: []);
+
+        Item(model, MessageCategory.Governance).EmailEnabled.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public async Task ExistingMarketingOptIn_RendersChecked()
+    {
+        var model = await InvokeWith(prefs:
+        [
+            new CommunicationPreferenceSnapshot(
+                MessageCategory.Marketing, OptedOut: false, InboxEnabled: true,
+                "Profile", Instant.FromUtc(2026, 1, 1, 0, 0)),
+        ]);
+
+        Item(model, MessageCategory.Marketing).EmailEnabled.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public async Task ExistingMarketingOptOut_RendersUnchecked()
+    {
+        var model = await InvokeWith(prefs:
+        [
+            new CommunicationPreferenceSnapshot(
+                MessageCategory.Marketing, OptedOut: true, InboxEnabled: true,
+                "Profile", Instant.FromUtc(2026, 1, 1, 0, 0)),
+        ]);
+
+        Item(model, MessageCategory.Marketing).EmailEnabled.Should().BeFalse();
+    }
+
+    private static CategoryPreferenceItem Item(CommunicationPreferencesViewModel model, MessageCategory category) =>
+        model.Categories.Single(c => c.Category == category);
+
+    private static async Task<CommunicationPreferencesViewModel> InvokeWith(
+        IReadOnlyList<CommunicationPreferenceSnapshot> prefs)
+    {
+        var commPrefs = Substitute.For<ICommunicationPreferenceService>();
+        commPrefs.GetPreferencesReadOnlyAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(prefs);
+
+        var tickets = Substitute.For<ITicketQueryService>();
+        tickets.HasTicketAttendeeMatchAsync(Arg.Any<Guid>()).Returns(false);
+
+        var sut = new CommunicationPreferencesPanelViewComponent(
+            commPrefs, tickets, new FakeClock(Instant.FromUtc(2026, 5, 20, 0, 0)))
+        {
+            ViewComponentContext = new ViewComponentContext
+            {
+                ViewContext = new ViewContext { HttpContext = new DefaultHttpContext() },
+            },
+        };
+
+        var result = await sut.InvokeAsync(Guid.NewGuid()) as ViewViewComponentResult;
+        return (CommunicationPreferencesViewModel)result!.ViewData!.Model!;
+    }
+}

--- a/tests/Humans.Domain.Tests/Enums/MessageCategoryExtensionsTests.cs
+++ b/tests/Humans.Domain.Tests/Enums/MessageCategoryExtensionsTests.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using AwesomeAssertions;
+using Humans.Domain.Enums;
+using Xunit;
+
+namespace Humans.Domain.Tests.Enums;
+
+public class MessageCategoryExtensionsTests
+{
+    [HumansTheory]
+    [InlineData(MessageCategory.Marketing, true)]
+    [InlineData(MessageCategory.System, false)]
+    [InlineData(MessageCategory.CampaignCodes, false)]
+    [InlineData(MessageCategory.FacilitatedMessages, false)]
+    [InlineData(MessageCategory.Ticketing, false)]
+    [InlineData(MessageCategory.VolunteerUpdates, false)]
+    [InlineData(MessageCategory.TeamUpdates, false)]
+    [InlineData(MessageCategory.Governance, false)]
+    public void DefaultOptedOut_MatchesDomainDefaults(MessageCategory category, bool expected) =>
+        category.DefaultOptedOut().Should().Be(expected);
+
+    [HumansFact]
+    public void DefaultOptedOut_OnlyMarketing_AmongActiveCategories() =>
+        MessageCategoryExtensions.ActiveCategories
+            .Where(c => c.DefaultOptedOut())
+            .Should().Equal(MessageCategory.Marketing);
+}


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `1f48324c8` fix(prefs): render missing Marketing pref as opted-out, not checked (peterdrier/Humans#693)

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly (none in this batch — display-only fix, no migration)