### PR TITLE
Promote QA → production (12 commits)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
@@ -64,7 +64,7 @@ jobs:
     outputs:
       migrations: ${{ steps.filter.outputs.migrations }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -94,7 +94,7 @@ jobs:
     runs-on: [self-hosted, devbox]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -184,7 +184,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -112,7 +112,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -39,6 +39,10 @@ name: claude-review
 #   On-demand: any OWNER/MEMBER/COLLABORATOR posting a comment starting with
 #              `/review` on the PR triggers a fresh run. The docs-only skip
 #              does NOT apply to comment-triggered runs (explicit ask wins).
+#   Dependabot: PRs opened by dependabot[bot] are skipped (actor guard in the
+#               `if:` below). Dependabot-triggered runs use the isolated
+#               Dependabot secret store, so CLAUDE_CODE_OAUTH_TOKEN is empty
+#               and the action fails fast — a spurious red check on every bump.
 #
 # Concurrency: per-PR group with cancel-in-progress. A new push or `/review`
 # during an in-flight review cancels the stale run instead of stacking.
@@ -91,7 +95,9 @@ jobs:
         && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
                     github.event.comment.author_association))
       ||
-      (github.event.pull_request.draft == false && (
+      (github.event.pull_request.draft == false
+        && github.actor != 'dependabot[bot]'
+        && (
         (github.event_name == 'pull_request'
           && github.repository == 'peterdrier/Humans'
           && github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/e2e-qa.yml
+++ b/.github/workflows/e2e-qa.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: tests/e2e
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/localization-sweep.yml
+++ b/.github/workflows/localization-sweep.yml
@@ -31,7 +31,7 @@ jobs:
   sweep:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/pr-surface-report.yml
+++ b/.github/workflows/pr-surface-report.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <!-- User-Agent parsing for /Admin/ClientStats (code-based, no regex DB; library telemetry left off) -->
     <PackageVersion Include="MyCSharp.HttpUserAgentParser" Version="3.1.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- AI/LLM -->
-    <PackageVersion Include="Anthropic" Version="12.29.0" />
+    <PackageVersion Include="Anthropic" Version="12.30.0" />
     <!-- Core Framework -->
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
     <!-- CSV — ALL CSV reading/writing goes through CsvHelper (memory/code/csv-use-csvhelper.md). Exact package name "CsvHelper" only; "CsvHelper.Excel.Core.Net" is known malware. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,7 +78,7 @@
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <!-- Analyzers -->
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.101" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.108" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <!-- Testing -->
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
     <PackageVersion Include="Ical.Net" Version="5.2.2" />
-    <PackageVersion Include="Markdig" Version="1.3.0" />
+    <PackageVersion Include="Markdig" Version="1.3.2" />
     <!-- User-Agent parsing for /Admin/ClientStats (code-based, no regex DB; library telemetry left off) -->
     <PackageVersion Include="MyCSharp.HttpUserAgentParser" Version="3.1.6" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="Octokit" Version="14.0.0" />
     <!-- Google Workspace APIs -->
     <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.75.0.4168" />
-    <PackageVersion Include="Google.Apis.CloudIdentity.v1" Version="1.75.0.4169" />
+    <PackageVersion Include="Google.Apis.CloudIdentity.v1" Version="1.75.0.4176" />
     <PackageVersion Include="Google.Apis.Drive.v3" Version="1.74.0.4135" />
     <PackageVersion Include="Google.Apis.DriveActivity.v2" Version="1.74.0.3880" />
     <PackageVersion Include="Google.Apis.Groupssettings.v1" Version="1.74.0.2721" />

--- a/src/Humans.Application/DTOs/Shifts/ShiftUserView.cs
+++ b/src/Humans.Application/DTOs/Shifts/ShiftUserView.cs
@@ -35,6 +35,15 @@ public sealed record ShiftUserView(
         s.Status is SignupStatus.Pending or SignupStatus.Confirmed);
 
     /// <summary>
+    /// Number of active-state signups (<see cref="SignupStatus.Pending"/> or
+    /// <see cref="SignupStatus.Confirmed"/>) the user holds in the active event.
+    /// Refused / Bailed / Cancelled / NoShow signups don't count. Same
+    /// "active commitment" rule as <see cref="HasShift"/>, expressed as a count.
+    /// </summary>
+    public int ActiveSignupCount => Signups.Count(s =>
+        s.Status is SignupStatus.Pending or SignupStatus.Confirmed);
+
+    /// <summary>
     /// True when the user has at least one active signup (Pending/Confirmed) on
     /// a shift classified into the given <paramref name="period"/>. Each shift's
     /// period is derived from its <see cref="Shift.DayOffset"/> against the

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -10,6 +10,7 @@ using NodaTime;
 using Humans.Application;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.CityPlanning;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Camps;
 using Humans.Web.Models.Camp;
@@ -23,6 +24,7 @@ public class CampController(
     ICampContactService campContactService,
     ICampRoleService campRoleService,
     ICityPlanningServiceRead cityPlanningService,
+    IShiftView shiftView,
     IUserServiceRead userService,
     IAuthorizationService authorizationService,
     IClock clock,
@@ -435,6 +437,13 @@ public class CampController(
             .ToList();
         if (memberUserIds.Count > 0)
         {
+            var shiftViews = await shiftView.GetUsersAsync(
+                viewModel.ActiveMembers.Select(m => m.UserId), ct);
+            foreach (var member in viewModel.ActiveMembers)
+            {
+                member.EventShiftSignupCount = shiftViews[member.UserId].ActiveSignupCount;
+            }
+
             var memberUsers = await _userService.GetUserInfosAsync(memberUserIds, ct);
             string MemberName(CampMemberRowViewModel m) =>
                 memberUsers.TryGetValue(m.UserId, out var u) ? u.BurnerName : "";

--- a/src/Humans.Web/Controllers/EventsController.cs
+++ b/src/Humans.Web/Controllers/EventsController.cs
@@ -553,45 +553,6 @@ public class EventsController(
         return View(model);
     }
 
-    [HttpPost("Browse/Favourite/{eventId:guid}")]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> ToggleFavourite(Guid eventId, int? day, [FromQuery(Name = "days")] int[]? days, Guid? categoryId, Guid? venueId, string? q, bool favouritesOnly = false)
-    {
-        var user = await GetCurrentUserInfoAsync();
-        if (user == null) return Challenge();
-
-        await guide.ToggleFavouriteAsync(user.Id, eventId, day);
-        return RedirectToAction(nameof(Browse), null, new { days, categoryId, venueId, q, favouritesOnly }, $"event-{eventId}");
-    }
-
-    [HttpPost("Schedule/Unfavourite/{eventId:guid}")]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Unfavourite(Guid eventId, int? day)
-    {
-        var user = await GetCurrentUserInfoAsync();
-        if (user == null) return Challenge();
-
-        if (await guide.RemoveFavouriteAsync(user.Id, eventId, day))
-            SetSuccess("Event removed from your schedule.");
-
-        return RedirectToAction(nameof(Schedule));
-    }
-
-    // Favourite toggle for the events card (camp detail page, profile page).
-    // Bounces back to the host page via returnUrl, falling back to Browse when
-    // the URL is missing or not local.
-    [HttpPost("Card/Favourite/{eventId:guid}")]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> ToggleCardFavourite(Guid eventId, string? returnUrl)
-    {
-        var user = await GetCurrentUserInfoAsync();
-        if (user == null) return Challenge();
-
-        // The card lists one row per event, so its heart is whole-event.
-        await guide.ToggleFavouriteAsync(user.Id, eventId, null);
-        return Url.IsLocalUrl(returnUrl) ? Redirect(returnUrl!) : RedirectToAction(nameof(Browse));
-    }
-
     private bool IsSubmissionOpen(EventGuideSettingsView? settings) =>
         settings?.IsSubmissionOpenAt(clock.GetCurrentInstant()) ?? false;
 

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -188,6 +188,35 @@ public sealed class MailerAdminController(
         return RedirectToAction(nameof(Index));
     }
 
+    [HttpPost("SyncAll")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SyncAll(CancellationToken ct)
+    {
+        try
+        {
+            var actor = await GetCurrentUserInfoAsync();
+            var results = await audienceSync.SyncAllAsync(actor?.Id, ct);
+
+            var created = results.Sum(r => r.Created);
+            var assigned = results.Sum(r => r.Assigned);
+            var unassigned = results.Sum(r => r.Unassigned);
+            var errors = results.Sum(r => r.Errors);
+            var failed = _audiences.Count - results.Count;
+
+            var banner = $"Push All: {results.Count}/{_audiences.Count} audiences synced — " +
+                $"{created} created, {assigned} newly assigned, {unassigned} unassigned, {errors} errors.";
+            if (failed > 0) banner += $" {failed} audience(s) failed — see logs.";
+            TempData["Banner"] = banner;
+        }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // HttpClient timeout surfaces as TaskCanceledException when caller didn't cancel.
+            logger.LogWarning("Push All timed out");
+            TempData["Banner"] = "Push All timed out. Some audiences may have synced; try again shortly.";
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
     [HttpPost("Refresh")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Refresh(CancellationToken ct)

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -190,7 +190,22 @@ public class CampMemberRowViewModel
     public NodaTime.Instant RequestedAt { get; set; }
     public NodaTime.Instant? ConfirmedAt { get; set; }
     public bool HasEarlyEntry { get; set; }
+    public int EventShiftSignupCount { get; set; }
     public CampMemberStatus Status { get; set; }
+
+    public string EventShiftSignupDisplay => EventShiftSignupCount >= 5
+        ? "5+"
+        : EventShiftSignupCount.ToString(CultureInfo.InvariantCulture);
+
+    public string EventShiftSignupBadgeClass => EventShiftSignupCount switch
+    {
+        <= 0 => "bg-danger",
+        1 => "bg-success-subtle text-success-emphasis border border-success-subtle",
+        2 => "bg-success bg-opacity-25 text-success-emphasis border border-success-subtle",
+        3 => "bg-success bg-opacity-50 text-dark border border-success",
+        4 => "bg-success bg-opacity-75 text-white border border-success",
+        _ => "bg-success text-white"
+    };
 }
 
 public class CampImageViewModel

--- a/src/Humans.Web/Models/Events/EventsCardViewModel.cs
+++ b/src/Humans.Web/Models/Events/EventsCardViewModel.cs
@@ -7,9 +7,6 @@ namespace Humans.Web.Models.Events;
 /// </summary>
 public class EventsCardViewModel
 {
-    /// <summary>Local URL of the host page — the favourite toggle redirects back here.</summary>
-    public string ReturnUrl { get; set; } = string.Empty;
-
     public List<EventsCardRow> Rows { get; set; } = [];
 }
 

--- a/src/Humans.Web/Models/Events/FavouriteButtonModel.cs
+++ b/src/Humans.Web/Models/Events/FavouriteButtonModel.cs
@@ -1,0 +1,27 @@
+namespace Humans.Web.Models.Events;
+
+/// <summary>
+/// Drives the instant favourite heart shared by Browse, the events card, and
+/// My Schedule. Single source of the JS contract rendered by
+/// <c>_FavouriteButton.cshtml</c> and handled by <c>wwwroot/js/site.js</c>:
+/// the button toggles the favourite through the JSON API without reloading the
+/// page, so the user's filters and scroll position survive.
+/// </summary>
+public sealed class FavouriteButtonModel
+{
+    public required Guid EventId { get; init; }
+
+    /// <summary>Day offset the heart toggles; null = whole-event favourite.</summary>
+    public int? DayOffset { get; init; }
+
+    public bool IsFavourited { get; init; }
+
+    /// <summary>
+    /// My Schedule: remove the row on un-favourite (after <see cref="ConfirmMessage"/>)
+    /// instead of flipping the heart in place. Renders the broken-heart icon.
+    /// </summary>
+    public bool RemoveRow { get; init; }
+
+    /// <summary>Optional confirm prompt shown before acting (My Schedule removal).</summary>
+    public string? ConfirmMessage { get; init; }
+}

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -6502,11 +6502,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Benvingut/da — comencem pel teu nom</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Crític</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Important</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>L'esdeveniment només té un {0}% dels torns "crítics" coberts. Si no s'omplen, l'esdeveniment podria cancel·lar-se, ja que no seria viable ni segur tirar-lo endavant.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si en pots omplir alguns, o pots venir abans de l'esdeveniment o quedar-te al desmuntatge, prioritza'ls a l'hora de triar els teus torns.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANT:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Només està cobert el {0}% dels torns "crítics". Ajuda'ns a fer possible l'esdeveniment cobrint-ne alguns quan puguis.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si pots venir abans per al muntatge o quedar-te al desmuntatge, aquests són els torns més difícils de cobrir — si us plau, prioritza'ls a l'hora de triar els teus torns.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Les inscripcions de muntatge estan tancades — ja som al lloc. Si us plau, centra't en els torns de l'esdeveniment i de desmuntatge.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>Et necessitem!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>També hi ha {0} torns "importants" oberts.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hi ha {0} torns "importants" oberts. Si pots venir abans de l'esdeveniment o quedar-te al desmuntatge, prioritza'ls.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hi ha {0} torns "importants" oberts. Si pots venir abans per al muntatge o quedar-te al desmuntatge, si us plau, prioritza'ls.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Hi ha {0} torns "importants" oberts — si us plau, centra't en els torns de l'esdeveniment i de desmuntatge.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Ara mateix no hi ha cap esdeveniment actiu. Pots acabar la incorporació sense triar cap torn.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>De moment no hi ha torns crítics oberts — prova amb Importants o Tots.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>De moment no hi ha torns importants oberts — prova amb Tots.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -3055,6 +3055,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Admin de barris</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Inscripcions a torns actives per a l'esdeveniment actual (pendents o confirmades)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} inscripcions a torns actives</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>Aquest camp s’ha anomenat mai "Swiss Camp"?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -6502,11 +6502,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Willkommen — fangen wir mit deinem Namen an</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Kritisch</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Wichtig</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Bei der Veranstaltung sind nur {0}% der „kritischen“ Schichten besetzt. Wenn diese nicht besetzt werden, könnte die Veranstaltung abgesagt werden, da es nicht möglich oder sicher wäre, sie durchzuführen.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Wenn du einige davon übernehmen kannst oder vor der Veranstaltung kommen bzw. zum Abbau bleiben kannst, priorisiere diese bitte bei der Auswahl deiner Schichten.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>WICHTIG:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Nur {0}% der „kritischen“ Schichten sind besetzt. Hilf uns, die Veranstaltung möglich zu machen, indem du ein paar übernimmst, wo du kannst.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Wenn du früh zum Aufbau kommen oder zum Abbau bleiben kannst, sind das die am schwersten zu besetzenden Schichten — bitte priorisiere sie bei der Auswahl deiner Schichten.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Aufbau-Anmeldungen sind geschlossen — wir sind bereits vor Ort. Bitte konzentriere dich auf Schichten während der Veranstaltung und beim Abbau.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>Wir brauchen dich!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>Es sind außerdem {0} „wichtige“ Schichten offen.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Es sind {0} „wichtige“ Schichten offen. Wenn du vor der Veranstaltung kommen oder zum Abbau bleiben kannst, priorisiere diese bitte.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Es sind {0} „wichtige“ Schichten offen. Wenn du früh zum Aufbau kommen oder zum Abbau bleiben kannst, priorisiere diese bitte.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Es sind {0} „wichtige“ Schichten offen — bitte konzentriere dich auf Schichten während der Veranstaltung und beim Abbau.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Derzeit keine aktive Veranstaltung. Du kannst das Onboarding abschließen, ohne eine Schicht auszuwählen.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Derzeit keine kritischen Schichten offen — probiere Wichtig oder Alle.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Derzeit keine wichtigen Schichten offen — probiere Alle.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -3055,6 +3055,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Barrios Admin</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Aktive Schichtanmeldungen für das aktuelle Event (ausstehend oder bestätigt)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} aktive Schichtanmeldungen</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>Wurde dieses Camp jemals "Swiss Camp" genannt?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -6539,11 +6539,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Bienvenido — empecemos por tu nombre</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Crítico</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Importante</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>El evento solo tiene cubierto el {0}% de los turnos "críticos". Si no se cubren, el evento podría cancelarse, ya que no sería viable ni seguro llevarlo a cabo.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si puedes cubrir alguno de esos, o puedes venir antes del evento o quedarte al desmontaje, por favor priorízalos al elegir tus turnos.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANTE:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Solo está cubierto el {0}% de los turnos "críticos". Ayúdanos a hacer posible el evento cubriendo algunos cuando puedas.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si puedes venir antes para el montaje o quedarte al desmontaje, esos son los turnos más difíciles de cubrir — por favor, priorízalos al elegir tus turnos.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Las inscripciones de montaje están cerradas — ya estamos en el sitio. Por favor, céntrate en los turnos del evento y de desmontaje.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>¡Te necesitamos!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>También hay {0} turnos "importantes" abiertos.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hay {0} turnos "importantes" abiertos. Si puedes venir antes del evento o quedarte al desmontaje, por favor priorízalos.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Hay {0} turnos "importantes" abiertos. Si puedes venir antes para el montaje o quedarte al desmontaje, por favor, priorízalos.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Hay {0} turnos "importantes" abiertos — por favor, céntrate en los turnos del evento y de desmontaje.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>No hay ningún evento activo ahora mismo. Puedes terminar la incorporación sin elegir un turno.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>No hay turnos críticos abiertos en este momento — prueba con Importantes o Todos.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>No hay turnos importantes abiertos en este momento — prueba con Todos.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -3079,6 +3079,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Barrios Admin</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Inscripciones a turnos activas para el evento actual (pendientes o confirmadas)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} inscripciones a turnos activas</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>¿Este camp se ha llamado alguna vez "Swiss Camp"?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -6502,11 +6502,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Bienvenue — commençons par votre nom</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Critique</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Important</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>L'événement n'a que {0} % des quarts « critiques » pourvus. S'ils ne sont pas pourvus, l'événement pourrait être annulé car il ne serait pas viable ni sûr de l'organiser.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si vous pouvez en pourvoir certains, ou si vous pouvez venir avant l'événement ou rester pour le démontage, veuillez les prioriser lors du choix de vos quarts.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANT :</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Seuls {0} % des quarts « critiques » sont pourvus. Aidez-nous à rendre l'événement possible en en prenant quelques-uns si vous le pouvez.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Si vous pouvez venir tôt pour le montage ou rester pour le démontage, ce sont les quarts les plus difficiles à pourvoir — veuillez les prioriser lors du choix de vos quarts.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Les inscriptions au montage sont closes — nous sommes déjà sur place. Veuillez vous concentrer sur les quarts pendant l'événement et de démontage.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>Nous avons besoin de vous !</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>Il y a également {0} quarts « importants » à pourvoir.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Il y a {0} quarts « importants » à pourvoir. Si vous pouvez venir avant l'événement ou rester pour le démontage, veuillez les prioriser.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Il y a {0} quarts « importants » à pourvoir. Si vous pouvez venir tôt pour le montage ou rester pour le démontage, veuillez les prioriser.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Il y a {0} quarts « importants » à pourvoir — veuillez vous concentrer sur les quarts pendant l'événement et de démontage.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Aucun événement actif pour le moment. Vous pouvez terminer l'intégration sans choisir de quart.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Aucun quart critique à pourvoir pour le moment — essayez Important ou Tous.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Aucun quart important à pourvoir pour le moment — essayez Tous.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -3055,6 +3055,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Barrios Admin</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Inscriptions aux créneaux actives pour l'événement en cours (en attente ou confirmées)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} inscriptions aux créneaux actives</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>Ce camp a-t-il déjà été appelé "Swiss Camp" ?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -6502,11 +6502,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Benvenuto — iniziamo dal tuo nome</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Critico</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Importante</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>L'evento ha riempito solo il {0}% dei turni "critici". Se non vengono riempiti, l'evento potrebbe essere annullato perché non sarebbe sostenibile o sicuro organizzarlo.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Se riesci a riempirne alcuni, o se puoi venire prima dell'evento o restare per lo smontaggio, dai priorità a questi quando scegli i tuoi turni.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANTE:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>È coperto solo il {0}% dei turni "critici". Aiutaci a rendere possibile l'evento coprendone alcuni quando puoi.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>Se puoi venire prima per il montaggio o restare per lo smontaggio, sono i turni più difficili da coprire — dai loro priorità quando scegli i tuoi turni.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Le iscrizioni al montaggio sono chiuse — siamo già sul posto. Concentrati sui turni durante l'evento e di smontaggio.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>Abbiamo bisogno di te!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>Ci sono anche {0} turni "importanti" aperti.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Ci sono {0} turni "importanti" aperti. Se puoi venire prima dell'evento o restare per lo smontaggio, dai priorità a questi.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>Ci sono {0} turni "importanti" aperti. Se puoi venire prima per il montaggio o restare per lo smontaggio, dai loro priorità.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>Ci sono {0} turni "importanti" aperti — concentrati sui turni durante l'evento e di smontaggio.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>Nessun evento attivo al momento. Puoi completare l'onboarding senza scegliere un turno.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>Nessun turno critico aperto al momento — prova Importanti o Tutti.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>Nessun turno importante aperto al momento — prova Tutti.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -3055,6 +3055,8 @@
   <data name="Camp_AdminTitle" xml:space="preserve">
     <value>Barrios Admin</value>
   </data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Iscrizioni ai turni attive per l'evento corrente (in attesa o confermate)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} iscrizioni ai turni attive</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve">
     <value>Questo camp è mai stato chiamato "Swiss Camp"?</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2934,11 +2934,13 @@
   <data name="Onboarding_NamesTitle" xml:space="preserve"><value>Welcome — let's start with your name</value></data>
   <data name="Onboarding_PriorityCritical" xml:space="preserve"><value>Critical</value></data>
   <data name="Onboarding_PriorityImportant" xml:space="preserve"><value>Important</value></data>
-  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>The event has only {0}% of the "critical" shifts filled. If these are not filled, the event might be cancelled as it would not be viable or safe to run it.</value></data>
-  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>If you're able to fill some of those, or you're able to come pre-event or stay for strike, please prioritize those when picking your shifts.</value></data>
-  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>IMPORTANT:</value></data>
+  <data name="Onboarding_ShiftsCriticalBody" xml:space="preserve"><value>Only {0}% of the "critical" shifts are filled. Please help us make the event happen by picking up a few where you can.</value></data>
+  <data name="Onboarding_ShiftsCriticalCta" xml:space="preserve"><value>If you can come early for set-up or stay for strike, those slots are the hardest to fill — please prioritise them when picking your shifts.</value></data>
+  <data name="Onboarding_ShiftsCriticalCtaSetupClosed" xml:space="preserve"><value>Set-up sign-ups are closed — we're already on site. Please focus on event-time and strike shifts.</value></data>
+  <data name="Onboarding_ShiftsCriticalHeading" xml:space="preserve"><value>We need you!</value></data>
   <data name="Onboarding_ShiftsImportantAlsoOpen" xml:space="preserve"><value>There are also {0} "important" shifts open.</value></data>
-  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>There are {0} "important" shifts open. If you're able to come pre-event or stay for strike, please prioritize those.</value></data>
+  <data name="Onboarding_ShiftsImportantBody" xml:space="preserve"><value>There are {0} "important" shifts open. If you can come early for set-up or stay for strike, please prioritise those.</value></data>
+  <data name="Onboarding_ShiftsImportantBodySetupClosed" xml:space="preserve"><value>There are {0} "important" shifts open — please focus on event-time and strike shifts.</value></data>
   <data name="Onboarding_ShiftsNoActiveEvent" xml:space="preserve"><value>No active event right now. You can finish onboarding without picking a shift.</value></data>
   <data name="Onboarding_ShiftsNoCritical" xml:space="preserve"><value>No critical shifts open at the moment — try Important or All.</value></data>
   <data name="Onboarding_ShiftsNoImportant" xml:space="preserve"><value>No important shifts open at the moment — try All.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1306,6 +1306,8 @@
   <data name="Camp_Singular" xml:space="preserve"><value>Barrio</value></data>
   <data name="Camp_Plural" xml:space="preserve"><value>Barrios</value></data>
   <data name="Camp_AdminTitle" xml:space="preserve"><value>Barrios Admin</value></data>
+  <data name="Camp_ShiftSignupBadgeTitle" xml:space="preserve"><value>Active shift signups for the current event (pending or confirmed)</value></data>
+  <data name="Camp_ShiftSignupBadgeAriaLabel" xml:space="preserve"><value>{0} active shift signups</value></data>
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Has this camp ever been called "Swiss Camp"</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Barrio Info</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Barrio Name</value></data>

--- a/src/Humans.Web/ViewComponents/EventsCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/EventsCardViewComponent.cs
@@ -13,8 +13,8 @@ namespace Humans.Web.ViewComponents;
 /// events card) or a user's personal (non-camp) submitted events — their
 /// profile page; camp events they submitted live on the camp's page. Invoked with
 /// ids only — no Event types cross into the host section's views. The favourite
-/// toggle bounces back to the current request's URL. Auth-gated at the call
-/// site (logged-in Humans users); returns empty content when the Events feature
+/// heart toggles in place via the JSON favourites API (no page reload). Auth-gated
+/// at the call site (logged-in Humans users); returns empty content when the Events feature
 /// is disabled or there are no approved events in scope so the card auto-hides.
 /// </summary>
 public class EventsCardViewComponent(
@@ -27,7 +27,7 @@ public class EventsCardViewComponent(
         try
         {
             // Mirror EventsFeatureFilter: when the Event Guide is off, the Events
-            // routes 404 — so the card (and its favourite POST target) must vanish too.
+            // routes 404 — so the card (and its favourite API target) must vanish too.
             if (!configuration.GetValue<bool>("Features:Events"))
                 return Content(string.Empty);
 
@@ -71,10 +71,8 @@ public class EventsCardViewComponent(
                 })
                 .ToList();
 
-            var request = ViewContext.HttpContext.Request;
             return View(new EventsCardViewModel
             {
-                ReturnUrl = request.Path + request.QueryString,
                 Rows = rows
             });
         }

--- a/src/Humans.Web/Views/Camp/Members.cshtml
+++ b/src/Humans.Web/Views/Camp/Members.cshtml
@@ -204,8 +204,13 @@
                         @foreach (var active in Model.ActiveMembers)
                         {
                             <li class="list-group-item d-flex justify-content-between align-items-center gap-2">
-                                <div class="d-flex align-items-center gap-2">
+                                <div class="d-flex align-items-center gap-2 flex-wrap">
                                     <vc:human user-id="@active.UserId" />
+                                    <span class="badge rounded-pill @active.EventShiftSignupBadgeClass"
+                                          title="@Localizer["Camp_ShiftSignupBadgeTitle"]"
+                                          aria-label="@Localizer["Camp_ShiftSignupBadgeAriaLabel", active.EventShiftSignupCount]">
+                                        @active.EventShiftSignupDisplay
+                                    </span>
                                 </div>
                                 <div class="d-flex gap-2 align-items-center">
                                     @{

--- a/src/Humans.Web/Views/Events/Browse.cshtml
+++ b/src/Humans.Web/Views/Events/Browse.cshtml
@@ -113,21 +113,12 @@ else
                             <strong>@item.Title</strong>
                             <span class="badge bg-secondary ms-1">@item.CategoryName</span>
                         </div>
-                        <form method="post" asp-action="ToggleFavourite" asp-route-eventId="@item.EventId"
-                              asp-route-day="@item.FavouriteDayOffset"
-                              asp-route-categoryId="@Model.FilterCategoryId"
-                              asp-route-venueId="@Model.FilterVenueId" asp-route-q="@Model.SearchQuery"
-                              asp-route-favouritesOnly="@Model.FavouritesOnly" class="d-inline">
-                            @Html.AntiForgeryToken()
-                            @foreach (var d in Model.FilterDays)
-                            {
-                                <input type="hidden" name="days" value="@d" />
-                            }
-                            <button type="submit" class="btn btn-sm @(item.IsFavourited ? "btn-danger" : "btn-outline-danger")"
-                                    title="@(item.IsFavourited ? Localizer["Events_RemoveFromFavourites"].Value : Localizer["Events_AddToFavourites"].Value)">
-                                <i class="fa-solid fa-heart"></i>
-                            </button>
-                        </form>
+                        @await Html.PartialAsync("_FavouriteButton", new FavouriteButtonModel
+                        {
+                            EventId = item.EventId,
+                            DayOffset = item.FavouriteDayOffset,
+                            IsFavourited = item.IsFavourited
+                        })
                     </div>
                     <div class="mt-1 small text-muted">
                         <i class="fa-solid fa-clock me-1"></i>@item.StartAt.ToTime() — @item.StartAt.AddMinutes(item.DurationMinutes).ToTime()

--- a/src/Humans.Web/Views/Events/Schedule.cshtml
+++ b/src/Humans.Web/Views/Events/Schedule.cshtml
@@ -39,12 +39,14 @@ else
                             <strong>@item.Title</strong>
                             <span class="badge bg-secondary ms-1">@item.CategoryName</span>
                         </div>
-                        <form method="post" asp-action="Unfavourite" asp-route-eventId="@item.EventId" asp-route-day="@item.FavouriteDayOffset" class="d-inline" data-confirm="@Localizer["Events_RemoveFromScheduleConfirm"].Value">
-                            @Html.AntiForgeryToken()
-                            <button type="submit" class="btn btn-sm btn-outline-danger" title="@Localizer["Events_RemoveFromSchedule"]">
-                                <i class="fa-solid fa-heart-crack"></i>
-                            </button>
-                        </form>
+                        @await Html.PartialAsync("_FavouriteButton", new FavouriteButtonModel
+                        {
+                            EventId = item.EventId,
+                            DayOffset = item.FavouriteDayOffset,
+                            IsFavourited = true,
+                            RemoveRow = true,
+                            ConfirmMessage = Localizer["Events_RemoveFromScheduleConfirm"].Value
+                        })
                     </div>
                     <div class="mt-1 small text-muted">
                         <i class="fa-solid fa-clock me-1"></i>@item.StartAt.ToTime() — @item.StartAt.AddMinutes(item.DurationMinutes).ToTime()

--- a/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
@@ -1,8 +1,18 @@
 @model IReadOnlyList<Humans.Web.Models.Mailer.AudienceCardRow>
 
 <section class="card mb-4">
-    <header class="card-header">
+    <header class="card-header d-flex justify-content-between align-items-center">
         <h2 class="h5 mb-0">Audiences</h2>
+        @if (Model.Count > 0)
+        {
+            <form asp-action="SyncAll" method="post" class="m-0"
+                  data-confirm="Push all @Model.Count audiences to MailerLite sequentially?">
+                @Html.AntiForgeryToken()
+                <button type="submit" class="btn btn-sm btn-primary">
+                    <i class="fa-solid fa-bolt me-1"></i>Push All
+                </button>
+            </form>
+        }
     </header>
     <div class="card-body">
         @if (Model.Count == 0)
@@ -40,3 +50,14 @@
         }
     </div>
 </section>
+
+<script>
+    (function () {
+        document.querySelectorAll('form[data-confirm]').forEach(function (form) {
+            form.addEventListener('submit', function (ev) {
+                var msg = form.getAttribute('data-confirm');
+                if (msg && !window.confirm(msg)) ev.preventDefault();
+            });
+        });
+    })();
+</script>

--- a/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
@@ -50,14 +50,3 @@
         }
     </div>
 </section>
-
-<script>
-    (function () {
-        document.querySelectorAll('form[data-confirm]').forEach(function (form) {
-            form.addEventListener('submit', function (ev) {
-                var msg = form.getAttribute('data-confirm');
-                if (msg && !window.confirm(msg)) ev.preventDefault();
-            });
-        });
-    })();
-</script>

--- a/src/Humans.Web/Views/OnboardingWidget/Shifts.cshtml
+++ b/src/Humans.Web/Views/OnboardingWidget/Shifts.cshtml
@@ -22,13 +22,17 @@
                     {
                         <div class="mt-2 mb-0">@Localizer["Onboarding_ShiftsImportantAlsoOpen", Model.ImportantOpenCount]</div>
                     }
-                    <div class="mt-2 mb-0">@Localizer["Onboarding_ShiftsCriticalCta"]</div>
+                    <div class="mt-2 mb-0">@(browse.EarlyEntrySignupsClosed
+                        ? Localizer["Onboarding_ShiftsCriticalCtaSetupClosed"]
+                        : Localizer["Onboarding_ShiftsCriticalCta"])</div>
                 </div>
             }
             else if (Model.HasAnyImportant)
             {
                 <div class="alert alert-warning" role="alert">
-                    @Localizer["Onboarding_ShiftsImportantBody", Model.ImportantOpenCount]
+                    @(browse.EarlyEntrySignupsClosed
+                        ? Localizer["Onboarding_ShiftsImportantBodySetupClosed", Model.ImportantOpenCount]
+                        : Localizer["Onboarding_ShiftsImportantBody", Model.ImportantOpenCount])
                 </div>
             }
 

--- a/src/Humans.Web/Views/Shared/Components/EventsCard/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/EventsCard/Default.cshtml
@@ -29,14 +29,13 @@
                             </span>
                         }
                     </div>
-                    <form method="post" asp-controller="Events" asp-action="ToggleCardFavourite"
-                          asp-route-eventId="@row.EventId" asp-route-returnUrl="@Model.ReturnUrl" class="d-inline ms-2">
-                        @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-sm @(row.IsFavourited ? "btn-danger" : "btn-outline-danger")"
-                                title="@(row.IsFavourited ? "Remove from favourites" : "Add to favourites")">
-                            <i class="fa-solid fa-heart"></i>
-                        </button>
-                    </form>
+                    <span class="ms-2">
+                        @await Html.PartialAsync("_FavouriteButton", new FavouriteButtonModel
+                        {
+                            EventId = row.EventId,
+                            IsFavourited = row.IsFavourited
+                        })
+                    </span>
                 </div>
                 <div class="mt-1 small text-muted">
                     <i class="fa-solid fa-clock me-1"></i>@row.StartAt.ToWeekdayDayMonth() &middot;

--- a/src/Humans.Web/Views/Shared/_FavouriteButton.cshtml
+++ b/src/Humans.Web/Views/Shared/_FavouriteButton.cshtml
@@ -1,0 +1,31 @@
+@model Humans.Web.Models.Events.FavouriteButtonModel
+@*
+    Instant favourite heart — single source of truth for the JS contract:
+    .js-favourite-toggle + data-event-id [+ data-day] + data-favourited, handled by
+    wwwroot/js/site.js. Two modes:
+      • toggle (Browse, events card) — flips the heart in place.
+      • remove (My Schedule) — removes the row; sets data-remove-row + data-favourite-confirm.
+*@
+@{
+    var addTitle = Localizer["Events_AddToFavourites"].Value;
+    var removeTitle = Localizer["Events_RemoveFromFavourites"].Value;
+    var title = Model.RemoveRow
+        ? Localizer["Events_RemoveFromSchedule"].Value
+        : (Model.IsFavourited ? removeTitle : addTitle);
+    var stateClass = !Model.RemoveRow && Model.IsFavourited ? "btn-danger" : "btn-outline-danger";
+    var favourited = Model.IsFavourited.ToString().ToLowerInvariant();
+}
+<button type="button"
+        class="btn btn-sm js-favourite-toggle @stateClass"
+        data-event-id="@Model.EventId"
+        data-day="@Model.DayOffset"
+        data-favourited="@favourited"
+        data-title-add="@addTitle"
+        data-title-remove="@removeTitle"
+        data-error="@Localizer["Common_Error"].Value"
+        data-remove-row="@(Model.RemoveRow ? "true" : null)"
+        data-favourite-confirm="@Model.ConfirmMessage"
+        aria-pressed="@(Model.RemoveRow ? null : favourited)"
+        title="@title" aria-label="@title">
+    <i class="fa-solid @(Model.RemoveRow ? "fa-heart-crack" : "fa-heart")" aria-hidden="true"></i>
+</button>

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -584,3 +584,54 @@ function showToast(message, type) {
         });
     });
 })();
+
+// Favourite hearts (Events): toggle the favourite in place — or remove the row
+// on My Schedule — via the JSON favourites API, so the action never reloads the
+// page and the user's filters/scroll survive. The JS contract is rendered by
+// Views/Shared/_FavouriteButton.cshtml. The API is same-origin + cookie-auth and
+// carries no antiforgery requirement.
+(function () {
+    function removeRow(btn) {
+        var row = btn.closest('.list-group-item');
+        if (!row) return;
+        var list = row.closest('.list-group');
+        row.remove();
+        // Drop an emptied day group (its heading + list) so no orphan date header lingers.
+        if (list && !list.querySelector('.list-group-item')) {
+            var heading = list.previousElementSibling;
+            if (heading && heading.tagName === 'H4') heading.remove();
+            list.remove();
+        }
+        // Whole schedule cleared — reload so the canonical empty-state message renders.
+        if (!document.querySelector('.js-favourite-toggle[data-remove-row="true"]')) window.location.reload();
+    }
+
+    document.addEventListener('click', function (e) {
+        var btn = e.target.closest('.js-favourite-toggle');
+        if (!btn || btn.disabled) return;
+
+        var confirmMsg = btn.getAttribute('data-favourite-confirm');
+        if (confirmMsg && !confirm(confirmMsg)) return;
+
+        var favourited = btn.getAttribute('data-favourited') === 'true';
+        var url = '/api/events/favourites/' + encodeURIComponent(btn.getAttribute('data-event-id'));
+        var day = btn.getAttribute('data-day');
+        if (day !== null && day !== '') url += '?day=' + encodeURIComponent(day);
+
+        btn.disabled = true;
+        fetch(url, { method: favourited ? 'DELETE' : 'POST' })
+            .then(function (r) {
+                if (!r.ok) throw new Error(r.status);
+                if (btn.getAttribute('data-remove-row') === 'true') { removeRow(btn); return; }
+                var nowFav = !favourited;
+                btn.setAttribute('data-favourited', nowFav ? 'true' : 'false');
+                btn.setAttribute('aria-pressed', nowFav ? 'true' : 'false');
+                btn.classList.toggle('btn-danger', nowFav);
+                btn.classList.toggle('btn-outline-danger', !nowFav);
+                var label = btn.getAttribute(nowFav ? 'data-title-remove' : 'data-title-add');
+                if (label) { btn.title = label; btn.setAttribute('aria-label', label); }
+            })
+            .catch(function () { showToast(btn.getAttribute('data-error') || 'Something went wrong.', 'danger'); })
+            .finally(function () { btn.disabled = false; });
+    });
+})();

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -592,16 +592,25 @@ function showToast(message, type) {
 // carries no antiforgery requirement.
 (function () {
     function removeRow(btn) {
-        var row = btn.closest('.list-group-item');
-        if (!row) return;
-        var list = row.closest('.list-group');
-        row.remove();
-        // Drop an emptied day group (its heading + list) so no orphan date header lingers.
-        if (list && !list.querySelector('.list-group-item')) {
-            var heading = list.previousElementSibling;
-            if (heading && heading.tagName === 'H4') heading.remove();
-            list.remove();
-        }
+        // A whole-event unfavourite (empty data-day) deletes every occurrence
+        // server-side, so remove every occurrence row for this event; a day-specific
+        // unfavourite removes only the clicked row.
+        var day = btn.getAttribute('data-day');
+        var toggles = (day === null || day === '')
+            ? document.querySelectorAll('.js-favourite-toggle[data-remove-row="true"][data-event-id="' + btn.getAttribute('data-event-id') + '"]')
+            : [btn];
+        Array.prototype.forEach.call(toggles, function (t) {
+            var row = t.closest('.list-group-item');
+            if (!row) return;
+            var list = row.closest('.list-group');
+            row.remove();
+            // Drop an emptied day group (its heading + list) so no orphan date header lingers.
+            if (list && !list.querySelector('.list-group-item')) {
+                var heading = list.previousElementSibling;
+                if (heading && heading.tagName === 'H4') heading.remove();
+                list.remove();
+            }
+        });
         // Whole schedule cleared — reload so the canonical empty-state message renders.
         if (!document.querySelector('.js-favourite-toggle[data-remove-row="true"]')) window.location.reload();
     }

--- a/tests/Humans.Application.Tests/ViewComponents/EventsCardViewComponentTests.cs
+++ b/tests/Humans.Application.Tests/ViewComponents/EventsCardViewComponentTests.cs
@@ -21,8 +21,6 @@ namespace Humans.Application.Tests.ViewComponents;
 /// </summary>
 public class EventsCardViewComponentTests
 {
-    private const string RequestPath = "/Barrios/shenanicamp";
-
     private readonly IEventServiceRead _events = Substitute.For<IEventServiceRead>();
 
     private EventsCardViewComponent BuildSut(Guid? viewerId, bool eventsEnabled = true)
@@ -31,7 +29,6 @@ public class EventsCardViewComponentTests
             ? new ClaimsIdentity()
             : new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, viewerId.Value.ToString())], "Test");
         var http = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
-        http.Request.Path = RequestPath;
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal) { ["Features:Events"] = eventsEnabled ? "true" : "false" })
             .Build();
