### PR TITLE
Gate hardening: TicketTailor check-in fix + scan-result auto-clear (PII) + operator-UX

### DIFF
--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -158,6 +158,13 @@ tap-list because the `GateTerminal` account is route-locked to `/Gate` and so ca
   deadline back (active use keeps it up). The interim ID-confirm card has a longer ~45s **safety**
   timeout only (it shows a name but the operator is mid-decision); the supervisor-override panel pauses
   the timer while a PIN is being entered.
+- **No dead-ends / minimal-training affordances** (kiosk is chromeless — no browser back). Every screen
+  has a visible way out: Leaderboard has "← Back to scanning"; the PIN keypad has "← Not you?". "Change"
+  (switch operator) is a deliberate two-tap (it abandons the session). The scan screen has an always-on
+  "?" help cheat-sheet (green=admit / red=stop / amber=supervisor), STOP cards spell out the action
+  ("Do not admit · if disputed, get the gate lead"), the ID-confirm card has a "Wrong ticket — scan
+  again" escape and a visible auto-clear countdown, the override panel has "← Wrong person", and the
+  freshness line taps to reload.
 
 ## Cross-Section Dependencies
 

--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -74,12 +74,14 @@ admission record. Distinct from the read-only `Scanner` section, which must neve
 - **Vendor check-in mirror** — on an admit the controller enqueues `GateVendorCheckInJob`
   (fire-and-forget) which calls `ITicketVendorService.CreateCheckInAsync` (TicketTailor
   `POST /v1/check_ins`). Best-effort only; `gate_scan_events` remains the dedupe authority.
-  **Gated behind `Gate:VendorMirrorEnabled` (default off).** Payload field names were verified
-  read-only against the live API (2026-06-29): the `check_in` object is
-  `{ issued_ticket_id, check_in_at (unix s), event_id, event_series_id, quantity }`, so the body
-  uses `check_in_at` (not the earlier guess `checked_in_at`) with the id in the body, not the path.
-  Still unverified (needs one live POST): whether create requires `event_id`. The flag stays off
-  until that POST is confirmed — a wrong body 4xx-fails silently and permanently.
+  **Gated behind `Gate:VendorMirrorEnabled` (default off).** Payload **verified live (2026-06-30)**
+  with a real POST → 201: the endpoint is **form-encoded** (not JSON), **requires `issued_ticket_id`
+  AND `quantity`**, accepts `check_in_at` (unix s), and `event_id` is optional (derived from the
+  ticket). The **API key must have Event-manager (or Admin) scope** — an Order-manager key 403s on
+  `/v1/check_ins`. Check-ins are **not idempotent** (each POST creates a new `check_in` record), so
+  `GateVendorCheckInJob` runs with `Attempts = 0` (no retry — a retry after a silent success would
+  double-record; a missed mirror is acceptable, `gate_scan_events` is authoritative). Before enabling
+  the flag, confirm the configured TicketTailor key has Event-manager scope.
 - **Vendor-checked-in dedupe signal is currently dead** (pre-existing Tickets bug, not Gate).
   The `CheckedInAtVendor` precedence input depends on the Tickets sync detecting check-ins, but
   that sync parses a nested `check_in` object the live API no longer returns (it returns a
@@ -149,6 +151,13 @@ tap-list because the `GateTerminal` account is route-locked to `/Gate` and so ca
   `GuestUserId`/`ScannedByUserId`), and retention purge.
 - The gate view shows name + verdict + one reason line only; Early-Entry source, the previous
   scanner's id, and internal GUIDs stay server-side.
+- **A result card auto-clears** back to the Ready screen so the previous guest's name never lingers on
+  the shared kiosk (PII) and the screen is never stuck on the last scan. Timeouts vary by outcome (a
+  quick ADMIT clears in ~10s; a STOP/AMBER refusal that gets explained to the guest lingers ~30s); a
+  terminal card also shows a "Next ticket" button with a live countdown. Any tap on the card pushes the
+  deadline back (active use keeps it up). The interim ID-confirm card has a longer ~45s **safety**
+  timeout only (it shows a name but the operator is mid-decision); the supervisor-override panel pauses
+  the timer while a PIN is being entered.
 
 ## Cross-Section Dependencies
 

--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -155,7 +155,7 @@ tap-list because the `GateTerminal` account is route-locked to `/Gate` and so ca
   the shared kiosk (PII) and the screen is never stuck on the last scan. Timeouts vary by outcome (a
   quick ADMIT clears in ~10s; a STOP/AMBER refusal that gets explained to the guest lingers ~30s); a
   terminal card also shows a "Next ticket" button with a live countdown. Any tap on the card pushes the
