### PR TITLE
Promote QA → production (1 commit)

### DIFF
--- a/docs/sections/Store.md
+++ b/docs/sections/Store.md
@@ -176,6 +176,8 @@ Stored as int via `HasConversion<int>()`.
 - `/Store/Admin/Catalog/Deactivate/{id}` — POST soft-deactivate product.
 - `/Store/Admin/Orders` — FinanceAdmin order ledger + payment entry + Issue Invoice. **Not yet implemented (Phase 5 stub).**
 - `/Store/Admin/Summary` — FinanceAdmin/StoreAdmin/Admin aggregate report: by-counterparty (with Type column distinguishing Camp / Team), by-item (sums lines from both camp and team orders for supplier aggregation), counterparties × products cross-tab for a given year. Reuses `PolicyNames.StoreCatalogAdmin`.
+- `/Store/Admin/Payments` — FinanceAdmin/StoreAdmin/Admin Stripe payment reconciliation screen: webhook/checkout health banner, every Store Checkout Session matched to its order with a status (Recorded / Missing / Unmatched / Unpaid), and orphan recorded payments. Reuses `PolicyNames.StoreCatalogAdmin`. Linked from the Store-admin button group on `/Store`.
+- `/Store/Admin/Payments/RecordMissing` — POST: records every paid, order-matched, not-yet-recorded session via the idempotent `RecordStripePaymentAsync` path.
 - `/Store/StripeWebhook` — anonymous endpoint for Stripe checkout-session events (`StoreStripeWebhookController`).
 
 ## Actors & Roles
@@ -184,9 +186,9 @@ Stored as int via `HasConversion<int>()`.
 |-------|--------------|
 | Camp Lead | View / create orders for camp-seasons they lead. Add and remove lines while order is Open and the product's `OrderableUntil` has not passed. Edit counterparty fields while Open. Initiate Stripe checkout to pay. |
 | Coordinator (department) | View / create the single team order for departments (top-level teams) they coordinate, scoped to the active event year. Add and remove lines while the product's `OrderableUntil` has not passed. No pay, no counterparty edit, no invoice — team orders are non-billable. |
-| StoreAdmin | **Store-domain superset** (per `memory/code/admin-role-superset.md`): catalog CRUD, view all orders, record manual payments, issue invoices, run treasury sync. Equivalent to FinanceAdmin within the Store section. EditCounterparty/Pay remain denied on team orders even for admins. |
+| StoreAdmin | **Store-domain superset** (per `memory/code/admin-role-superset.md`): catalog CRUD, view all orders, record manual payments, issue invoices, run treasury sync, reconcile Stripe payments (`/Store/Admin/Payments`). Equivalent to FinanceAdmin within the Store section. EditCounterparty/Pay remain denied on team orders even for admins. |
 | TeamsAdmin | **View any order** (camp or team) and **manage team orders only** (AddLine / RemoveLine while `Open`; Delete any state). Camp orders are view-only. Never Pay / EditCounterparty (team orders are non-billable). Additive — a TeamsAdmin who is also a camp lead keeps camp-edit rights through the lead path. |
-| FinanceAdmin, Admin | All Camp Lead and StoreAdmin capabilities. Record manual payments (incl. refunds via negative amounts) regardless of order state. Issue invoice (single + Issue All). View `/Store/Admin/Summary`. Run treasury sync on demand. EditCounterparty/Pay remain denied on team orders. |
+| FinanceAdmin, Admin | All Camp Lead and StoreAdmin capabilities. Record manual payments (incl. refunds via negative amounts) regardless of order state. Issue invoice (single + Issue All). View `/Store/Admin/Summary` and `/Store/Admin/Payments`. Reconcile missing Stripe payments. Run treasury sync on demand. EditCounterparty/Pay remain denied on team orders. |
 
 ## Invariants
 
@@ -203,6 +205,7 @@ Stored as int via `HasConversion<int>()`.
 - Issuing an invoice is idempotent: re-issuing an order that already has `IssuedInvoiceId` set throws and does NOT call Holded.
 - Issue-invoice failure mid-flight leaves the order in `Open` state with no `StoreInvoice` row (atomic on success only).
 - A Stripe `checkout.session.completed` event with a known `humans_store_order_id` inserts at most one `StorePayment` per `StripePaymentIntentId` (filtered unique index + service-level dedup check).
+- **Reconciliation is the recovery path when the webhook misses a payment** (e.g. `STRIPE_STORE_WEBHOOK_SECRET` unset → webhook 503s). `RecordMissingStripePaymentsAsync` lists Store Checkout Sessions, and records only those that are `payment_status == paid`, resolve to an existing **billable** (non-Team) order via `humans_store_order_id` metadata, and are not already recorded. Amount + PaymentIntent id come **from Stripe** — never fabricated. Idempotent (same PI-id guard as the webhook), so it is safe to re-run. Unmatched sessions and orphan recorded payments are surfaced read-only, never auto-recorded or auto-deleted.
 - The treasury sync job matches Holded entries to orders **best-effort** by exact `Order.Label` ↔ entry description; ambiguous matches (multiple orders share a Label) are skipped and logged.
 - Resource-based authorization per design-rules §11: `StoreOrderAuthorizationHandler` + `StoreOrderOperationRequirement` gate Camp Lead writes against the order's parent camp-season. Operations: `View`, `Create`, `AddLine`, `RemoveLine`, `EditCounterparty`, `Pay`, `Delete`. Mutating ops (`AddLine`, `RemoveLine`, `EditCounterparty`) are gated on `State = Open`; `View` and `Pay` carry no state gate. `Delete` is admin-only (Admin/FinanceAdmin/StoreAdmin on any order; TeamsAdmin on team orders) — camp leads and team coordinators never delete their own orders. A **TeamsAdmin** additionally passes `View` on any order and manages team orders only — `AddLine`/`RemoveLine` (Open only); camp orders stay view-only for them, and `EditCounterparty`/`Pay` are never granted on team orders.
 
@@ -220,6 +223,7 @@ Stored as int via `HasConversion<int>()`.
 - Order create, line add/remove, counterparty edit, and Stripe payment record emit audit log entries via `IAuditLogService` (`StoreOrderCreated`, `StoreLineAdded`, `StoreLineRemoved`, `StoreCounterpartyEdited`, `StorePaymentRecorded`).
 - Product create, update, and deactivate emit `StoreProductCreated`, `StoreProductUpdated`, `StoreProductDeactivated`.
 - The Stripe webhook controller (`StoreStripeWebhookController`) verifies the request signature via `IStripeService.ParseStoreCheckoutEvent` and calls `IStoreService.RecordStripePaymentAsync` for `checkout.session.completed` events. Idempotent on `StripePaymentIntentId`.
+- `/Store/Admin/Payments/RecordMissing` reconciles Stripe → ledger on demand (admin-triggered), recording missing paid sessions via the same idempotent path and emitting one `StorePaymentsReconciled` summary audit entry (with the human actor) plus the per-payment `StorePaymentRecorded` entries. The webhook is therefore no longer the *sole* writer of Stripe payments — but it remains the only automatic one.
 
 **Not yet shipped (Phase 5+):**
 - `IssueInvoiceAsync` — will call `IHoldedClient.UpsertContactAsync` then `IHoldedClient.CreateInvoiceAsync`, write the `StoreInvoice` row, flip `StoreOrder.State = InvoiceIssued`, and emit `StorePaymentRecorded` audit entry. Currently throws `NotSupportedException("Phase 5")`.