@@ -77,7 +74,6 @@ public class EventsCardViewComponentTests
 
         var view = result.Should().BeOfType<ViewViewComponentResult>().Subject;
         var vm = view.ViewData!.Model.Should().BeOfType<EventsCardViewModel>().Subject;
-        vm.ReturnUrl.Should().Be(RequestPath);
         vm.Rows.Select(r => r.Title).Should().ContainInOrder("Early", "Late");
         vm.Rows[0].IsFavourited.Should().BeTrue();   // Early — favourited
         vm.Rows[1].IsFavourited.Should().BeFalse();  // Late — not favourited

--- a/tests/Humans.Web.Tests/Controllers/CampControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/CampControllerTests.cs
@@ -1,8 +1,11 @@
 using System.Security.Claims;
 using AwesomeAssertions;
 using Humans.Application;
+using Humans.Application.Services.Camps;
+using Humans.Application.DTOs.Shifts;
 using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.CityPlanning;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -27,6 +30,7 @@ public class CampControllerTests
     private readonly ICampContactService _contacts = Substitute.For<ICampContactService>();
     private readonly ICampRoleService _roles = Substitute.For<ICampRoleService>();
     private readonly ICityPlanningService _cityPlanning = Substitute.For<ICityPlanningService>();
+    private readonly IShiftView _shiftView = Substitute.For<IShiftView>();
     private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
     private readonly IAuthorizationService _authorization = Substitute.For<IAuthorizationService>();
     private readonly IClock _clock = Substitute.For<IClock>();