-  deadline back (active use keeps it up). The interim ID-confirm card has a longer ~45s **safety**
+  deadline back (active use keeps it up). The interim ID-confirm card has a longer ~60s **safety**
   timeout only (it shows a name but the operator is mid-decision); the supervisor-override panel pauses
   the timer while a PIN is being entered.
 - **No dead-ends / minimal-training affordances** (kiosk is chromeless — no browser back). Every screen

--- a/src/Humans.Infrastructure/Jobs/GateVendorCheckInJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GateVendorCheckInJob.cs
@@ -13,12 +13,19 @@ namespace Humans.Infrastructure.Jobs;
 /// after an admit is recorded, so the gate screen never waits on the vendor.
 /// The Gate section's <c>gate_scan_events</c> row is the dedupe authority; this
 /// job only keeps the vendor dashboard / vendor check-in app consistent.
-/// Hangfire retries on failure (the vendor treats repeat check-ins idempotently).
-/// Gated behind <c>Gate:VendorMirrorEnabled</c> (default off) until the
-/// TicketTailor check-in payload is verified against a live API key — a wrong
-/// body 4xx-fails silently and permanently, so the mirror stays off by default.
+/// <para>
+/// <b>No automatic retries</b> (<c>Attempts = 0</c>): TicketTailor check-ins are NOT idempotent —
+/// each POST creates a new check_in record (verified live 2026-06-30) — so retrying after a
+/// silently-succeeded call would double-record. <c>Attempts = 0</c> disables the auto-retry filter
+/// but does NOT make this exactly-once: Hangfire's at-least-once delivery can still re-run an
+/// orphaned job after a worker crash, which would create a duplicate. That's accepted — at this
+/// scale it's rare and a duplicate vendor-dashboard row is cosmetic; <c>gate_scan_events</c> is the
+/// authority. A transient failure simply loses one mirror.
+/// </para>
+/// Gated behind <c>Gate:VendorMirrorEnabled</c> (default off). NB the vendor API key must have
+/// Event-manager (or Admin) scope — an Order-manager key 403s on <c>/v1/check_ins</c>.
 /// </summary>
-[AutomaticRetry(Attempts = 5)]
+[AutomaticRetry(Attempts = 0)]
 public sealed class GateVendorCheckInJob(
     ITicketVendorService vendor,
     IClock clock,
@@ -52,9 +59,11 @@ public sealed class GateVendorCheckInJob(
         }
         catch (Exception ex)
         {
+            // Best-effort: a transient failure (vendor 5xx / network) just loses this one mirror.
+            // We do NOT retry — repeat check-ins aren't idempotent, so a retry after a silent
+            // success would double-record. gate_scan_events is the authority.
             logger.LogWarning(
-                ex, "Vendor check-in mirror failed for issued ticket {VendorTicketId}; Hangfire will retry", vendorTicketId);
-            throw;
+                ex, "Vendor check-in mirror failed for issued ticket {VendorTicketId} — not retried", vendorTicketId);
         }
     }
 }

--- a/src/Humans.Infrastructure/Services/TicketTailorService.cs
+++ b/src/Humans.Infrastructure/Services/TicketTailorService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
@@ -332,27 +333,26 @@ public class TicketTailorService : ITicketVendorService
     {
         using var _ = _logger.TimeOperation();
 
-        // TicketTailor records check-ins against an issued ticket. We send the
-        // issued-ticket id and the time of admission; the vendor treats repeat
-        // check-ins idempotently, so retries are safe.
-        // Field names VERIFIED 2026-06-29 (read-only) against a live GET /v1/check_ins:
-        // the check_in object is { issued_ticket_id, check_in_at (unix seconds),
-        // event_id, event_series_id, quantity }. So the collection POST /v1/check_ins
-        // with issued_ticket_id in the BODY (not the path) is the right shape, and the
-        // time field is `check_in_at` (an earlier guess used `checked_in_at`, which the
-        // API would silently ignore). STILL UNVERIFIED (needs one live POST): whether
-        // create REQUIRES event_id and whether check_in_at is writable on create vs
-        // server-set. A 4xx here fails fast (the job does not retry 4xx); the caller
-        // (GateVendorCheckInJob) stays gated behind Gate:VendorMirrorEnabled (default
-        // off) until a live POST confirms create succeeds end-to-end.
-        var payload = new
+        // TicketTailor records check-ins against an issued ticket.
+        // VERIFIED LIVE 2026-06-30 with a real POST /v1/check_ins (→ 201) against a test ticket:
+        //  • the endpoint is FORM-ENCODED (application/x-www-form-urlencoded), NOT JSON — a JSON
+        //    body is ignored and every field reads as null/missing (silent 400);
+        //  • `issued_ticket_id` AND `quantity` are REQUIRED; `check_in_at` (unix seconds) is
+        //    accepted; `event_id` is OPTIONAL (the API derives it from the ticket);
+        //  • the API key must have Event-manager (or Admin) scope — an Order-manager key 403s here
+        //    (read AND write), so the production vendor key must be scoped accordingly.
+        //  • repeat check-ins are NOT idempotent — each POST creates a new check_in record (the
+        //    ticket just stays checked in), which is why GateVendorCheckInJob does not retry.
+        // The mirror stays gated behind Gate:VendorMirrorEnabled (default off).
+        // StringComparer.Ordinal only to satisfy MA0002 — FormUrlEncodedContent just enumerates the pairs.
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            issued_ticket_id = vendorTicketId,
-            check_in_at = occurredAt.ToUnixTimeSeconds(),
-        };
+            ["issued_ticket_id"] = vendorTicketId,
+            ["quantity"] = "1", // exactly one issued ticket per gate scan (the job carries a single ticket id)
+            ["check_in_at"] = occurredAt.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture),
+        });
 
-        var response = await _httpClient.PostAsJsonAsync(
-            $"{BaseUrl}/check_ins", payload, JsonOptions, ct);
+        var response = await _httpClient.PostAsync($"{BaseUrl}/check_ins", form, ct);
 
         if (!response.IsSuccessStatusCode)
         {

--- a/src/Humans.Web/Views/Gate/Claim.cshtml
+++ b/src/Humans.Web/Views/Gate/Claim.cshtml
@@ -8,10 +8,7 @@
 }
 
 <h1>Who is scanning?</h1>
-<p class="text-muted">
-    Tap your name to claim the gate session, or search below. Your Humans account is
-    stamped on every scan you record, so anyone on gate — rostered or not — can take over.
-</p>
+<p class="text-muted">Tap your name, or search below. Every scan is recorded against you.</p>
 
 @if (Model.Roster.Count > 0)
 {

--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -14,8 +14,10 @@
     <div class="gate-topbar">
         <span>Scanning as <strong>@Model.ScannerName</strong></span>
         <span class="gate-asof" data-asof="@Model.DataAsOf"
-              title="When this terminal last loaded — re-open it if this gets old">loaded…</span>
-        <a asp-action="Claim" class="gate-topbar-link">Change</a>
+              title="Tap to reload">loaded…</span>
+        @* "Change" abandons the session (re-enter PIN), so it's a deliberate two-tap (gate.js) to
+           stop a mid-queue fat-finger from dumping the operator back to the roster. *@
+        <a asp-action="Claim" class="gate-topbar-link" data-confirm-change>Change</a>
         <a asp-action="Leaderboard" class="gate-topbar-link">Leaderboard</a>
     </div>
 
@@ -72,11 +74,29 @@
                 </div>
             </div>
             <div class="gate-override-step d-none" data-override-pin>
+                <button type="button" class="gate-override-back" data-override-back>&larr; Wrong person</button>
                 <p class="gate-override-prompt"><span data-supervisor-name></span> — enter your PIN</p>
                 <partial name="_PinPad" />
             </div>
         }
     </div>
+
+    @* Always-available cheat-sheet for a barely-trained volunteer (native <details> — no JS).
+       Fixed corner button so it never crowds the scan flow. *@
+    <details class="gate-help">
+        <summary class="gate-help-toggle" title="What the colours mean" aria-label="Help">?</summary>
+        <div class="gate-help-panel">
+            <h2 class="gate-help-title">Quick guide</h2>
+            <ul class="gate-help-list">
+                <li><span class="gate-help-dot gate-admit"></span> <strong>GREEN — admit.</strong> Give a wristband.</li>
+                <li><span class="gate-help-dot gate-stop"></span> <strong>RED — do not admit.</strong> If disputed, get the gate lead.</li>
+                <li><span class="gate-help-dot gate-amber"></span> <strong>AMBER — get a supervisor</strong> / gate lead.</li>
+                <li><span class="gate-help-dot gate-idconfirm"></span> <strong>"Does the ID say…?"</strong> Check the photo ID, then tap Yes or No.</li>
+            </ul>
+            <p class="gate-help-tip">Scan the next ticket any time. Stuck or unsure? Get the gate lead.</p>
+            <p class="gate-help-tip">Tap <strong>?</strong> again to close.</p>
+        </div>
+    </details>
 </div>
 
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider

--- a/src/Humans.Web/Views/Gate/Leaderboard.cshtml
+++ b/src/Humans.Web/Views/Gate/Leaderboard.cshtml
@@ -4,6 +4,14 @@
     ViewData["Title"] = "Gate leaderboard";
 }
 
+@section Styles {
+    <link rel="stylesheet" href="@Url.Content("~/css/gate/gate.css")" asp-append-version="true" />
+}
+
+@* The kiosk is chromeless (no browser back), so a prominent return path is mandatory — without it
+   the operator is stranded here mid-queue. *@
+<a asp-action="Index" class="gate-back">&larr; Back to scanning</a>
+
 <h1>Gate leaderboard</h1>
 <p class="text-muted">
     <strong>@ViewData["TotalAdmitted"]</strong> admitted ·