@@ -240,7 +244,7 @@ Stored as int via `HasConversion<int>()`.
 
 The Store section uses `IStripeService` (Application-layer abstraction; Infrastructure impl in `Humans.Infrastructure/Services/StripeService.cs`).
 
-- `STRIPE_STORE_KEY` — `checkout_session:write` only. Refunds, payouts, and chargebacks remain manual via the Stripe dashboard; the bookkeeping side posts as negative `StorePayment` rows via FinanceAdmin manual entry (Phase 5.3).
+- `STRIPE_STORE_KEY` — `checkout_session:write` (Write ⊇ Read, so it also creates Checkout Sessions **and** lists/reads them for reconciliation via `ListStoreCheckoutSessionsAsync`). Each session is created with `humans_store_order_id` stamped on **both** the session metadata and the PaymentIntent metadata, plus a legible description, so payments are matchable from the dashboard, receipts, and PI search. Refunds, payouts, and chargebacks remain manual via the Stripe dashboard; the bookkeeping side posts as negative `StorePayment` rows via FinanceAdmin manual entry (Phase 5.3).
 - `STRIPE_STORE_WEBHOOK_SECRET` — signing secret for `StoreStripeWebhookController`. Set manually in QA/prod; auto-provisioned at boot in PR-preview envs via `StoreWebhookRegistrationService` (requires `STRIPE_STORE_WEBHOOK_REGISTRAR_KEY`).
 - Webhook events subscribed: `checkout.session.completed` (handled); `checkout.session.async_payment_succeeded/failed/expired` (logged at Warning, not yet handled).
 - Boot-time `StripeStartupSmokeService` validates each key with one low-risk read (Checkout.Sessions.list for Store key). Positive-confirmation only — cannot detect over-granted scopes.