@@ -90,6 +94,67 @@ public class CampControllerTests
         vm.Camps.Select(c => c.Id).Should().Equal(leadCamp.Id, alphabeticalFirst.Id);
     }
 
+    [HumansFact]
+    public async Task Members_Shows_Active_Event_Shift_Counts_From_Shift_View()
+    {
+        var leadUserId = Guid.NewGuid();
+        var zeroShiftMemberId = Guid.NewGuid();
+        var oneShiftMemberId = Guid.NewGuid();
+        var fivePlusShiftMemberId = Guid.NewGuid();
+
+        var members = new[]
+        {
+            MakeSeasonMember(zeroShiftMemberId),
+            MakeSeasonMember(oneShiftMemberId),
+            MakeSeasonMember(fivePlusShiftMemberId),
+        };
+        var camp = MakeCamp("garden-of-joy", "Garden of Joy", CampSeasonStatus.Active, leadUserId, members: members);
+        var season = camp.Seasons.Single();
+
+        _camps.GetCampBySlugAsync(camp.Slug, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<CampInfo?>(camp));
+        _camps.GetCampEditDataAsync(camp.Id, null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<CampEditData?>(MakeEditData(camp, season)));
+        _users.GetUserInfoAsync(leadUserId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(MakeUserInfo(leadUserId)));
+        _users.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(call => new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                call.ArgAt<IReadOnlyCollection<Guid>>(0).ToDictionary(id => id, MakeUserInfo)));
+        _authorization.AuthorizeAsync(
+                Arg.Any<ClaimsPrincipal>(),
+                Arg.Any<object?>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Success());
+        _roles.BuildPanelAsync(season.Id, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new CampRolesPanelData(season.Id, [])));
+        _shiftView.GetUsersAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, ShiftUserView>>(
+                new Dictionary<Guid, ShiftUserView>
+                {
+                    [zeroShiftMemberId] = MakeShiftUserView(zeroShiftMemberId),
+                    [oneShiftMemberId] = MakeShiftUserView(oneShiftMemberId, SignupStatus.Confirmed),
+                    [fivePlusShiftMemberId] = MakeShiftUserView(
+                        fivePlusShiftMemberId,
+                        SignupStatus.Confirmed,
+                        SignupStatus.Pending,
+                        SignupStatus.Confirmed,
+                        SignupStatus.Pending,
+                        SignupStatus.Confirmed,
+                        SignupStatus.Bailed),
+                }));
+
+        var controller = BuildController(leadUserId);
+
+        var result = await controller.Members(camp.Slug, null, Xunit.TestContext.Current.CancellationToken);
+
+        var vm = result.Should().BeOfType<ViewResult>().Subject
+            .Model.Should().BeOfType<CampEditViewModel>().Subject;
+        vm.ActiveMembers.Single(m => m.UserId == zeroShiftMemberId).EventShiftSignupCount.Should().Be(0);
+        vm.ActiveMembers.Single(m => m.UserId == oneShiftMemberId).EventShiftSignupCount.Should().Be(1);
+        vm.ActiveMembers.Single(m => m.UserId == fivePlusShiftMemberId).EventShiftSignupCount.Should().Be(5);
+        vm.ActiveMembers.Single(m => m.UserId == fivePlusShiftMemberId).EventShiftSignupDisplay.Should().Be("5+");
+    }
+
     private void StubCampReadModel(IReadOnlyList<CampInfo> camps)
     {
         _camps.GetSettingsAsync(Arg.Any<CancellationToken>())
@@ -105,6 +170,7 @@ public class CampControllerTests
             _contacts,
             _roles,
             _cityPlanning,
+            _shiftView,
             _users,
             _authorization,
             _clock,
@@ -136,7 +202,8 @@ public class CampControllerTests
         string name,
         CampSeasonStatus status,
         Guid? leadUserId = null,
-        YesNoMaybe kidsWelcome = YesNoMaybe.Yes)
+        YesNoMaybe kidsWelcome = YesNoMaybe.Yes,
+        IReadOnlyList<CampSeasonMemberInfo>? members = null)
     {
         var campId = Guid.NewGuid();
         var season = new CampSeasonInfo(
@@ -161,7 +228,8 @@ public class CampControllerTests
             EeGrantedCount: 0,
             JoinedMemberCount: 0)
         {
-            LeadUserIds = leadUserId.HasValue ? [leadUserId.Value] : []
+            LeadUserIds = leadUserId.HasValue ? [leadUserId.Value] : [],
+            Members = members ?? []
         };
 
         return new CampInfo(
@@ -173,6 +241,64 @@ public class CampControllerTests
             TimesAtNowhere: 1,
             Seasons: [season]);
     }