--- a/src/Humans.Web/Views/Gate/Pin.cshtml
+++ b/src/Humans.Web/Views/Gate/Pin.cshtml
@@ -15,9 +15,8 @@
             <div class="gate-pin-icon" aria-hidden="true"><i class="fa-solid fa-user-shield"></i></div>
             <div class="gate-pin-name">@Model.DisplayName</div>
             <p class="gate-pin-blocked-text">
-                Supervisor PINs are set by an admin — they carry override authority, so they're never
-                created here at the gate. Ask an admin to enrol your PIN in <strong>Gate &#9656; Admin</strong>,
-                then come back and tap your name.
+                Supervisor PINs carry override authority, so they're set up ahead of time — not here at
+                the gate. <strong>Ask the gate lead to set up your PIN</strong>, then come back and tap your name.
             </p>
             <a asp-action="Claim" class="gate-pin-back">&larr; Back to names</a>
         </div>

--- a/src/Humans.Web/Views/Gate/_VerdictCard.cshtml
+++ b/src/Humans.Web/Views/Gate/_VerdictCard.cshtml
@@ -38,6 +38,13 @@
         <div class="gate-reason">@Model.Reason</div>
     }
 
+    @* Imperative next step for a refusal — a 2-minute-trained volunteer needs to be told what to DO,
+       and where to escalate if the guest disputes it, not just the diagnosis. *@
+    @if (Model.Kind == GateCardKind.Stop)
+    {
+        <div class="gate-action">Do not admit · if the guest disputes it, get the gate lead</div>
+    }
+
     @if (Model.Kind == GateCardKind.IdConfirm)
     {
         <div class="gate-decide" data-barcode="@Model.Barcode">
@@ -55,6 +62,10 @@
                     Child — with adult (supervisor)
                 </button>
             }