--- a/docs/superpowers/specs/2026-06-04-store-stripe-payment-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-06-04-store-stripe-payment-reconciliation-design.md
@@ -1,0 +1,148 @@
+# Store → Stripe Payment Reconciliation
+
+**Date:** 2026-06-04
+**Section:** Store
+**Status:** Design approved (Peter), pre-implementation
+
+## Problem
+
+Store payments are recorded only by the Stripe webhook (`POST /Store/StripeWebhook` →
+`HandleStripeCheckoutWebhookEventAsync` → `RecordStripePaymentAsync` → `StorePayment` row).
+When `STRIPE_STORE_WEBHOOK_SECRET` is unset the endpoint returns 503 to every Stripe
+delivery (`StoreStripeWebhookController.cs:24-28`), so a paid Checkout Session is never
+recorded — the order balance stays at the full amount even though Stripe collected the
+money. This happened in production: a paid €1800 camp order shows unpaid, and because the
+webhook was misconfigured there is **no event left to redeliver**.
+
+There is no path to recover such a payment today: `RecordManualPaymentAsync` throws
+`NotSupportedException("Phase 5")`, and nothing polls Stripe. The webhook is the sole writer.
+
+## Goal
+
+A durable, always-available **reconciliation** between Stripe (source of truth for money
+received) and our `StorePayment` records, surfaced as an admin screen under the Store
+section. It is the operational home for Store-payment problems and management: it shows
+webhook health, every Stripe payment matched to its order, what is unrecorded, and the
+action to record the missing ones — idempotently, with all values pulled **from Stripe**,
+never typed or guessed.
+
+Reconciliation is mandatory infrastructure, not a one-off for the current €1800.
+
+## Non-goals
+
+- **Refunds / chargebacks / payouts** — stay 100% dashboard-manual per the Stripe-keys
+  convention (`StripeSettings`). Out of scope.
+- **Non-Stripe (cash / bank transfer) manual entry** — that is the separate Phase-5
+  `RecordManualPaymentAsync` concern; not built here.
+- **Automatic background sweep** — manual admin trigger only (re-runnable safely). A
+  scheduled job is a trivial later add, deliberately deferred (YAGNI).
+- **Amount-mismatch auto-correction** — mismatches are surfaced for humans, never auto-fixed.
+
+## The join key
+
+Every Checkout Session we create stamps `metadata["humans_store_order_id"]`
+(`StripeService.cs:108-111`). That metadata is returned by the Stripe API even though the
+dashboard's description column ("2026 - Yes") doesn't show it. So the **server** matches a
+Stripe payment to its order reliably; a human never has to eyeball or paste a session id.
+
+## Reconciliation status per Stripe payment
+
+Computed in the Store service by diffing the Stripe session list against recorded
+`StorePayment` rows (matched on PaymentIntent id):
+
+| Status | Meaning | Action |
+|---|---|---|
+| **Recorded** | paid session, PI already in `store_payments` | none |
+| **Missing** | `payment_status == paid`, order resolved, PI not recorded | recordable |
+| **Unmatched** | paid but no/unknown/Team order in metadata | flagged for human; never auto-recorded |
+| **Unpaid** | session `payment_status != paid` (open/expired/async-pending) | informational |
+
+Reverse direction — **Orphan**: a recorded Stripe-method `StorePayment` whose PI id is
+absent from the Stripe list — is reported read-only (never auto-deleted).
+
+## Architecture
+
+Layers respected: DbContext → Repository → Service → Controller. The Store service calls
+its own repository and the `IStripeService` connector (the established Store pattern for
+checkout + webhook parse). No cross-section access. Stripe SDK types stay behind the
+connector seam (design-rules §15i).
+
+### New surface (all flagged for Peter's sign-off)
+
+**Domain**
+- `AuditAction.StorePaymentsReconciled` — appended to the enum (positional; no migration).
+
+**Application — connector (`IStripeService` / `StripeService`)**
+- `Task<IReadOnlyList<StoreCheckoutSessionData>> ListStoreCheckoutSessionsAsync(CancellationToken ct = default)`
+  — `SessionService.ListAutoPagingAsync` on the existing `StoreKey` (checkout_session Write ⊇ Read,
+  no re-provisioning). Permission-error handling mirrors `CreateCheckoutSessionAsync`.
+- **Reuse decision:** extend the existing `StoreCheckoutSessionData` record with
+  `PaymentStatus` (string?) and `CreatedAt` (Instant?), populated in both the list path and
+  the existing webhook-parse path, rather than introduce a second near-identical session DTO.
+
+**Application — repository (`IStoreRepository` / `StoreRepository`)**
+- `Task<IReadOnlyList<StoreRecordedStripePayment>> GetRecordedStripePaymentsAsync(CancellationToken ct = default)`
+  returning `(string PaymentIntentId, Guid OrderId, decimal AmountEur, Instant ReceivedAt)` for
+  rows where `StripePaymentIntentId != null`. Feeds both the missing-detection set and orphan detection.
+  Rejected `GetRecordedStripePaymentIntentIdsAsync` (set only) because orphan rows need order/amount to display.
+
+**Application — service (`IStoreService` / `StoreService`)**
+- `Task<StripeReconciliationReport> GetStripeReconciliationAsync(CancellationToken ct = default)`
+  — builds the rows + health flags + counts; resolves matched-order labels via the repo
+  (`GetOrderByIdAsync`) for the distinct matched ids.
+- `Task<StripeReconciliationResult> RecordMissingStripePaymentsAsync(Guid actorUserId, CancellationToken ct = default)`
+  — re-pulls the Stripe list (never trusts client-posted amounts), records every
+  paid+matched+unrecorded session via the existing **idempotent** `RecordStripePaymentAsync`,
+  writes one `StorePaymentsReconciled` summary audit entry (plus the per-payment audit each
+  record already emits). Team-owned orders are skipped (defense-in-depth already in
+  `RecordStripePaymentAsync`).
+- New read-model records (Application, no EF types): `StripeReconciliationReport`
+  (`WebhookConfigured`, `CheckoutConfigured`, `Rows`, `Orphans`, count summary),
+  `StripeReconciliationRow` (session/PI id, amount, status enum, created, OrderId?, OrderLabel?),
+  `StripeReconciliationResult` (`RecordedCount`, `TotalEur`).
+
+**Web (`StoreAdminController`, route `Store/Admin`, policy `StoreCatalogAdmin`)**
+- `GET Store/Admin/Payments` → `GetStripeReconciliationAsync` → `Views/StoreAdmin/Payments.cshtml`.
+- `POST Store/Admin/Payments/RecordMissing` `[ValidateAntiForgeryToken]` → `RecordMissingStripePaymentsAsync`
+  → redirect back with a success summary.
+- `StorePaymentsReconciliationViewModel`; controller does formatting/ordering only.
+- Nav link "Payments" added to the Store admin area alongside Catalog / Summary.
+
+**Forward fix (in scope — so this can't recur invisibly)**
+- `CreateCheckoutSessionAsync`: also set `PaymentIntentData.Metadata["humans_store_order_id"]`
+  and a legible description (order ref + counterparty), so the PI itself carries the join key
+  and the Stripe dashboard / customer receipt stop reading "2026 - Yes".
+
+## Data flow
+
+```
+GET /Store/Admin/Payments
+  StripeService.ListStoreCheckoutSessionsAsync (StoreKey, auto-paged)  ─┐
+  StoreRepository.GetRecordedStripePaymentsAsync ─────────────────────┐ │
+  StoreService diffs by PI id, resolves order labels  <───────────────┴─┘
+  → health banner + rows (Recorded/Missing/Unmatched/Unpaid) + orphans
+
+POST /Store/Admin/Payments/RecordMissing
+  re-pull Stripe list → for each paid+matched+unrecorded:
+    RecordStripePaymentAsync(orderId, piId, amountEur)   // idempotent on PI id
+  → one StorePaymentsReconciled audit + per-payment audits → summary
+```
+
+## Safety / invariants
+
+- **Idempotent**: recording guards on unique PI id (`StripePaymentIntentExistsAsync`); the
+  screen and the record action are safe to run repeatedly.
+- **No fabricated data**: amount + PI id come from Stripe. Unmatched/orphan rows are reported,
+  never recorded or deleted.
+- **No hand-editing runtime state**: recovery flows through the normal service path with full audit.
+- **Never blocks anything**: read-only screen + additive recording; no impact on checkout or sign-in.
+
+## Testing
+
+- Service recon logic (fake `IStripeService` + `IStoreRepository`): each status classification
+  (recorded / missing / unmatched / unpaid), orphan detection, label resolution.
+- `RecordMissingStripePaymentsAsync`: records only paid+matched+unrecorded; idempotent on
+  re-run; skips Team orders; correct count/total + audit.
+- Connector mapping (`payment_status`, metadata order id, amount minor-unit conversion) covered
+  by mapping the SDK `Session` → `StoreCheckoutSessionData`.
+- Architecture tests stay green (no new cross-section refs, no SDK types across the seam).

--- a/src/Humans.Application/Interfaces/IStripeService.cs
+++ b/src/Humans.Application/Interfaces/IStripeService.cs
@@ -1,3 +1,5 @@
+using NodaTime;
+
 namespace Humans.Application.Interfaces;
 
 /// <summary>
@@ -50,6 +52,18 @@ public interface IStripeService : IApplicationService
     /// <param name="body">Raw request body as received from Stripe.</param>
     /// <param name="signature">Value of the <c>Stripe-Signature</c> header.</param>
     StoreCheckoutWebhookEvent? ParseStoreCheckoutEvent(string body, string signature);
+
+    /// <summary>
+    /// Lists every Checkout Session on the Store account (Stripe returns them newest-first),
+    /// each projected to <see cref="StoreCheckoutSessionData"/>. Used by Store payment
+    /// reconciliation to diff Stripe (source of truth) against recorded payments. Reads with
+    /// the existing Store key (checkout_session Write ⊇ Read).
+    /// Returns <c>null</c> when Stripe could not be queried (Store key unset or missing read
+    /// scope; logged internally) — callers must treat that as "unknown", not "no sessions",
+    /// so they don't false-flag recorded payments as orphans. An empty (non-null) list means
+    /// Stripe was queried successfully and returned no sessions.
+    /// </summary>
+    Task<IReadOnlyList<StoreCheckoutSessionData>?> ListStoreCheckoutSessionsAsync(CancellationToken ct = default);
 }
 
 /// <summary>Fee and payment method data extracted from a Stripe PaymentIntent's charge.</summary>
@@ -94,8 +108,12 @@ public sealed record StoreCheckoutWebhookEvent(
 /// <param name="OrderId">Round-tripped via <c>session.metadata['humans_store_order_id']</c>; null if missing or malformed.</param>
 /// <param name="PaymentIntentId">Stripe PaymentIntent id; null if Stripe didn't include one.</param>
 /// <param name="AmountEur">Total amount in EUR (already converted from minor units); null if Stripe didn't send a total.</param>
+/// <param name="PaymentStatus">Stripe <c>payment_status</c> (<c>paid</c> / <c>unpaid</c> / <c>no_payment_required</c>); null if absent. Reconciliation acts only on <c>paid</c>.</param>
+/// <param name="CreatedAt">When Stripe created the session; null if absent. Used to order the reconciliation view.</param>
 public sealed record StoreCheckoutSessionData(
     string SessionId,
     Guid? OrderId,
     string? PaymentIntentId,
-    decimal? AmountEur);
+    decimal? AmountEur,
+    string? PaymentStatus = null,
+    Instant? CreatedAt = null);

--- a/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
@@ -18,6 +18,17 @@ public record StoreLineContext(
     LocalDate ProductOrderableUntil);
 
 /// <summary>
+/// A recorded Stripe-method <see cref="StorePayment"/> projected for reconciliation
+/// against the Stripe Checkout Session list. Returned by
+/// <see cref="IStoreRepository.GetRecordedStripePaymentsAsync"/>.
+/// </summary>
+public record StoreRecordedStripePayment(
+    string PaymentIntentId,
+    Guid OrderId,
+    decimal AmountEur,
+    Instant ReceivedAt);
+
+/// <summary>
 /// Repository for the Store section's tables: <c>store_products</c>,
 /// <c>store_orders</c>, <c>store_order_lines</c>, <c>store_payments</c>,
 /// <c>store_invoices</c>, and <c>store_treasury_sync_state</c>. The only
@@ -103,6 +114,14 @@ public interface IStoreRepository : IRepository
     // Payments
     Task AddPaymentAsync(StorePayment payment, CancellationToken ct = default);
     Task<bool> StripePaymentIntentExistsAsync(string paymentIntentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns every recorded Stripe-method payment (rows with a non-null
+    /// <see cref="StorePayment.StripePaymentIntentId"/>), projected for reconciliation.
+    /// Feeds both missing-payment detection (Stripe sessions absent here) and orphan
+    /// detection (recorded here but absent from Stripe).
+    /// </summary>
+    Task<IReadOnlyList<StoreRecordedStripePayment>> GetRecordedStripePaymentsAsync(CancellationToken ct = default);
 
     // Invoices
     Task AddInvoiceAsync(StoreInvoice invoice, CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/Store/IStoreService.cs
+++ b/src/Humans.Application/Interfaces/Store/IStoreService.cs
@@ -78,6 +78,21 @@ public interface IStoreService : IApplicationService
     /// </summary>
     Task HandleStripeCheckoutWebhookEventAsync(StoreCheckoutWebhookEvent evt, CancellationToken ct = default);
 
+    /// <summary>
+    /// Builds the Stripe payment reconciliation report for the Store admin screen: webhook/checkout
+    /// health, every Store Checkout Session matched to its order with a reconciliation status, and
+    /// recorded Stripe payments orphaned from Stripe. Read-only — records nothing.
+    /// </summary>
+    Task<StripeReconciliationReport> GetStripeReconciliationAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Records every paid, order-matched, not-yet-recorded Stripe Checkout Session via the idempotent
+    /// <see cref="RecordStripePaymentAsync"/> path, pulling amounts from Stripe (never the caller).
+    /// Skips unmatched and Team-owned orders. Writes one <c>StorePaymentsReconciled</c> audit entry.
+    /// Safe to re-run. Returns how many were recorded and their total.
+    /// </summary>
+    Task<StripeReconciliationResult> RecordMissingStripePaymentsAsync(Guid actorUserId, CancellationToken ct = default);
+
     // Invoice issuance (FinanceAdmin) — implemented in Phase 5
     Task IssueInvoiceAsync(Guid orderId, Guid actorUserId, CancellationToken ct = default);
 

--- a/src/Humans.Application/Services/Store/Dtos/StripeReconciliation.cs
+++ b/src/Humans.Application/Services/Store/Dtos/StripeReconciliation.cs
@@ -1,0 +1,69 @@
+using NodaTime;
+
+namespace Humans.Application.Services.Store.Dtos;
+
+/// <summary>
+/// Reconciliation status of a single Stripe Checkout Session against recorded
+/// <c>StorePayment</c> rows. See the 2026-06-04 reconciliation design.
+/// </summary>
+public enum StripeReconciliationStatus
+{
+    /// <summary>Paid session whose PaymentIntent is already a recorded payment.</summary>
+    Recorded,
+    /// <summary>Paid session, order resolved and billable, but not yet recorded — recordable.</summary>
+    Missing,
+    /// <summary>Paid session with no resolvable billable order (missing metadata, deleted order, or Team order).</summary>
+    Unmatched,
+    /// <summary>Session not in a paid state (open / expired / async-pending) — informational.</summary>
+    Unpaid,
+}
+
+/// <summary>One Stripe Checkout Session row in the reconciliation view.</summary>
+public sealed record StripeReconciliationRow(
+    string SessionId,
+    string? PaymentIntentId,
+    decimal? AmountEur,
+    string? PaymentStatus,
+    Instant? CreatedAt,
+    Guid? OrderId,
+    string? OrderLabel,
+    StripeReconciliationStatus Status);
+
+/// <summary>
+/// A recorded Stripe-method payment with no matching session in the Stripe list —
+/// reported for human review, never auto-deleted.
+/// </summary>
+public sealed record StripeOrphanPayment(
+    string PaymentIntentId,
+    Guid OrderId,
+    string? OrderLabel,
+    decimal AmountEur,
+    Instant ReceivedAt);
+
+/// <summary>
+/// Full reconciliation report for the Store Stripe Payments admin screen: webhook/checkout
+/// health, every Stripe payment matched to its order, and recorded payments orphaned from Stripe.
+/// </summary>
+/// <param name="StripeQueried">
+/// True when the Stripe session list was actually read. False when Stripe could not be queried
+/// (key unset or missing read scope) — in which case <see cref="Orphans"/> is empty rather than
+/// false-flagging every recorded payment as an orphan.
+/// </param>
+public sealed record StripeReconciliationReport(
+    bool WebhookConfigured,
+    bool CheckoutConfigured,
+    bool StripeQueried,
+    IReadOnlyList<StripeReconciliationRow> Rows,
+    IReadOnlyList<StripeOrphanPayment> Orphans)
+{
+    public int RecordedCount => Rows.Count(r => r.Status == StripeReconciliationStatus.Recorded);
+    public int MissingCount => Rows.Count(r => r.Status == StripeReconciliationStatus.Missing);
+    public int UnmatchedCount => Rows.Count(r => r.Status == StripeReconciliationStatus.Unmatched);
+
+    public decimal MissingTotalEur => Rows
+        .Where(r => r.Status == StripeReconciliationStatus.Missing)
+        .Sum(r => r.AmountEur ?? 0m);
+}
+
+/// <summary>Outcome of recording the missing payments: how many were recorded and their total.</summary>
+public sealed record StripeReconciliationResult(int RecordedCount, decimal TotalEur);

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -666,6 +666,106 @@ public class StoreService(
             orderId, nameof(StoreOrder));
     }
 
+    public async Task<StripeReconciliationReport> GetStripeReconciliationAsync(CancellationToken ct = default)
+    {
+        var sessionsOrNull = await stripeService.ListStoreCheckoutSessionsAsync(ct);
+        var stripeQueried = sessionsOrNull is not null;
+        var sessions = sessionsOrNull ?? [];
+        var recorded = await repo.GetRecordedStripePaymentsAsync(ct);
+        var recordedPis = recorded.Select(p => p.PaymentIntentId).ToHashSet(StringComparer.Ordinal);
+
+        // Resolve each distinct matched order once (Stripe-side and recorded-side) for its
+        // display label and billable check.
+        var matchedIds = sessions.Where(s => s.OrderId is not null).Select(s => s.OrderId!.Value)
+            .Concat(recorded.Select(p => p.OrderId))
+            .Distinct();
+        var orders = new Dictionary<Guid, OrderDto>();
+        foreach (var id in matchedIds)
+        {
+            var order = await GetOrderAsync(id, ct);
+            if (order is not null) orders[id] = order;
+        }
+
+        var rows = new List<StripeReconciliationRow>(sessions.Count);
+        foreach (var s in sessions)
+        {
+            OrderDto? order = s.OrderId is { } oid && orders.TryGetValue(oid, out var o) ? o : null;
+            rows.Add(new StripeReconciliationRow(
+                s.SessionId, s.PaymentIntentId, s.AmountEur, s.PaymentStatus, s.CreatedAt,
+                s.OrderId, order?.CounterpartyDisplayName,
+                ClassifyStripeSession(s, order, recordedPis)));
+        }
+
+        // Orphans: recorded Stripe payments whose PI is absent from the Stripe list — but only
+        // when Stripe was actually queried. If it couldn't be read, an empty session list does
+        // NOT mean those payments are orphans, so skip the check entirely.
+        var stripePis = sessions.Where(s => s.PaymentIntentId is not null)
+            .Select(s => s.PaymentIntentId!).ToHashSet(StringComparer.Ordinal);
+        var orphans = stripeQueried
+            ? recorded
+                .Where(p => !stripePis.Contains(p.PaymentIntentId))
+                .Select(p => new StripeOrphanPayment(
+                    p.PaymentIntentId, p.OrderId,
+                    orders.TryGetValue(p.OrderId, out var oo) ? oo.CounterpartyDisplayName : null,
+                    p.AmountEur, p.ReceivedAt))
+                .ToList()
+            : new List<StripeOrphanPayment>();
+
+        return new StripeReconciliationReport(
+            stripeService.IsStoreWebhookConfigured,
+            stripeService.IsStoreCheckoutConfigured,
+            stripeQueried,
+            rows,
+            orphans);
+    }
+
+    private static StripeReconciliationStatus ClassifyStripeSession(
+        StoreCheckoutSessionData s, OrderDto? order, IReadOnlySet<string> recordedPis)
+    {
+        if (!string.Equals(s.PaymentStatus, "paid", StringComparison.Ordinal))
+            return StripeReconciliationStatus.Unpaid;
+        if (s.PaymentIntentId is { } pi && recordedPis.Contains(pi))
+            return StripeReconciliationStatus.Recorded;
+        if (order is null || s.PaymentIntentId is null || order.CounterpartyType == StoreOrderCounterpartyType.Team)
+            return StripeReconciliationStatus.Unmatched;
+        return StripeReconciliationStatus.Missing;
+    }
+
+    public async Task<StripeReconciliationResult> RecordMissingStripePaymentsAsync(
+        Guid actorUserId, CancellationToken ct = default)
+    {
+        var sessions = await stripeService.ListStoreCheckoutSessionsAsync(ct) ?? [];
+        var recorded = await repo.GetRecordedStripePaymentsAsync(ct);
+        var recordedPis = recorded.Select(p => p.PaymentIntentId).ToHashSet(StringComparer.Ordinal);
+
+        var count = 0;
+        var total = 0m;
+        foreach (var s in sessions)
+        {
+            if (!string.Equals(s.PaymentStatus, "paid", StringComparison.Ordinal)) continue;
+            if (s.OrderId is not { } orderId || s.PaymentIntentId is not { } pi || s.AmountEur is not { } amount) continue;
+            if (amount <= 0 || recordedPis.Contains(pi)) continue;
+
+            // Never fabricate a payment on an unmatched or non-billable (Team) order.
+            var order = await repo.GetOrderByIdAsync(orderId, ct);
+            if (order is null || order.TeamId is not null) continue;
+
+            await RecordStripePaymentAsync(orderId, pi, amount, ct); // idempotent on PI id
+            count++;
+            total += amount;
+        }
+
+        if (count > 0)
+        {
+            await audit.LogAsync(
+                AuditAction.StorePaymentsReconciled, "Store", Guid.Empty,
+                $"Reconciled {count} Stripe payment(s) totalling EUR {total:0.00} from the Store Stripe account",
+                actorUserId);
+        }
+
+        return new StripeReconciliationResult(count, total);
+    }
+
     public async Task HandleStripeCheckoutWebhookEventAsync(StoreCheckoutWebhookEvent evt, CancellationToken ct = default)
     {
         switch (evt.Kind)

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -184,4 +184,5 @@ public enum AuditAction
     EarlyEntryGranted,
     EarlyEntryUpdated,
     EarlyEntryRevoked,
+    StorePaymentsReconciled,
 }

--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -223,6 +223,16 @@ internal sealed class StoreRepository(IDbContextFactory<HumansDbContext> factory
         return await ctx.StorePayments.AnyAsync(p => p.StripePaymentIntentId == paymentIntentId, ct);
     }
 
+    public async Task<IReadOnlyList<StoreRecordedStripePayment>> GetRecordedStripePaymentsAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await factory.CreateDbContextAsync(ct);
+        return await ctx.StorePayments.AsNoTracking()
+            .Where(p => p.StripePaymentIntentId != null)
+            .Select(p => new StoreRecordedStripePayment(
+                p.StripePaymentIntentId!, p.OrderId, p.AmountEur, p.ReceivedAt))
+            .ToListAsync(ct);
+    }
+
     // ==========================================================================
     // Invoices
     // ==========================================================================

--- a/src/Humans.Infrastructure/Services/StripeService.cs
+++ b/src/Humans.Infrastructure/Services/StripeService.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using NodaTime;
 using Stripe;
 using Stripe.Checkout;
 
@@ -109,6 +110,17 @@ public class StripeService(IOptions<StripeSettings> settings, ILogger<StripeServ
             {
                 ["humans_store_order_id"] = storeOrderId.ToString(),
             },
+            // Stamp the same order-id metadata and a legible description onto the PaymentIntent
+            // itself (not only the session) so the Stripe dashboard, customer receipt, and PI
+            // search can match a payment back to its order. See the 2026-06-04 reconciliation design.
+            PaymentIntentData = new SessionPaymentIntentDataOptions
+            {
+                Description = lineItemDescription,
+                Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["humans_store_order_id"] = storeOrderId.ToString(),
+                },
+            },
         };
 
         try