+
+    private static CampSeasonMemberInfo MakeSeasonMember(Guid userId) =>
+        new(
+            Guid.NewGuid(),
+            userId,
+            CampMemberStatus.Active,
+            SystemClock.Instance.GetCurrentInstant(),
+            SystemClock.Instance.GetCurrentInstant(),
+            HasEarlyEntry: false);
+
+    private static CampEditData MakeEditData(CampInfo camp, CampSeasonInfo season) =>
+        new(
+            camp.Id,
+            camp.Slug,
+            season.Id,
+            season.Year,
+            IsNameLocked: false,
+            season.Name,
+            camp.ContactEmail,
+            camp.ContactPhone,
+            Links: [],
+            camp.IsSwissCamp,
+            camp.HideHistoricalNames,
+            camp.TimesAtNowhere,
+            season.BlurbLong,
+            season.BlurbShort,
+            season.Languages,
+            season.AcceptingMembers,
+            season.KidsWelcome,
+            season.KidsVisiting,
+            season.KidsAreaDescription,
+            season.HasPerformanceSpace,
+            season.PerformanceTypes,
+            season.Vibes,
+            season.AdultPlayspace,
+            season.MemberCount,
+            season.SpaceRequirement,
+            season.SoundZone,
+            season.ElectricalGrid,
+            Images: [],
+            HistoricalNames: []);
+
+    private static ShiftUserView MakeShiftUserView(Guid userId, params SignupStatus[] statuses) =>
+        new(
+            userId,
+            Profile: null,
+            Availability: null,
+            BuildStatus: null,
+            TagPreferences: [],
+            Signups: statuses.Select(status => new ShiftSignup
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                ShiftId = Guid.NewGuid(),
+                Status = status,
+                CreatedAt = SystemClock.Instance.GetCurrentInstant(),
+                UpdatedAt = SystemClock.Instance.GetCurrentInstant(),
+            }).ToList());
 
     private static UserInfo MakeUserInfo(Guid userId) =>
         UserInfo.Create(

--- a/tests/Humans.Web.Tests/Controllers/EventsControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/EventsControllerTests.cs
@@ -107,53 +107,6 @@ public class EventsControllerTests
         result.Should().BeOfType<ForbidResult>();
     }
 