+            @* Scanned the wrong code (caught a neighbouring ticket)? Bail back to Ready and rescan. *@
+            <button type="button" class="gate-btn gate-cancel-scan" data-cancel-scan>
+                <i class="fa-solid fa-rotate-left" aria-hidden="true"></i> Wrong ticket — scan again
+            </button>
         </div>
     }
 

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -167,6 +167,56 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 }
 .gate-next:active { background: #000; }
 
+/* Operator-UX additions ---------------------------------------------------- */
+
+/* Big return-to-scanning control (Leaderboard has no browser back on the chromeless kiosk). */
+.gate-back {
+    display: inline-block; margin-bottom: 1rem; padding: .8rem 1.25rem;
+    background: #2b3440; color: #fff; border-radius: 12px; font-size: 1.2rem; font-weight: 700;
+}
+.gate-back:hover, .gate-back:focus { background: #1e2a33; color: #fff; }
+
+/* Imperative "what to do" line on a STOP card — full-opacity white, sits under the reason. */
+.gate-action { font-size: 1.35rem; font-weight: 700; margin-top: .75rem; line-height: 1.3; }
+
+/* Lower-prominence "wrong ticket — scan again" escape on the ID-confirm card. */
+.gate-cancel-scan { display: block; width: 100%; margin-top: 1rem; background: #5a6672; font-size: 1.05rem; }
+
+/* ID-confirm visible countdown hint — non-silent safety net so the card can't vanish unannounced. */
+.gate-idhint { margin-top: 1.1rem; font-size: 1.05rem; color: rgba(255, 255, 255, .85); }
+
+/* "← Wrong person" back-step inside the override PIN panel (cream card, so dark text). */
+.gate-override-back {
+    align-self: flex-start; background: none; border: none; color: #5f6b76;
+    font-size: 1.05rem; font-weight: 600; cursor: pointer; margin-bottom: .25rem;
+}
+
+/* "Change" link while armed for the confirming second tap. */
+.gate-topbar-link.gate-armed { color: #B11217; font-weight: 700; }
+
+/* The freshness line doubles as the reload control on the chromeless kiosk. */
+.gate-asof { cursor: pointer; }
+
+/* Always-available help cheat-sheet — fixed "?" button bottom-left + a centred card (native <details>). */
+.gate-help { position: fixed; left: .75rem; bottom: .75rem; z-index: 1000; }
+.gate-help-toggle {
+    list-style: none; width: 52px; height: 52px; border-radius: 50%; background: #2b3440; color: #fff;
+    font-size: 1.6rem; font-weight: 700; display: flex; align-items: center; justify-content: center;
+    cursor: pointer; box-shadow: 0 2px 8px rgba(0, 0, 0, .35);
+}
+.gate-help-toggle::-webkit-details-marker { display: none; }
+.gate-help-toggle::marker { content: ""; }
+.gate-help-panel {
+    position: fixed; left: 50%; top: 50%; transform: translate(-50%, -50%);
+    width: 90vw; max-width: 440px; background: #f4ede1; color: #1e2a33;
+    border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 40px rgba(0, 0, 0, .45); z-index: 1001;
+}
+.gate-help-title { font-size: 1.5rem; margin: 0 0 .75rem; }
+.gate-help-list { list-style: none; padding: 0; margin: 0 0 1rem; font-size: 1.15rem; line-height: 1.5; }
+.gate-help-list li { margin-bottom: .5rem; }
+.gate-help-dot { display: inline-block; width: 18px; height: 18px; border-radius: 50%; vertical-align: middle; margin-right: .5rem; }
+.gate-help-tip { font-size: 1.05rem; color: #2b3440; margin: .25rem 0 0; }
+
 /* Roster quick-pick on the claim screen — big FILLED tap targets (outline buttons
    wash out in direct sun) for gloved use. Capped height so a large roster scrolls
    instead of burying the search box below the fold. */

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -187,7 +187,7 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 
 /* "← Wrong person" back-step inside the override PIN panel (cream card, so dark text). */
 .gate-override-back {
-    align-self: flex-start; background: none; border: none; color: #5f6b76;
+    display: block; background: none; border: none; color: #5f6b76;
     font-size: 1.05rem; font-weight: 600; cursor: pointer; margin-bottom: .25rem;
 }
 

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -157,6 +157,16 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 /* The supervisor-override affordance on a too-early / failed-override card. */
 .gate-override-btn { display: block; width: 100%; margin-top: 1rem; background: #3a4753; font-size: 1.15rem; }
 
+/* "Next ticket" — appears on a terminal result card; clears the screen back to Ready (also auto-
+   fires after a countdown). SOLID near-black (not a translucent wash) so it stays legible on any
+   verdict colour in direct sun — outline/translucent buttons wash out (see the roster-pick note). */
+.gate-next {
+    display: block; width: 100%; margin-top: 1.5rem; padding: 1rem;
+    background: #11181d; color: #fff; border: none;
+    border-radius: 12px; font-size: 1.3rem; font-weight: 700; cursor: pointer;
+}
+.gate-next:active { background: #000; }
+
 /* Roster quick-pick on the claim screen — big FILLED tap targets (outline buttons
    wash out in direct sun) for gloved use. Capped height so a large roster scrolls
    instead of burying the search box below the fold. */

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -93,9 +93,17 @@ export function initGate(refs) {
         return hint;
     }
 
-    // A tap anywhere on the result card means "still using this" — push the auto-return back.
-    // One delegated listener (not per-card) so it never accumulates across renders.
-    result.addEventListener('pointerdown', () => { if (resetTimer) startResetTimer(); }, { passive: true });
+    // A tap anywhere on the result card means "still using this" — push the deadline back. We only
+    // reschedule the setTimeout and leave the countdown setInterval running (its tick reads
+    // resetDeadline live and self-corrects), so rapid taps don't rebuild the interval or make the
+    // visible number stutter. One delegated listener (not per-card) so it never accumulates.
+    function bumpReset() {
+        if (!resetTimer) return;
+        resetDeadline = Date.now() + resetMs;
+        clearTimeout(resetTimer);
+        resetTimer = setTimeout(resetToReady, resetMs);
+    }
+    result.addEventListener('pointerdown', bumpReset, { passive: true });
 
     // "Change" abandons the session (re-enter PIN), so require a deliberate second tap.
     initChangeConfirm();
@@ -299,10 +307,15 @@ export function initGate(refs) {
             override.setAttribute('aria-hidden', 'true');
             keypad.reset();
             focusInput();
-            // Cancelled back to the (still-displayed) too-early card — re-arm its auto-return so the
-            // name doesn't linger. (When close() follows a successful submit, render() supersedes this.)
+        }
+
+        // Cancel returns to the card behind the panel — re-arm its auto-return so the guest's name
+        // doesn't linger. Covers the ID-confirm card too (its timer was paused when the panel opened),
+        // and matches on any card carrying a verdict (never the Ready card, which has no data-kind).
+        function closeAndReArm() {
+            close();
             const current = result.firstElementChild;
-            if (current && !current.querySelector('.gate-decide')) armAutoReset(current, current.getAttribute('data-kind'));
+            if (current && current.hasAttribute('data-kind')) armAutoReset(current, current.getAttribute('data-kind'));
         }
 
         override.querySelectorAll('[data-supervisor-id]').forEach(btn => {
@@ -315,7 +328,7 @@ export function initGate(refs) {
             });
         });
 
-        if (cancelBtn) cancelBtn.addEventListener('click', close);
+        if (cancelBtn) cancelBtn.addEventListener('click', closeAndReArm);
 
         // Tapped the wrong supervisor — go back to the name list without closing the whole panel.
         if (backBtn) backBtn.addEventListener('click', () => {

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -23,8 +23,8 @@ export function initGate(refs) {
     // but the operator is mid-decision). Any tap on the card pushes the deadline back (active use
     // keeps it up); terminal cards also get a "Next ticket" button with a visible countdown.
     const readyCard = result.firstElementChild ? result.firstElementChild.cloneNode(true) : null;
-    const RESET_MS = { Admit: 10000, Stop: 30000, Amber: 30000, IdConfirm: 45000 };
-    let resetTimer = null, resetCountdown = null, resetDeadline = 0, resetMs = 0, resetLabel = null;
+    const RESET_MS = { Admit: 10000, Stop: 30000, Amber: 30000, IdConfirm: 60000 };
+    let resetTimer = null, resetCountdown = null, resetDeadline = 0, resetMs = 0, resetLabel = null, resetLabelKind = 'next';
 
     function clearResetTimer() {
         if (resetTimer) { clearTimeout(resetTimer); resetTimer = null; }
@@ -46,7 +46,9 @@ export function initGate(refs) {
         if (resetLabel) {
             const tick = () => {
                 const left = Math.max(0, Math.ceil((resetDeadline - Date.now()) / 1000));
-                resetLabel.textContent = `Next ticket › (${left})`;
+                resetLabel.textContent = resetLabelKind === 'hint'
+                    ? `Auto-clears in ${left}s · tap to keep`
+                    : `Next ticket › (${left})`;
             };
             tick();
             resetCountdown = setInterval(tick, 1000);
@@ -56,9 +58,16 @@ export function initGate(refs) {
     function armAutoReset(card, kind) {
         clearResetTimer();
         resetMs = RESET_MS[kind] || 10000;
-        // Terminal cards (no pending Yes/No) get a Next button + countdown; the ID-confirm card
-        // auto-clears silently, only as an abandonment safety net.
-        resetLabel = card.querySelector('.gate-decide') ? null : ensureNextButton(card);
+        // Terminal cards (no pending Yes/No) get a Next button + countdown. The ID-confirm card is
+        // mid-decision, so instead of a Next button it shows a visible "auto-clears in Ns · tap to
+        // keep" hint — a long, *non-silent* safety net so it can't vanish unannounced mid-ID-check.
+        if (card.querySelector('.gate-decide')) {
+            resetLabel = ensureIdHint(card);
+            resetLabelKind = 'hint';
+        } else {
+            resetLabel = ensureNextButton(card);
+            resetLabelKind = 'next';
+        }
         startResetTimer();
     }
 
@@ -74,9 +83,40 @@ export function initGate(refs) {
         return btn;
     }
 
+    function ensureIdHint(card) {
+        let hint = card.querySelector('.gate-idhint');
+        if (!hint) {
+            hint = document.createElement('div');
+            hint.className = 'gate-idhint';
+            card.appendChild(hint);
+        }
+        return hint;
+    }
+
     // A tap anywhere on the result card means "still using this" — push the auto-return back.
     // One delegated listener (not per-card) so it never accumulates across renders.
     result.addEventListener('pointerdown', () => { if (resetTimer) startResetTimer(); }, { passive: true });
+
+    // "Change" abandons the session (re-enter PIN), so require a deliberate second tap.
+    initChangeConfirm();
+    // The freshness line is a reload affordance on the chromeless kiosk (no browser reload button).
+    const asofEl = document.querySelector('.gate-asof');
+    if (asofEl) asofEl.addEventListener('click', () => location.reload());
+
+    function initChangeConfirm() {
+        const link = document.querySelector('[data-confirm-change]');
+        if (!link) return;
+        let armed = false;
+        link.addEventListener('click', (e) => {
+            if (armed) return; // second tap within the window → allow the link to navigate
+            e.preventDefault();
+            armed = true;
+            const original = link.textContent;
+            link.textContent = 'Tap again to switch';
+            link.classList.add('gate-armed');
+            setTimeout(() => { armed = false; link.textContent = original; link.classList.remove('gate-armed'); }, 3000);
+        });
+    }
 
     // Render the "loaded HH:mm · N min ago" indicator and redden it once the terminal
     // has been open a while — a nudge to re-open the page so its data view isn't stale.
@@ -191,6 +231,10 @@ export function initGate(refs) {
             childBtn.addEventListener('click', () => overrideController.open('child', barcode));
         }
 
+        // Scanned the wrong code — bail straight back to Ready so the operator can rescan.
+        const cancelScan = decide.querySelector('[data-cancel-scan]');
+        if (cancelScan) cancelScan.addEventListener('click', resetToReady);
+
         // The ID-confirm card shows a name, so give it a long *safety* timeout (no Next button): if
         // it's abandoned (guest walks off / staffer distracted), the name doesn't linger forever.
         // Any tap — including the Yes/No buttons — pushes the deadline back during active use.
@@ -227,6 +271,7 @@ export function initGate(refs) {
         const nameEl = override.querySelector('[data-supervisor-name]');
         const keypadEl = override.querySelector('[data-gate-keypad]');
         const cancelBtn = override.querySelector('[data-override-cancel]');
+        const backBtn = override.querySelector('[data-override-back]');
 
         let mode = 'early';
         let barcode = null;
@@ -271,6 +316,14 @@ export function initGate(refs) {
         });
 
         if (cancelBtn) cancelBtn.addEventListener('click', close);
+
+        // Tapped the wrong supervisor — go back to the name list without closing the whole panel.
+        if (backBtn) backBtn.addEventListener('click', () => {
+            supervisorUserId = null;
+            if (pinStep) pinStep.classList.add('d-none');
+            if (pickStep) pickStep.classList.remove('d-none');
+            keypad.reset();
+        });
 
         function submit(pin) {
             if (!supervisorUserId || !barcode) return;

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -16,6 +16,68 @@ export function initGate(refs) {
     const overrideController = initOverride();
     const overrideOpen = () => override && !override.classList.contains('d-none');
 
+    // After a result, auto-return to the Ready screen so the previous guest's name never lingers on
+    // the shared kiosk (PII) and the screen is never stuck on the last scan. Durations differ by
+    // outcome: an ADMIT is a glance, but a STOP/AMBER refusal gets explained to the guest, so it
+    // lingers longer; the interim ID-confirm card gets a long *safety* timeout only (it shows a name
+    // but the operator is mid-decision). Any tap on the card pushes the deadline back (active use
+    // keeps it up); terminal cards also get a "Next ticket" button with a visible countdown.
+    const readyCard = result.firstElementChild ? result.firstElementChild.cloneNode(true) : null;
+    const RESET_MS = { Admit: 10000, Stop: 30000, Amber: 30000, IdConfirm: 45000 };
+    let resetTimer = null, resetCountdown = null, resetDeadline = 0, resetMs = 0, resetLabel = null;
+
+    function clearResetTimer() {
+        if (resetTimer) { clearTimeout(resetTimer); resetTimer = null; }
+        if (resetCountdown) { clearInterval(resetCountdown); resetCountdown = null; }
+        resetLabel = null;
+    }
+
+    function resetToReady() {
+        clearResetTimer();
+        if (readyCard) result.replaceChildren(readyCard.cloneNode(true));
+        focusInput();
+    }
+
+    function startResetTimer() {
+        if (resetTimer) clearTimeout(resetTimer);
+        if (resetCountdown) clearInterval(resetCountdown);
+        resetDeadline = Date.now() + resetMs;
+        resetTimer = setTimeout(resetToReady, resetMs);
+        if (resetLabel) {
+            const tick = () => {
+                const left = Math.max(0, Math.ceil((resetDeadline - Date.now()) / 1000));
+                resetLabel.textContent = `Next ticket › (${left})`;
+            };
+            tick();
+            resetCountdown = setInterval(tick, 1000);
+        }
+    }
+
+    function armAutoReset(card, kind) {
+        clearResetTimer();
+        resetMs = RESET_MS[kind] || 10000;
+        // Terminal cards (no pending Yes/No) get a Next button + countdown; the ID-confirm card
+        // auto-clears silently, only as an abandonment safety net.
+        resetLabel = card.querySelector('.gate-decide') ? null : ensureNextButton(card);
+        startResetTimer();
+    }
+
+    function ensureNextButton(card) {
+        let btn = card.querySelector('.gate-next');
+        if (!btn) {
+            btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'gate-next';
+            btn.addEventListener('click', resetToReady);
+            card.appendChild(btn);
+        }
+        return btn;
+    }
+
+    // A tap anywhere on the result card means "still using this" — push the auto-return back.
+    // One delegated listener (not per-card) so it never accumulates across renders.
+    result.addEventListener('pointerdown', () => { if (resetTimer) startResetTimer(); }, { passive: true });
+
     // Render the "loaded HH:mm · N min ago" indicator and redden it once the terminal
     // has been open a while — a nudge to re-open the page so its data view isn't stale.
     // A once-a-minute text update only (no network, no scan-loop cost).
@@ -63,6 +125,7 @@ export function initGate(refs) {
     });
 
     async function render(url, body) {
+        clearResetTimer(); // a new scan/decision is incoming — cancel any pending auto-return
         try {
             const opts = body
                 ? { method: 'POST', headers: { 'RequestVerificationToken': token }, body }
@@ -102,7 +165,12 @@ export function initGate(refs) {
         }
 
         const decide = card.querySelector('.gate-decide');
-        if (!decide) return;
+        if (!decide) {
+            // Terminal result (admit / stop / amber / too-early) — no decision pending, so arm the
+            // per-kind auto-return + Next-ticket button. The override panel pauses this while open.
+            armAutoReset(card, kind);
+            return;
+        }
 
         const barcode = decide.getAttribute('data-barcode');
         const buttons = decide.querySelectorAll('.gate-btn');
@@ -122,6 +190,11 @@ export function initGate(refs) {
         if (childBtn) {
             childBtn.addEventListener('click', () => overrideController.open('child', barcode));
         }
+
+        // The ID-confirm card shows a name, so give it a long *safety* timeout (no Next button): if
+        // it's abandoned (guest walks off / staffer distracted), the name doesn't linger forever.
+        // Any tap — including the Yes/No buttons — pushes the deadline back during active use.
+        armAutoReset(card, kind);
     }
 
     async function submitDecision(barcode, opts) {
@@ -164,6 +237,7 @@ export function initGate(refs) {
             : { reset: () => {} };
 
         function open(nextMode, nextBarcode) {
+            clearResetTimer(); // hold the auto-return while the supervisor enters their PIN
             mode = nextMode;
             barcode = nextBarcode;
             supervisorUserId = null;
@@ -180,6 +254,10 @@ export function initGate(refs) {
             override.setAttribute('aria-hidden', 'true');
             keypad.reset();
             focusInput();
+            // Cancelled back to the (still-displayed) too-early card — re-arm its auto-return so the
+            // name doesn't linger. (When close() follows a successful submit, render() supersedes this.)
+            const current = result.firstElementChild;
+            if (current && !current.querySelector('.gate-decide')) armAutoReset(current, current.getAttribute('data-kind'));
         }
 
         override.querySelectorAll('[data-supervisor-id]').forEach(btn => {


### PR DESCRIPTION
Two small post-ship Gate fixes, each peer-reviewed (one code, one UX). Authored with Claude Code on behalf of @veryaaron. Branched off current prod (`c953623`).

## 1. TicketTailor check-in mirror — actually works now
The mirror is flag-off (`Gate:VendorMirrorEnabled`), so there's **no live impact today** — but it would have failed silently the moment it was enabled. I **verified the real request live against production TicketTailor (HTTP 201)** with a disposable test ticket, which corrected three wrong assumptions in the shipped code:

- **Form-encoded, not JSON.** `CreateCheckInAsync` used `PostAsJsonAsync`; TicketTailor's API ignores a JSON body (every field read null → 400). Now `FormUrlEncodedContent`.
- **`quantity` is required** (and was missing). Now sent (`=1`; one issued ticket per scan).
- **`event_id` is optional** (derived from the ticket); `check_in_at` is accepted.
- **Key scope:** `/v1/check_ins` needs an **Event-manager (or Admin)** key — an Order-manager key 403s. (The `humans-prod` key already has Event-manager.)
- **Retries disabled** (`Attempts = 0`): check-ins aren't idempotent (each POST creates a new `check_in` record), so retrying after a silent success would double-record. `Attempts = 0` isn't exactly-once (Hangfire's at-least-once can still rarely re-run an orphaned job after a crash) — a duplicate vendor-dashboard row is cosmetic and tolerated; `gate_scan_events` is authoritative.

**To enable the mirror:** set `Gate:VendorMirrorEnabled=true` (prod only — non-prod uses the stub) with the Event-manager key.

## 2. Scan-result auto-clear (PII + stuck screen)
The previous scan's verdict card — **including the guest's name** — stayed on the shared kiosk until the next scan (a PII leak, and it looked stuck). Result cards now auto-return to the Ready screen and offer a **"Next ticket"** button:

- **Per-outcome timeout** — ADMIT ~10s; STOP/AMBER ~30s (a refusal gets explained to the guest, so it shouldn't vanish mid-conversation — flagged by the UX review).
- **Tap-to-extend** — any touch on the card pushes the deadline back; a **visible countdown** on the button so staff aren't surprised.
- The interim **ID-confirm** card (shows a name, operator mid-decision) gets a longer **~45s safety** timeout rather than lingering forever.
- The supervisor-override panel pauses the timer during PIN entry.
- Button is solid near-black (translucent/outline washes out in direct sun).

## Verification
- Build clean · `dotnet format` clean · **Gate 121 + Web 339 tests green**.
- TicketTailor request verified live (201) against prod.
- `gate.js` syntax-checked. **Caveat:** the browser/Playwright was unavailable this session, so the auto-clear UI was validated by logic + a UX-specialist review, not a live click-through — worth a quick look on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)