@@ -215,26 +227,62 @@ public class StripeService(IOptions<StripeSettings> settings, ILogger<StripeServ
             _ => StoreCheckoutEventKind.Other,
         };
 
-        StoreCheckoutSessionData? session = null;
-        if (stripeEvent.Data.Object is Session s)
-        {
-            Guid? orderId = null;
-            if (s.Metadata is not null &&
-                s.Metadata.TryGetValue("humans_store_order_id", out var orderIdStr) &&
-                Guid.TryParse(orderIdStr, out var parsed))
-            {
-                orderId = parsed;
-            }
-
-            decimal? amountEur = s.AmountTotal.HasValue ? FromStripeMinorUnits(s.AmountTotal.Value) : null;
-
-            session = new StoreCheckoutSessionData(
-                SessionId: s.Id,
-                OrderId: orderId,
-                PaymentIntentId: string.IsNullOrEmpty(s.PaymentIntentId) ? null : s.PaymentIntentId,
-                AmountEur: amountEur);
-        }
+        StoreCheckoutSessionData? session = stripeEvent.Data.Object is Session s ? MapSession(s) : null;
 
         return new StoreCheckoutWebhookEvent(stripeEvent.Id, kind, session);
+    }
+
+    public async Task<IReadOnlyList<StoreCheckoutSessionData>?> ListStoreCheckoutSessionsAsync(
+        CancellationToken ct = default)
+    {
+        if (!_settings.IsStoreCheckoutConfigured)
+        {
+            logger.LogWarning("Store Checkout Session list requested while STRIPE_STORE_KEY is unset; Stripe not queried.");
+            return null;
+        }
+
+        var client = new StripeClient(_settings.StoreKey);
+        var sessions = new SessionService(client);
+        var results = new List<StoreCheckoutSessionData>();
+        try
+        {
+            await foreach (var s in sessions.ListAutoPagingAsync(new SessionListOptions { Limit = 100 }, cancellationToken: ct))
+            {
+                results.Add(MapSession(s));
+            }
+        }
+        catch (StripeException ex) when (StripeStartupSmokeService.IsPermissionError(ex))
+        {
+            logger.LogWarning(
+                "Stripe permission_error listing Store Checkout Sessions: the Store key is missing checkout_session:read scope. {Message}",
+                ex.Message);
+            return null;
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Projects a Stripe SDK <see cref="Session"/> to the connector DTO. Shared by the
+    /// webhook-parse and reconciliation-list paths so both read the order-id metadata,
+    /// amount, payment status, and creation time identically.
+    /// </summary>
+    private static StoreCheckoutSessionData MapSession(Session s)
+    {
+        Guid? orderId = null;
+        if (s.Metadata is not null &&
+            s.Metadata.TryGetValue("humans_store_order_id", out var orderIdStr) &&
+            Guid.TryParse(orderIdStr, out var parsed))
+        {
+            orderId = parsed;
+        }
+
+        return new StoreCheckoutSessionData(
+            SessionId: s.Id,
+            OrderId: orderId,
+            PaymentIntentId: string.IsNullOrEmpty(s.PaymentIntentId) ? null : s.PaymentIntentId,
+            AmountEur: s.AmountTotal.HasValue ? FromStripeMinorUnits(s.AmountTotal.Value) : null,
+            PaymentStatus: s.PaymentStatus,
+            CreatedAt: Instant.FromDateTimeUtc(DateTime.SpecifyKind(s.Created, DateTimeKind.Utc)));
     }
 }

--- a/src/Humans.Web/Controllers/StoreAdminController.cs
+++ b/src/Humans.Web/Controllers/StoreAdminController.cs
@@ -1,5 +1,6 @@
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Store;
+using Humans.Application.Services.Store.Dtos;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Humans.Web.Models.Store;
@@ -44,6 +45,32 @@ public class StoreAdminController(
 
         var summary = await storeService.GetStoreSummaryAsync(selectedYear, ct);
         return View(new StoreSummaryViewModel { Summary = summary });
+    }
+
+    [HttpGet("Payments")]
+    public async Task<IActionResult> Payments(CancellationToken ct)
+    {
+        var report = await storeService.GetStripeReconciliationAsync(ct);
+        var rows = report.Rows
+            .OrderByDescending(r => r.Status is StripeReconciliationStatus.Missing or StripeReconciliationStatus.Unmatched)
+            .ThenByDescending(r => r.CreatedAt)
+            .ToList();
+        return View(new StorePaymentsReconciliationViewModel { Report = report, Rows = rows });
+    }
+
+    [HttpPost("Payments/RecordMissing")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RecordMissingPayments(CancellationToken ct)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var result = await storeService.RecordMissingStripePaymentsAsync(user.Id, ct);
+        if (result.RecordedCount > 0)
+            SetSuccess($"Recorded {result.RecordedCount} Stripe payment(s) totalling €{result.TotalEur:0.00}.");
+        else
+            SetInfo("No missing Stripe payments to record — Stripe and the Store ledger are already reconciled.");
+        return RedirectToAction(nameof(Payments));
     }
 
     [HttpGet("Catalog/Edit")]

--- a/src/Humans.Web/Models/Store/StorePaymentsReconciliationViewModel.cs
+++ b/src/Humans.Web/Models/Store/StorePaymentsReconciliationViewModel.cs
@@ -1,0 +1,15 @@
+using Humans.Application.Services.Store.Dtos;
+
+namespace Humans.Web.Models.Store;
+
+/// <summary>
+/// View model for the Store → Stripe Payments admin screen. Wraps the reconciliation
+/// report with the display-ordered rows the controller prepared.
+/// </summary>
+public sealed class StorePaymentsReconciliationViewModel
+{
+    public required StripeReconciliationReport Report { get; init; }
+
+    /// <summary>Rows ordered for display: problems (Missing / Unmatched) first, then newest.</summary>
+    public required IReadOnlyList<StripeReconciliationRow> Rows { get; init; }
+}

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -6,7 +6,14 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1 class="mb-0">Store</h1>
-    <span class="badge bg-secondary fs-6">@Model.Year</span>
+    <div class="d-flex align-items-center gap-2">
+        <div class="btn-group" authorize-policy="StoreCatalogAdmin">
+            <a asp-controller="StoreAdmin" asp-action="Catalog" class="btn btn-sm btn-outline-secondary">Catalog</a>
+            <a asp-controller="StoreAdmin" asp-action="Summary" class="btn btn-sm btn-outline-secondary">Summary</a>
+            <a asp-controller="StoreAdmin" asp-action="Payments" class="btn btn-sm btn-outline-secondary">Payments</a>
+        </div>
+        <span class="badge bg-secondary fs-6">@Model.Year</span>
+    </div>
 </div>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/StoreAdmin/Payments.cshtml
+++ b/src/Humans.Web/Views/StoreAdmin/Payments.cshtml
@@ -1,0 +1,158 @@
+@using Humans.Application.Services.Store.Dtos
+@using Humans.Web.Models.Store
+@model StorePaymentsReconciliationViewModel
+@{
+    ViewData["Title"] = "Store Stripe Payments";
+    var report = Model.Report;
+}
+
+@functions {
+    private static (string Css, string Label) StatusBadge(StripeReconciliationStatus status) => status switch
+    {
+        StripeReconciliationStatus.Recorded => ("bg-success", "Recorded"),
+        StripeReconciliationStatus.Missing => ("bg-danger", "Missing"),
+        StripeReconciliationStatus.Unmatched => ("bg-warning text-dark", "Unmatched"),
+        _ => ("bg-secondary", "Unpaid"),
+    };
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Stripe Payments</h1>
+    <div class="btn-group">
+        <a asp-action="Catalog" class="btn btn-outline-secondary">Catalog</a>
+        <a asp-action="Summary" class="btn btn-outline-secondary">Summary</a>
+        <a asp-controller="Store" asp-action="Index" class="btn btn-outline-secondary">Back to Store</a>
+    </div>
+</div>
+
+<vc:temp-data-alerts />
+
+@if (!report.WebhookConfigured)
+{
+    <div class="alert alert-danger">
+        <i class="fa-solid fa-triangle-exclamation me-1"></i>
+        <strong>Stripe webhook is not configured.</strong> Paid orders will <em>not</em> record automatically
+        until <code>STRIPE_STORE_WEBHOOK_SECRET</code> is set. Until then, reconcile here after each payment.
+    </div>
+}
+@if (!report.CheckoutConfigured)
+{
+    <div class="alert alert-warning">
+        <i class="fa-solid fa-triangle-exclamation me-1"></i>
+        The Store Stripe key (<code>STRIPE_STORE_KEY</code>) is not configured, so Stripe cannot be read.
+        This list is empty until it is set.
+    </div>
+}
+else if (!report.StripeQueried)
+{
+    <div class="alert alert-warning">
+        <i class="fa-solid fa-triangle-exclamation me-1"></i>
+        The Store Stripe key is set but the session list could not be read (missing
+        <code>checkout_session:read</code> scope). Matching and orphan checks are suppressed
+        until it is fixed.
+    </div>
+}
+
+<div class="card mb-4">
+    <div class="card-body d-flex flex-wrap align-items-center gap-3">
+        <div>
+            <span class="badge bg-success">@report.RecordedCount recorded</span>
+            <span class="badge bg-danger">@report.MissingCount missing</span>
+            <span class="badge bg-warning text-dark">@report.UnmatchedCount unmatched</span>
+        </div>
+        <div class="ms-auto d-flex align-items-center gap-3">
+            @if (report.MissingCount > 0)
+            {
+                <span class="text-danger fw-semibold">€@report.MissingTotalEur.ToString("0.00") collected but unrecorded</span>
+                <form asp-action="RecordMissingPayments" method="post" class="mb-0">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa-solid fa-rotate me-1"></i>Record @report.MissingCount missing payment(s)
+                    </button>
+                </form>
+            }
+            else if (report.StripeQueried)
+            {
+                <span class="text-success"><i class="fa-solid fa-check me-1"></i>Stripe and the ledger are reconciled.</span>
+            }
+        </div>
+    </div>
+</div>
+
+@if (Model.Rows.Count == 0)
+{
+    <div class="card">
+        <div class="card-body text-center py-4 text-muted">No Stripe Checkout payments found for the Store account.</div>
+    </div>
+}
+else
+{
+    <div class="card">
+        <div class="table-responsive">
+            <table class="table table-striped align-middle mb-0">
+                <thead>
+                    <tr>
+                        <th>Created (UTC)</th>
+                        <th class="text-end">Amount</th>
+                        <th>Status</th>
+                        <th>Order</th>
+                        <th>PaymentIntent</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in Model.Rows)
+                    {
+                        var (css, label) = StatusBadge(row.Status);
+                        <tr>
+                            <td>@(row.CreatedAt?.ToAuditMinuteTimestamp() ?? "—")</td>
+                            <td class="text-end">@(row.AmountEur.HasValue ? $"€{row.AmountEur.Value:0.00}" : "—")</td>
+                            <td><span class="badge @css">@label</span></td>
+                            <td>
+                                @if (row.OrderId is { } oid)
+                                {
+                                    <a asp-controller="Store" asp-action="Order" asp-route-id="@oid">@(row.OrderLabel ?? oid.ToString())</a>
+                                }
+                                else
+                                {
+                                    <span class="text-muted">no order metadata</span>
+                                }
+                            </td>
+                            <td><code class="small">@(row.PaymentIntentId ?? "—")</code></td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+@if (report.Orphans.Count > 0)
+{
+    <h2 class="h5 mt-4 mb-2 text-warning">Orphan payments — recorded here but not found in Stripe</h2>
+    <p class="text-muted small">Investigate manually; these are never auto-removed.</p>
+    <div class="card">
+        <div class="table-responsive">
+            <table class="table table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th>Recorded (UTC)</th>
+                        <th class="text-end">Amount</th>
+                        <th>Order</th>
+                        <th>PaymentIntent</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var o in report.Orphans)
+                    {
+                        <tr>
+                            <td>@o.ReceivedAt.ToAuditMinuteTimestamp()</td>
+                            <td class="text-end">€@o.AmountEur.ToString("0.00")</td>
+                            <td><a asp-controller="Store" asp-action="Order" asp-route-id="@o.OrderId">@(o.OrderLabel ?? o.OrderId.ToString())</a></td>
+                            <td><code class="small">@o.PaymentIntentId</code></td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceStripeReconciliationTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceStripeReconciliationTests.cs
@@ -1,0 +1,214 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Services.Store;
+using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Store;
+
+public class StoreServiceStripeReconciliationTests
+{
+    private readonly IStoreRepository _repo = Substitute.For<IStoreRepository>();
+    private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
+    private readonly ICampServiceRead _campService = Substitute.For<ICampServiceRead>();
+    private readonly ITeamServiceRead _teams = Substitute.For<ITeamServiceRead>();
+    private readonly IShiftManagementService _shifts = Substitute.For<IShiftManagementService>();
+    private readonly IStripeService _stripe = Substitute.For<IStripeService>();
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 6, 4, 12, 0));
+    private readonly StoreService _service;
+
+    public StoreServiceStripeReconciliationTests()
+    {
+        _shifts.GetActiveAsync().Returns(new EventSettings { Year = 2026, TimeZoneId = "Europe/Madrid" });
+        // Mapping-chain stubs so GetOrderAsync resolves without throwing.
+        _repo.GetAllProductsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<StoreProduct>());
+        _repo.GetProductNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, string>());
+        _service = new StoreService(_repo, _audit, _campService, _teams, _clock, _shifts, _stripe, NullLogger<StoreService>.Instance);
+    }
+
+    private static StoreOrder CampOrder(Guid id) => new()
+    {
+        Id = id,
+        CampSeasonId = Guid.NewGuid(),
+        TeamId = null,
+        Year = 2026,
+        State = StoreOrderState.Open,
+        Lines = [],
+        Payments = [],
+    };
+
+    private static StoreOrder TeamOrder(Guid id) => new()
+    {
+        Id = id,
+        CampSeasonId = null,
+        TeamId = Guid.NewGuid(),
+        Year = 2026,
+        State = StoreOrderState.Open,
+        Lines = [],
+        Payments = [],
+    };
+
+    private static StoreCheckoutSessionData Session(
+        string sessionId, Guid? orderId, string? pi, decimal? amount, string status) =>
+        new(sessionId, orderId, pi, amount, status, Instant.FromUtc(2026, 6, 1, 9, 0));
+
+    [HumansFact]
+    public async Task GetStripeReconciliationAsync_classifies_each_session()
+    {
+        var recordedOrder = Guid.NewGuid();
+        var missingOrder = Guid.NewGuid();
+        var teamOrder = Guid.NewGuid();
+
+        _stripe.ListStoreCheckoutSessionsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreCheckoutSessionData>
+        {
+            Session("cs_recorded", recordedOrder, "pi_recorded", 100m, "paid"),
+            Session("cs_missing", missingOrder, "pi_missing", 1800m, "paid"),
+            Session("cs_team", teamOrder, "pi_team", 50m, "paid"),
+            Session("cs_nometa", null, "pi_nometa", 75m, "paid"),
+            Session("cs_unpaid", missingOrder, null, 200m, "unpaid"),
+        });
+        _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>
+        {
+            new("pi_recorded", recordedOrder, 100m, Instant.FromUtc(2026, 5, 1, 0, 0)),
+        });
+        _repo.GetOrderWithLinesAndPaymentsAsync(recordedOrder, Arg.Any<CancellationToken>()).Returns(CampOrder(recordedOrder));
+        _repo.GetOrderWithLinesAndPaymentsAsync(missingOrder, Arg.Any<CancellationToken>()).Returns(CampOrder(missingOrder));
+        _repo.GetOrderWithLinesAndPaymentsAsync(teamOrder, Arg.Any<CancellationToken>()).Returns(TeamOrder(teamOrder));
+
+        var report = await _service.GetStripeReconciliationAsync();
+
+        report.Rows.Should().Contain(r => r.SessionId == "cs_recorded" && r.Status == StripeReconciliationStatus.Recorded);
+        report.Rows.Should().Contain(r => r.SessionId == "cs_missing" && r.Status == StripeReconciliationStatus.Missing);
+        report.Rows.Should().Contain(r => r.SessionId == "cs_team" && r.Status == StripeReconciliationStatus.Unmatched);
+        report.Rows.Should().Contain(r => r.SessionId == "cs_nometa" && r.Status == StripeReconciliationStatus.Unmatched);
+        report.Rows.Should().Contain(r => r.SessionId == "cs_unpaid" && r.Status == StripeReconciliationStatus.Unpaid);
+        report.MissingCount.Should().Be(1);
+        report.MissingTotalEur.Should().Be(1800m);
+    }
+
+    [HumansFact]
+    public async Task GetStripeReconciliationAsync_flags_orphan_recorded_payment_absent_from_stripe()
+    {
+        var order = Guid.NewGuid();
+        _stripe.ListStoreCheckoutSessionsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreCheckoutSessionData>());
+        _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>
+        {
+            new("pi_orphan", order, 500m, Instant.FromUtc(2026, 5, 1, 0, 0)),
+        });
+        _repo.GetOrderWithLinesAndPaymentsAsync(order, Arg.Any<CancellationToken>()).Returns(CampOrder(order));
+
+        var report = await _service.GetStripeReconciliationAsync();
+
+        report.Orphans.Should().ContainSingle()
+            .Which.Should().Match<StripeOrphanPayment>(o => o.PaymentIntentId == "pi_orphan" && o.AmountEur == 500m);
+        report.Rows.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task GetStripeReconciliationAsync_surfaces_health_flags()
+    {
+        _stripe.IsStoreWebhookConfigured.Returns(false);
+        _stripe.IsStoreCheckoutConfigured.Returns(true);
+        _stripe.ListStoreCheckoutSessionsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreCheckoutSessionData>());
+        _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>());
+
+        var report = await _service.GetStripeReconciliationAsync();
+
+        report.WebhookConfigured.Should().BeFalse();
+        report.CheckoutConfigured.Should().BeTrue();
+        report.StripeQueried.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public async Task GetStripeReconciliationAsync_suppresses_orphans_when_stripe_unavailable()
+    {
+        var order = Guid.NewGuid();
+        // Stripe could not be queried (key unset or missing read scope) → null, not empty list.
+        _stripe.ListStoreCheckoutSessionsAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<StoreCheckoutSessionData>?)null);
+        _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>
+        {
+            new("pi_x", order, 500m, Instant.FromUtc(2026, 5, 1, 0, 0)),
+        });
+
+        var report = await _service.GetStripeReconciliationAsync();
+
+        report.StripeQueried.Should().BeFalse();
+        report.Orphans.Should().BeEmpty(); // recorded payment is NOT false-flagged as an orphan
+        report.Rows.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task RecordMissingStripePaymentsAsync_records_only_paid_matched_unrecorded()
+    {
+        var missingOrder = Guid.NewGuid();
+        var recordedOrder = Guid.NewGuid();
+        var teamOrder = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+
+        _stripe.ListStoreCheckoutSessionsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreCheckoutSessionData>
+        {
+            Session("cs_missing", missingOrder, "pi_missing", 1800m, "paid"),
+            Session("cs_recorded", recordedOrder, "pi_recorded", 100m, "paid"),  // already recorded → skip
+            Session("cs_team", teamOrder, "pi_team", 50m, "paid"),               // non-billable → skip
+            Session("cs_unpaid", missingOrder, "pi_unpaid", 200m, "unpaid"),     // not paid → skip
+        });
+        _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>
+        {
+            new("pi_recorded", recordedOrder, 100m, Instant.FromUtc(2026, 5, 1, 0, 0)),
+        });
+        _repo.GetOrderByIdAsync(missingOrder, Arg.Any<CancellationToken>()).Returns(CampOrder(missingOrder));
+        _repo.GetOrderByIdAsync(teamOrder, Arg.Any<CancellationToken>()).Returns(TeamOrder(teamOrder));
+
+        var result = await _service.RecordMissingStripePaymentsAsync(actor);
+
+        result.RecordedCount.Should().Be(1);
+        result.TotalEur.Should().Be(1800m);
+        await _repo.Received(1).AddPaymentAsync(
+            Arg.Is<StorePayment>(p =>
+                p.OrderId == missingOrder &&
+                p.StripePaymentIntentId == "pi_missing" &&
+                p.AmountEur == 1800m &&
+                p.Method == StorePaymentMethod.Stripe),
+            Arg.Any<CancellationToken>());
+        await _repo.DidNotReceive().AddPaymentAsync(
+            Arg.Is<StorePayment>(p => p.StripePaymentIntentId == "pi_team" || p.StripePaymentIntentId == "pi_unpaid" || p.StripePaymentIntentId == "pi_recorded"),
+            Arg.Any<CancellationToken>());
+        await _audit.Received(1).LogAsync(
+            AuditAction.StorePaymentsReconciled, "Store", Guid.Empty,
+            Arg.Any<string>(), actor, Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task RecordMissingStripePaymentsAsync_skips_unmatched_order_and_writes_no_audit()
+    {
+        var ghostOrder = Guid.NewGuid();
+        _stripe.ListStoreCheckoutSessionsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreCheckoutSessionData>
+        {
+            Session("cs_ghost", ghostOrder, "pi_ghost", 300m, "paid"),
+        });
+        _repo.GetRecordedStripePaymentsAsync(Arg.Any<CancellationToken>()).Returns(new List<StoreRecordedStripePayment>());
+        _repo.GetOrderByIdAsync(ghostOrder, Arg.Any<CancellationToken>()).Returns((StoreOrder?)null); // deleted/unknown
+
+        var result = await _service.RecordMissingStripePaymentsAsync(Guid.NewGuid());
+
+        result.RecordedCount.Should().Be(0);
+        await _repo.DidNotReceive().AddPaymentAsync(Arg.Any<StorePayment>(), Arg.Any<CancellationToken>());
+        await _audit.DidNotReceive().LogAsync(
+            AuditAction.StorePaymentsReconciled, Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+}


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `f852b62eb` feat(store): Stripe payment reconciliation admin screen (peterdrier/Humans#883)

A standing Stripe payment reconciliation screen under the Store admin nav (`/Store/Admin/Payments`): webhook/checkout health banner, every Store Checkout Session matched to its order with a status (Recorded / Missing / Unmatched / Unpaid), and a "record missing payments" action that pulls real amounts + PaymentIntent ids from Stripe via the existing idempotent path. Recovers payments the webhook missed (the unset `STRIPE_STORE_WEBHOOK_SECRET` 503 case). No EF/schema change.

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly (none in this batch)