-    [HumansFact]
-    public async Task ToggleCardFavourite_Authenticated_TogglesAndRedirectsToReturnUrl()
-    {
-        var userId = Guid.NewGuid();
-        var eventId = Guid.NewGuid();
-        var controller = BuildController(userId);
-        controller.Url = Substitute.For<IUrlHelper>();
-        controller.Url.IsLocalUrl("/Barrios/shenanicamp").Returns(true);
-
-        var result = await controller.ToggleCardFavourite(eventId, "/Barrios/shenanicamp");
-
-        await _guide.Received(1).ToggleFavouriteAsync(userId, eventId, null, Arg.Any<CancellationToken>());
-        result.Should().BeOfType<RedirectResult>().Which.Url.Should().Be("/Barrios/shenanicamp");
-    }
-
-    [HumansFact]
-    public async Task ToggleCardFavourite_NonLocalReturnUrl_RedirectsToBrowse()
-    {
-        var controller = BuildController(Guid.NewGuid());
-        controller.Url = Substitute.For<IUrlHelper>(); // IsLocalUrl → false by default
-
-        var result = await controller.ToggleCardFavourite(Guid.NewGuid(), "https://evil.example/phish");
-
-        result.Should().BeOfType<RedirectToActionResult>().Which.ActionName.Should().Be("Browse");
-    }
-
-    [HumansFact]
-    public async Task ToggleCardFavourite_Unauthenticated_ReturnsChallenge()
-    {
-        var controller = BuildAnonymousController();
-
-        var result = await controller.ToggleCardFavourite(Guid.NewGuid(), "/Barrios/shenanicamp");
-
-        result.Should().BeOfType<ChallengeResult>();
-        await _guide.DidNotReceive().ToggleFavouriteAsync(
-            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<int?>(), Arg.Any<CancellationToken>());
-    }
-
-    private EventsController BuildAnonymousController() =>
-        new(_guide, _users, _camps, _authz, _clock, NullLogger<EventsController>.Instance)
-        {
-            ControllerContext = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) },
-            },
-        };
-
     private Guid StubEvent(Guid submitterId, Guid? campId, EventStatus status)
     {
         var guideEvent = MakeEvent(campId, submitterId, status);

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -5,18 +5,33 @@ import { PERSONAS, liveLoginAndSave } from './helpers/auth';
 // Single test = single worker = no login herd during seeding. Failures are
 // collected so one broken persona doesn't hide the others.
 setup('authenticate all personas', async ({ browser, baseURL }) => {
-  setup.setTimeout(PERSONAS.length * 90_000);
+  // Worst-case: 2 attempts × 90 s + 5 s inter-attempt pause per persona,
+  // so the test always reaches the aggregate "personas failed" message rather
+  // than timing out mid-list when multiple personas are slow.
+  setup.setTimeout(PERSONAS.length * (90_000 * 2 + 5_000));
   const failures: string[] = [];
   for (const slug of PERSONAS) {
-    // baseURL isn't applied to ad-hoc contexts (only test page/context fixtures
-    // get use.* options), so pass it through for liveLoginAndSave's relative goto.
-    const context = await browser.newContext({ baseURL });
-    try {
-      await liveLoginAndSave(context, slug);
-    } catch (e) {
-      failures.push(`${slug}: ${(e as Error).message.split('\n')[0]}`);
-    } finally {
-      await context.close();
+    // Try each persona up to twice. QA cold-start or SeedLock contention on the
+    // first persona can push the response past the waitForSelector ceiling; a 5 s
+    // pause then a second attempt recovers without forcing Playwright to retry all
+    // 19 personas from scratch (baseURL isn't applied to ad-hoc contexts — only
+    // test page/context fixtures get use.* options — so pass it through here).
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt <= 1; attempt++) {
+      if (attempt > 0) await new Promise(r => setTimeout(r, 5_000));
+      const context = await browser.newContext({ baseURL });
+      try {
+        await liveLoginAndSave(context, slug);
+        lastError = null;
+        break;
+      } catch (e) {
+        lastError = e as Error;
+      } finally {
+        await context.close();
+      }
+    }
+    if (lastError !== null) {
+      failures.push(`${slug}: ${lastError.message.split('\n')[0]}`);
     }
   }
   expect(failures, `personas failed to seed/login:\n${failures.join('\n')}`).toEqual([]);


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `80e090c7b` ci(claude-review): skip review job for Dependabot PRs (peterdrier/Humans#1046)
- `3a0f1aab8` Show shift signup counts on camp members (peterdrier/Humans#1045)
- `0ca43cfd1` fix(events): toggle favourites without reloading the page (peterdrier/Humans#1044)
- `f2dda05df` chore(deps): Bump Microsoft.AspNetCore.Authentication.Google from 10.0.8 to 10.0.9 (peterdrier/Humans#1042)
- `542f78560` chore(deps): Bump Meziantou.Analyzer from 3.0.101 to 3.0.108 (peterdrier/Humans#1041)
- `b991444d5` chore(deps): Bump Markdig from 1.3.0 to 1.3.2 (peterdrier/Humans#1040)
- `788653dfe` chore(deps): Bump Google.Apis.CloudIdentity.v1 from 1.75.0.4169 to 1.75.0.4176 (peterdrier/Humans#1039)
- `b9595cea6` chore(deps): Bump Anthropic from 12.29.0 to 12.30.0 (peterdrier/Humans#1038)
- `9bf565100` chore(actions): Bump actions/checkout from 6 to 7 (peterdrier/Humans#1037)
- `a1e059301` fix(flaky): authenticate all personas (peterdrier/Humans#1036)
- `e5cb06920` feat(shifts): reframe onboarding critical-shift alert; early-entry-aware CTA (peterdrier/Humans#1035)
- `3eade71fe` feat(mailer): Push All button to sync every audience sequentially (peterdrier/Humans#1043)

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly