### PR TITLE
Promote QA → production (1 commit)

### DIFF
--- a/src/Humans.Domain/Entities/Profile.cs
+++ b/src/Humans.Domain/Entities/Profile.cs
@@ -94,7 +94,7 @@ public class Profile
     /// <summary>Obsolete — pictures live on the file share. DB column retained for prod-soak drop. See #702.</summary>
     [PersonalData]
     [Obsolete("Pictures live on the file share; this column is unused. The DB column stays until a follow-up PR after prod soak per memory/architecture/no-drops-until-prod-verified.md.", DiagnosticId = "HUM_PROFILE_PICTUREDATA", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/702")]
-    [Architecture.ExpiresOn("2026-06-01", reason: "Issue #702 — DB→FS migration complete (PR #576); column reserved for prod-soak drop.")]
+    [Architecture.ExpiresOn("2026-09-01", reason: "Issue #702 — DB→FS migration complete (PR #576); column reserved for prod-soak drop.")]
     public byte[]? ProfilePictureData { get; set; }
 
     /// <summary>Doubles as the "has picture?" predicate; supplies the file extension.</summary>

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -56,7 +56,7 @@ public class User : IdentityUser<Guid>
     /// <inheritdoc />
 #pragma warning disable CS0809 // Obsolete override of non-obsolete base — intentional.
     [Obsolete("NormalizedEmail is shadow-populated by Identity. Use User.Email or IUserEmailService for canonical email lookup.", DiagnosticId = "HUM_USER_NORMALIZEDEMAIL", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/635")]
-    [Architecture.ExpiresOn("2026-06-01", reason: "Issue #635 — Identity shadow column; application reads should go through User.Email / IUserEmailService.")]
+    [Architecture.ExpiresOn("2026-09-01", reason: "Issue #635 — Identity shadow column; application reads should go through User.Email / IUserEmailService.")]
     public override string? NormalizedEmail
     {
         get => Email?.ToUpperInvariant();

--- a/src/Humans.Web/Controllers/OnboardingWidgetController.cs
+++ b/src/Humans.Web/Controllers/OnboardingWidgetController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.HumanLifecycle;
@@ -53,10 +54,20 @@ public class OnboardingWidgetController(
     }
 
     [HttpGet]
-    public IActionResult Names()
+    public async Task<IActionResult> Names(CancellationToken ct)
     {
-        // Force explicit entry — OAuth-supplied names are unverified.
-        return View(new NamesViewModel());
+        // Prefill from the user's OWN saved profile — never from OAuth claims, which
+        // are unverified (see Names_Get_ReturnsBlankViewModel_IgnoringOauthClaims).
+        // Bare/Stub accounts have blank names, so a genuinely new user still gets an
+        // empty form; a returning or data-drifted user sees what's actually on file
+        // instead of a blank form that looks like their earlier entry never saved.
+        var profile = (await _userService.GetUserInfoAsync(CurrentUserId(), ct))?.Profile;
+        return View(new NamesViewModel
+        {
+            BurnerName = profile?.BurnerName ?? string.Empty,
+            FirstName = profile?.FirstName ?? string.Empty,
+            LastName = profile?.LastName ?? string.Empty,
+        });
     }
 
     [HttpPost]
@@ -67,28 +78,50 @@ public class OnboardingWidgetController(
             return View(vm);
 
         var userId = CurrentUserId();
+        var info = await _userService.GetUserInfoAsync(userId, ct);
 
-        // SaveProfileAsync does a full-field overwrite — bail if past Names step or we'd wipe data.
-        var currentStep = await state.GetCurrentStepAsync(userId, ct);
-        if (currentStep != OnboardingWidgetStep.Names)
+        // Skip the save for an already-named user (stale page / back-button re-POST).
+        // In-section check against the user's OWN profile — the name save must NOT be
+        // gated by any cross-section consent/step check, or a vacuously-"complete"
+        // consent state (no required legal docs) bounces a bare account into an endless
+        // Names redirect loop.
+        if (info is not null && info.HasRequiredNameFields)
             return RedirectToAction(nameof(Index));
 
-        var request = new ProfileSaveRequest(
-            BurnerName: vm.BurnerName,
-            FirstName: vm.FirstName,
-            LastName: vm.LastName,
-            City: null, CountryCode: null, Latitude: null, Longitude: null, PlaceId: null,
-            Bio: null, Pronouns: null, ContributionInterests: null, BoardNotes: null,
-            BirthdayMonth: null, BirthdayDay: null,
-            EmergencyContactName: null, EmergencyContactPhone: null, EmergencyContactRelationship: null,
-            NoPriorBurnExperience: false,
-            ProfilePictureData: null, ProfilePictureContentType: null, RemoveProfilePicture: false);
+        // SaveProfileAsync is a full-field overwrite but the form only carries the three
+        // names, so preserve every other field from the current profile. A data-drifted
+        // profile (City/Bio/emergency contact on file but a blank name) must keep that
+        // data when its name is fixed here.
+        var request = BuildNameSaveRequest(vm, info?.Profile);
 
         await profileEditorService.SaveProfileAsync(userId, vm.BurnerName, request, ct);
         await onboardingService.SetConsentCheckPendingIfEligibleAsync(userId, ct);
 
         return RedirectToAction(nameof(Shifts));
     }
+
+    // Builds a profile-save request that sets the three name fields from the form while
+    // carrying forward every other field from the existing profile (null for a brand-new
+    // profileless account — nothing to preserve). Picture is left as a no-op mutation
+    // (null data + RemoveProfilePicture:false) so SaveProfileAsync keeps the current one.
+    private static ProfileSaveRequest BuildNameSaveRequest(NamesViewModel vm, ProfileInfo? existing) =>
+        new(
+            BurnerName: vm.BurnerName,
+            FirstName: vm.FirstName,
+            LastName: vm.LastName,
+            City: existing?.City, CountryCode: existing?.CountryCode,
+            Latitude: existing?.Latitude, Longitude: existing?.Longitude, PlaceId: existing?.PlaceId,
+            Bio: existing?.Bio, Pronouns: existing?.Pronouns,
+            ContributionInterests: existing?.ContributionInterests, BoardNotes: existing?.BoardNotes,
+            BirthdayMonth: existing?.BirthdayMonth, BirthdayDay: existing?.BirthdayDay,
+            EmergencyContactName: existing?.EmergencyContactName,
+            EmergencyContactPhone: existing?.EmergencyContactPhone,
+            EmergencyContactRelationship: existing?.EmergencyContactRelationship,
+            NoPriorBurnExperience: existing?.NoPriorBurnExperience ?? false,
+            ProfilePictureData: null, ProfilePictureContentType: null, RemoveProfilePicture: false,
+            DietaryPreference: existing?.DietaryPreference,
+            Allergies: existing?.Allergies.ToList(),
+            AllergyOtherText: existing?.AllergyOtherText);
 
     [HttpGet]
     public async Task<IActionResult> Shifts(string? priority = null, CancellationToken ct = default)

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.HumanLifecycle;
@@ -7,12 +8,14 @@ using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Web.Controllers;
 using Humans.Web.Models.OnboardingWidget;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
+using NodaTime;
 using NSubstitute;
 using Xunit;
 
@@ -59,12 +62,13 @@ public class OnboardingWidgetControllerNamesTests
     }
 
     [HumansFact]
-    public void Names_Get_ReturnsBlankViewModel_IgnoringOauthClaims()
+    public async Task Names_Get_ReturnsBlankViewModel_IgnoringOauthClaims()
     {
         // OAuth-supplied legal names are unverified — provider-set GivenName /
         // Surname must NOT prefill the form. Reports of users blowing through
         // the Names step with whatever Google handed us are the regression
-        // this guards.
+        // this guards. The prefill reads the saved profile (none here → blank),
+        // never the claims.
         var userId = Guid.NewGuid();
         var ctrl = new OnboardingWidgetController(
             _userService, _state, _profileEditor, _signups, _shiftMgmt, _shiftView, _consents, _onboardingService, _humanLifecycle, _localizer);
@@ -79,13 +83,32 @@ public class OnboardingWidgetControllerNamesTests
         };
         ctrl.ControllerContext = new ControllerContext { HttpContext = http };
 
-        var result = ctrl.Names();
+        var result = await ctrl.Names(CancellationToken.None);
 
         var view = Assert.IsType<ViewResult>(result);
         var vm = Assert.IsType<NamesViewModel>(view.Model);
         Assert.Equal(string.Empty, vm.BurnerName);
         Assert.Equal(string.Empty, vm.FirstName);
         Assert.Equal(string.Empty, vm.LastName);
+    }
+
+    [HumansFact]
+    public async Task Names_Get_PrefillsFromSavedProfile()
+    {
+        // A returning or data-drifted user must see their saved name fields, not a
+        // blank form that looks like their earlier entry never persisted.
+        var userId = Guid.NewGuid();
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(MakeUserInfo(userId, burner: "Saved", first: "Jean", last: "Dupont"));
+        var ctrl = BuildSut(userId);
+
+        var result = await ctrl.Names(CancellationToken.None);
+
+        var view = Assert.IsType<ViewResult>(result);
+        var vm = Assert.IsType<NamesViewModel>(view.Model);
+        Assert.Equal("Saved", vm.BurnerName);
+        Assert.Equal("Jean", vm.FirstName);
+        Assert.Equal("Dupont", vm.LastName);
     }
 
     [HumansFact]
@@ -118,14 +141,17 @@ public class OnboardingWidgetControllerNamesTests
     }
 
     [HumansFact]
-    public async Task Names_Post_RedirectsToIndex_AndDoesNotSave_WhenAlreadyPastNamesStep()
+    public async Task Names_Post_RedirectsToIndex_AndDoesNotSave_WhenUserAlreadyNamed()
     {
         // Names POST is reachable directly. SaveProfileAsync does a full
         // overwrite, so re-posting with a Names-only viewmodel would clobber
-        // existing City/Bio/EmergencyContact/etc. Guard: bail out when the
-        // user is past the Names step.
+        // existing City/Bio/EmergencyContact/etc. Guard: bail out when the user
+        // already has their name on file — an in-section check against their own
+        // profile, NOT the consent/step state.
         var userId = Guid.NewGuid();
-        var ctrl = BuildSut(userId, currentStep: OnboardingWidgetStep.Shifts);
+        var ctrl = BuildSut(userId);
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(MakeUserInfo(userId, burner: "Existing", first: "Already", last: "Named"));
         var vm = new NamesViewModel { BurnerName = "Burner1", FirstName = "First", LastName = "Last" };
 
         var result = await ctrl.Names(vm, CancellationToken.None);
@@ -135,6 +161,96 @@ public class OnboardingWidgetControllerNamesTests
 
         await _profileEditor.DidNotReceiveWithAnyArgs().SaveProfileAsync(
             Guid.Empty, null!, null!, CancellationToken.None);
+    }
+
+    [HumansFact]
+    public async Task Names_Post_SavesProfile_EvenWhenConsentsVacuouslyComplete()
+    {
+        // Regression for the OnboardingWidget/Names redirect loop: when the
+        // Volunteers team has no required+effective legal docs the dispatcher's
+        // step resolves to Complete vacuously. The name save must NOT be gated by
+        // that cross-section state — a bare account must still be able to save its
+        // name and move on, or it loops on Names forever (Names POST → Index →
+        // Home → NameRequiredFilter → Names, save skipped, nothing logged).
+        var userId = Guid.NewGuid();
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(MakeUserInfo(userId, burner: "", first: "", last: "")); // bare account, no name yet
+        // Step resolves to Complete (vacuous consents) — the POST must ignore it.
+        var ctrl = BuildSut(userId, currentStep: OnboardingWidgetStep.Complete);
+        var vm = new NamesViewModel { BurnerName = "Burner1", FirstName = "First", LastName = "Last" };
+
+        var result = await ctrl.Names(vm, CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(OnboardingWidgetController.Shifts), redirect.ActionName);
+
+        await _profileEditor.Received(1).SaveProfileAsync(
+            userId,
+            "Burner1",
+            Arg.Is<ProfileSaveRequest>(r =>
+                r.FirstName == "First" && r.LastName == "Last" && r.BurnerName == "Burner1"),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static UserInfo MakeUserInfo(
+        Guid userId, string burner, string first, string last,
+        string? city = null, string? bio = null) =>
+        UserInfo.Create(
+            user: new User
+            {
+                Id = userId,
+                DisplayName = burner,
+                PreferredLanguage = "en",
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                GoogleEmailStatus = GoogleEmailStatus.Unknown,
+            },
+            userEmails: [],
+            eventParticipations: [],
+            externalLogins: [],
+            profile: new Profile
+            {
+                UserId = userId,
+                BurnerName = burner,
+                FirstName = first,
+                LastName = last,
+                City = city,
+                Bio = bio,
+                State = string.IsNullOrWhiteSpace(burner) || string.IsNullOrWhiteSpace(first) || string.IsNullOrWhiteSpace(last)
+                    ? ProfileState.Stub
+                    : ProfileState.Active,
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            },
+            contactFields: [],
+            profileLanguages: [],
+            volunteerHistory: [],
+            communicationPreferences: []);
+
+    [HumansFact]
+    public async Task Names_Post_PreservesExistingProfileFields_WhenFixingDriftedName()
+    {
+        // A data-drifted profile (City/Bio on file but a blank required name) reaches
+        // this POST via NameRequiredFilter. SaveProfileAsync is a full-field overwrite,
+        // so fixing the name must carry the existing City/Bio forward, not null them.
+        var userId = Guid.NewGuid();
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(MakeUserInfo(userId, burner: "Drifted", first: "Has", last: "", city: "Madrid", bio: "existing bio"));
+        var ctrl = BuildSut(userId);
+        var vm = new NamesViewModel { BurnerName = "Drifted", FirstName = "Has", LastName = "NowSet" };
+
+        var result = await ctrl.Names(vm, CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(OnboardingWidgetController.Shifts), redirect.ActionName);
+
+        await _profileEditor.Received(1).SaveProfileAsync(
+            userId,
+            "Drifted",
+            Arg.Is<ProfileSaveRequest>(r =>
+                r.LastName == "NowSet" &&
+                r.City == "Madrid" &&
+                r.Bio == "existing bio"),
+            Arg.Any<CancellationToken>());
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `fba227ebb` fix(onboarding): don't gate the Names save on cross-section consent state (peterdrier/Humans#908)

Fixes the bare-account onboarding redirect loop on `/OnboardingWidget/Names` (the name save was gated on a cross-section consent/step check that resolved vacuously to `Complete` when no required legal docs were configured, skipping the save forever). The name save is now gated only by an in-section name-presence check, the GET form prefills from the user's saved profile, and the POST preserves non-name profile fields. Also bumps two HUM0011 `ExpiresOn` dates (`Profile.ProfilePictureData` / `User.NormalizedEmail`) from 2026-06-01 to 2026-09-01.

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly