### PR TITLE
Promote QA → production (4 commits)

### DIFF
--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -170,8 +170,10 @@ tap-list because the `GateTerminal` account is route-locked to `/Gate` and so ca
   timeout only (it shows a name but the operator is mid-decision); the supervisor-override panel pauses
   the timer while a PIN is being entered.
 - **No dead-ends / minimal-training affordances** (kiosk is chromeless — no browser back). Every screen
-  has a visible way out: Leaderboard has "← Back to scanning"; the PIN keypad has "← Not you?". "Change"
-  (switch operator) is a deliberate two-tap (it abandons the session). The scan screen has an always-on
+  has a visible way out: Leaderboard has "← Back to scanning"; the PIN keypad has "← Not you?". "End shift"
+  (hand over to the next operator) is a deliberate two-tap button that POSTs `GateController.EndShift` to
+  clear the scanner session **server-side**, so a walk-away can't leave the next person's scans attributed
+  to whoever last claimed. The scan screen has an always-on
   "?" help cheat-sheet (green=admit / red=stop / amber=supervisor), STOP cards spell out the action
   ("Do not admit · if disputed, get the gate lead"), the ID-confirm card has a "Wrong ticket — scan
   again" escape and a visible auto-clear countdown, the override panel has "← Wrong person", and the

--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -52,9 +52,15 @@ admission record. Distinct from the read-only `Scanner` section, which must neve
 - **Personal staff PINs (`gate_staff_pins`)** — each staffer sets a 4-digit PIN the first time they
   claim the gate (`SetOwnPinAsync`, hashed via Identity's `IPasswordHasher`), reused across shifts.
   Claiming the scanner becomes a PIN entry (`/Gate/ClaimPin`), so the leaderboard attribution is a
-  real per-person claim rather than honour-system. **Supervisors** (Admin/Board/TicketAdmin) cannot
-  self-enrol at the anonymous kiosk — their PIN carries override authority, so an admin enrols it out
-  of band (`/Gate/Admin`); the override path is verify-only and rejects un-enrolled supervisors.
+  real per-person claim rather than honour-system. **Claim vs override are decoupled by the
+  `AdminEnrolled` flag on the PIN.** _Everyone_ — supervisors included — may self-enrol a **claim**
+  PIN at the kiosk (`SetOwnPinAsync`, `AdminEnrolled = false`); it attributes scans only. **Override
+  authority** is conferred solely by an **admin enrolment** (`/Gate/Admin` → `AdminSetPinAsync`,
+  `AdminEnrolled = true`). `AuthorizeOverrideAsync` requires all three, server-checked: an
+  admin-enrolled PIN, the correct PIN, AND a currently-held supervisor role — so an attacker
+  cold-setting a supervisor's PIN at the anonymous kiosk gains attribution spoofing only (already
+  possible for any staffer), never override power. The enrolled-supervisor override picker
+  (`GetEnrolledSupervisorIdsAsync`) lists only admin-enrolled supervisors.
   **First-time set** has two guards (claim-only, never on verify): an "is this you?" confirm before a
   PIN is minted in someone's name, and a double-entry (enter twice, must match) so a mis-typed PIN
   can't silently lock a volunteer out (there is no self-service reset — an admin clears it). Every

--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -55,6 +55,11 @@ admission record. Distinct from the read-only `Scanner` section, which must neve
   real per-person claim rather than honour-system. **Supervisors** (Admin/Board/TicketAdmin) cannot
   self-enrol at the anonymous kiosk — their PIN carries override authority, so an admin enrols it out
   of band (`/Gate/Admin`); the override path is verify-only and rejects un-enrolled supervisors.
+  **First-time set** has two guards (claim-only, never on verify): an "is this you?" confirm before a
+  PIN is minted in someone's name, and a double-entry (enter twice, must match) so a mis-typed PIN
+  can't silently lock a volunteer out (there is no self-service reset — an admin clears it). Every
+  PIN **set/reset is audited** (`GateStaffPinSet`/`GateStaffPinReset` with the acting user — the
+  staffer on self-enrol, the admin on admin-set/reset); PIN values are never logged.
 - **Supervisor override** — a too-early scan (e.g. a Friday Early-Entry ticket scanned on Wednesday)
   STOPs with a precise reason (the holder's EE date vs today, or "no early entry · general entry
   opens …" — date only, never the EE source) and offers a **supervisor override**: the supervisor

--- a/src/Humans.Application/Interfaces/Gate/IGateService.cs
+++ b/src/Humans.Application/Interfaces/Gate/IGateService.cs
@@ -60,8 +60,8 @@ public interface IGateService : IApplicationService
     /// </summary>
     Task<GatePinSetResult> SetOwnPinAsync(Guid userId, string pin, CancellationToken ct = default);
 
-    /// <summary>Admin sets/initialises any user's PIN (incl. supervisors), from the gate admin page. Returns false if the PIN is invalid.</summary>
-    Task<bool> AdminSetPinAsync(Guid userId, string pin, CancellationToken ct = default);
+    /// <summary>Admin sets/initialises any user's PIN (incl. supervisors), from the gate admin page. <paramref name="actorUserId"/> is the acting admin (audit). Returns false if the PIN is invalid.</summary>
+    Task<bool> AdminSetPinAsync(Guid userId, string pin, Guid actorUserId, CancellationToken ct = default);
 
     /// <summary>Verify a staffer's PIN for claiming the scanner. Timing-safe. False if no PIN set or mismatch.</summary>
     Task<bool> VerifyPinAsync(Guid userId, string pin, CancellationToken ct = default);
@@ -73,8 +73,8 @@ public interface IGateService : IApplicationService
     /// </summary>
     Task<bool> AuthorizeOverrideAsync(Guid supervisorUserId, string pin, CancellationToken ct = default);
 
-    /// <summary>Clear a user's PIN (admin reset). They re-enrol on next claim.</summary>
-    Task ClearPinAsync(Guid userId, CancellationToken ct = default);
+    /// <summary>Clear a user's PIN (admin reset). <paramref name="actorUserId"/> is the acting admin (audit). They re-enrol on next claim.</summary>
+    Task ClearPinAsync(Guid userId, Guid actorUserId, CancellationToken ct = default);
 
     /// <summary>
     /// The user-ids of every gate-supervisor (Admin/Board/TicketAdmin) who has a PIN enrolled —

--- a/src/Humans.Application/Interfaces/Gate/IGateService.cs
+++ b/src/Humans.Application/Interfaces/Gate/IGateService.cs
@@ -100,9 +100,6 @@ public enum GatePinSetResult
 
     /// <summary>The PIN is not exactly four digits or is too easily guessed (e.g. 0000, 1234, repeats).</summary>
     InvalidPin,
-
-    /// <summary>The user holds a supervisor role — supervisor PINs must be set by an admin, not self-enrolled at the kiosk.</summary>
-    SupervisorMustBeAdminEnrolled,
 }
 
 /// <summary>Write-free result of evaluating a scan, before the agent's ID decision.</summary>

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -1,5 +1,6 @@
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Gate;
@@ -32,6 +33,7 @@ public sealed class GateService(
     IShiftManagementService shifts,
     IRoleAssignmentService roles,
     IPasswordHasher<GateStaffPin> pinHasher,
+    IAuditLogService auditLog,
     IClock clock) : IGateService, IUserMerge, IUserDataContributor
 {
     /// <summary>How far either side of "now" a gate shift may start to count as current.</summary>
@@ -207,14 +209,19 @@ public sealed class GateService(
         if (await IsSupervisorAsync(userId, ct))
             return GatePinSetResult.SupervisorMustBeAdminEnrolled;
         await StorePinAsync(userId, pin, ct);
+        // Self-enrol at the kiosk: actor == the claimed staffer (no PIN value is ever logged).
+        await auditLog.LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), userId,
+            "Staffer self-enrolled their gate PIN at the kiosk", userId);
         return GatePinSetResult.Ok;
     }
 
-    public async Task<bool> AdminSetPinAsync(Guid userId, string pin, CancellationToken ct = default)
+    public async Task<bool> AdminSetPinAsync(Guid userId, string pin, Guid actorUserId, CancellationToken ct = default)
     {
         if (!IsValidPin(pin))
             return false;
         await StorePinAsync(userId, pin, ct);
+        await auditLog.LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), userId,
+            "Admin set a staffer's gate PIN", actorUserId);
         return true;
     }
 
@@ -235,8 +242,12 @@ public sealed class GateService(
         return await IsSupervisorAsync(supervisorUserId, ct);
     }
 
-    public Task ClearPinAsync(Guid userId, CancellationToken ct = default) =>
-        repository.DeleteStaffPinAsync(userId, ct);
+    public async Task ClearPinAsync(Guid userId, Guid actorUserId, CancellationToken ct = default)
+    {
+        await repository.DeleteStaffPinAsync(userId, ct);
+        await auditLog.LogAsync(AuditAction.GateStaffPinReset, nameof(GateStaffPin), userId,
+            "Admin reset a staffer's gate PIN", actorUserId);
+    }
 
     public async Task<IReadOnlyList<Guid>> GetEnrolledSupervisorIdsAsync(CancellationToken ct = default)
     {

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -204,14 +204,14 @@ public sealed class GateService(
     {
         if (!IsValidPin(pin))
             return GatePinSetResult.InvalidPin;
-        // A supervisor's PIN carries override authority — never let it be minted from the
-        // anonymous kiosk (an attacker could cold-enrol a supervisor and impersonate them).
-        if (await IsSupervisorAsync(userId, ct))
-            return GatePinSetResult.SupervisorMustBeAdminEnrolled;
-        await StorePinAsync(userId, pin, ct);
+        // Everyone — supervisors included — may self-enrol a CLAIM PIN (attribution only). It carries
+        // NO override authority: AdminEnrolled stays false and AuthorizeOverrideAsync requires it true.
+        // So an attacker cold-setting a supervisor's PIN at the anonymous kiosk gains attribution
+        // spoofing (already possible for any staffer), never override power — which stays admin-enrolled.
+        await StorePinAsync(userId, pin, adminEnrolled: false, ct);
         // Self-enrol at the kiosk: actor == the claimed staffer (no PIN value is ever logged).
         await auditLog.LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), userId,
-            "Staffer self-enrolled their gate PIN at the kiosk", userId);
+            "Staffer self-enrolled their gate claim PIN at the kiosk", userId);
         return GatePinSetResult.Ok;
     }
 
@@ -219,9 +219,10 @@ public sealed class GateService(
     {
         if (!IsValidPin(pin))
             return false;
-        await StorePinAsync(userId, pin, ct);
+        // Admin enrolment is the only path that confers supervisor-override authority (AdminEnrolled = true).
+        await StorePinAsync(userId, pin, adminEnrolled: true, ct);
         await auditLog.LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), userId,
-            "Admin set a staffer's gate PIN", actorUserId);
+            "Admin set a staffer's gate PIN (override-enrolled)", actorUserId);
         return true;
     }
 
@@ -236,8 +237,13 @@ public sealed class GateService(
 
     public async Task<bool> AuthorizeOverrideAsync(Guid supervisorUserId, string pin, CancellationToken ct = default)
     {
-        // Verify-only: enrolled + correct PIN + currently holds a supervisor role. Never enrol here.
-        if (!await VerifyPinAsync(supervisorUserId, pin, ct))
+        // Verify-only, never enrol here. Requires all three, server-checked: an ADMIN-ENROLLED PIN
+        // (a self-set claim PIN — AdminEnrolled=false — can never authorize an override), the correct
+        // PIN, AND a currently-held supervisor role.
+        var row = await repository.GetStaffPinAsync(supervisorUserId, ct);
+        if (row is not { AdminEnrolled: true })
+            return false;
+        if (pinHasher.VerifyHashedPassword(row, row.PinHash, pin) == PasswordVerificationResult.Failed)
             return false;
         return await IsSupervisorAsync(supervisorUserId, ct);
     }
@@ -251,8 +257,8 @@ public sealed class GateService(
 
     public async Task<IReadOnlyList<Guid>> GetEnrolledSupervisorIdsAsync(CancellationToken ct = default)
     {
-        // Union the supervisor-role holders, then keep only those with a PIN — an un-enrolled
-        // supervisor can't override anyway, so listing them would just offer dead picks.
+        // Union the supervisor-role holders, then keep only those with an ADMIN-ENROLLED PIN — a
+        // self-set claim PIN can't authorize an override, so listing those would offer dead picks.
         var supervisors = new HashSet<Guid>();
         foreach (var role in SupervisorRoles)
             foreach (var id in await roles.GetActiveUserIdsInRoleAsync(role, ct))
@@ -260,7 +266,7 @@ public sealed class GateService(
 
         var enrolled = new List<Guid>();
         foreach (var id in supervisors)
-            if (await repository.GetStaffPinAsync(id, ct) is not null)
+            if (await repository.GetStaffPinAsync(id, ct) is { AdminEnrolled: true })
                 enrolled.Add(id);
         return enrolled;
     }
@@ -273,10 +279,10 @@ public sealed class GateService(
         return false;
     }
 
-    private async Task StorePinAsync(Guid userId, string pin, CancellationToken ct)
+    private async Task StorePinAsync(Guid userId, string pin, bool adminEnrolled, CancellationToken ct)
     {
         var now = clock.GetCurrentInstant();
-        var entity = new GateStaffPin { UserId = userId, CreatedAt = now, UpdatedAt = now };
+        var entity = new GateStaffPin { UserId = userId, CreatedAt = now, UpdatedAt = now, AdminEnrolled = adminEnrolled };
         entity.PinHash = pinHasher.HashPassword(entity, pin);
         await repository.UpsertStaffPinAsync(entity, ct);
     }

--- a/src/Humans.Domain/Entities/GateStaffPin.cs
+++ b/src/Humans.Domain/Entities/GateStaffPin.cs
@@ -23,4 +23,13 @@ public class GateStaffPin
 
     /// <summary>When the PIN was last set/reset.</summary>
     public Instant UpdatedAt { get; set; }
+
+    /// <summary>
+    /// True only when an admin set this PIN out of band (<c>/Gate/Admin</c>) — the enrolment that
+    /// confers <b>supervisor-override</b> authority. A staffer who self-enrols at the kiosk gets
+    /// <c>false</c>: their PIN attributes scans (claim) but can never authorize an override, so an
+    /// attacker cold-setting a supervisor's PIN at the anonymous kiosk gains attribution only, never
+    /// override power. The override authorization path requires this true.
+    /// </summary>
+    public bool AdminEnrolled { get; set; }
 }

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -191,6 +191,9 @@ public enum AuditAction
     EarlyEntryRevoked,
     StorePaymentsReconciled,
     GateTerminalPasswordSet,
+    // Gate personal-PIN lifecycle: who set (self-enrol or admin) or reset a staffer's claim PIN.
+    GateStaffPinSet,
+    GateStaffPinReset,
     SurveyCreated,
     SurveyUpdated,
     SurveyOpened,

--- a/src/Humans.Infrastructure/Data/Configurations/Gate/GateStaffPinConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Gate/GateStaffPinConfiguration.cs
@@ -20,5 +20,10 @@ public sealed class GateStaffPinConfiguration : IEntityTypeConfiguration<GateSta
 
         builder.Property(x => x.CreatedAt).IsRequired();
         builder.Property(x => x.UpdatedAt).IsRequired();
+
+        // Override-authority flag. Plain IsRequired (no HasDefaultValue — that bool-sentinel makes EF
+        // omit a `false` from writes). The migration's AddColumn supplies the one-time backfill default
+        // for existing rows; every write sets the value explicitly from the entity.
+        builder.Property(x => x.AdminEnrolled).IsRequired();
     }
 }

--- a/src/Humans.Infrastructure/Migrations/20260701005052_AddGateStaffPinAdminEnrolled.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260701005052_AddGateStaffPinAdminEnrolled.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701005052_AddGateStaffPinAdminEnrolled")]
+    partial class AddGateStaffPinAdminEnrolled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260701005052_AddGateStaffPinAdminEnrolled.cs
+++ b/src/Humans.Infrastructure/Migrations/20260701005052_AddGateStaffPinAdminEnrolled.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGateStaffPinAdminEnrolled : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AdminEnrolled",
+                table: "gate_staff_pins",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AdminEnrolled",
+                table: "gate_staff_pins");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Repositories/Gate/GateRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Gate/GateRepository.cs
@@ -99,6 +99,7 @@ internal sealed class GateRepository(IDbContextFactory<HumansDbContext> factory)
                     PinHash = fromPin.PinHash,
                     CreatedAt = fromPin.CreatedAt,
                     UpdatedAt = fromPin.UpdatedAt,
+                    AdminEnrolled = fromPin.AdminEnrolled, // keep the survivor's override authority
                 });
             }
             ctx.Set<GateStaffPin>().Remove(fromPin);
@@ -173,6 +174,7 @@ internal sealed class GateRepository(IDbContextFactory<HumansDbContext> factory)
         {
             existing.PinHash = pin.PinHash;
             existing.UpdatedAt = pin.UpdatedAt;
+            existing.AdminEnrolled = pin.AdminEnrolled;
         }
 
         await ctx.SaveChangesAsync(ct);

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -146,6 +146,19 @@ public sealed class GateController(
             : await SetClaimPinAsync(userId, name, status, pin, ct);
     }
 
+    [HttpPost("EndShift")]
+    [Authorize(Policy = PolicyNames.GateAdmit)]
+    [ValidateAntiForgeryToken]
+    public IActionResult EndShift()
+    {
+        // End the current scanner's session so the terminal drops back to "Who is scanning?".
+        // Clearing attribution server-side (not just navigating away) means a walk-away can't
+        // leave the next person's scans recorded against whoever last claimed — the session
+        // otherwise survives ~8h of idle, long past a single staffer's shift.
+        HttpContext.Session.Remove(ScannerSessionKey);
+        return RedirectToAction(nameof(Claim));
+    }
+
     // Name-only people search for the claim screen. The route-locked kiosk can't reach
     // /api/profiles/search (that lock is what keeps the supervisor-override picker a tap-list),
     // so the claim picker points here instead. Burner names only — no email, no broad fields —

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -224,9 +224,11 @@ public sealed class GateController(
     [Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
     public async Task<IActionResult> SetStaffPin(Guid userId, string? pin, CancellationToken ct)
     {
+        if (GetCurrentUserId() is not { } actor)
+            return Unauthorized();
         if (userId == Guid.Empty)
             SetError("Pick a person before setting a PIN.");
-        else if (await gate.AdminSetPinAsync(userId, pin ?? string.Empty, ct))
+        else if (await gate.AdminSetPinAsync(userId, pin ?? string.Empty, actor, ct))
             SetSuccess("PIN set.");
         else
             SetError("PIN must be 4 digits and not trivially guessable (no 1234, 0000, or repeats).");
@@ -240,11 +242,13 @@ public sealed class GateController(
     [Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
     public async Task<IActionResult> ResetStaffPin(Guid userId, CancellationToken ct)
     {
+        if (GetCurrentUserId() is not { } actor)
+            return Unauthorized();
         if (userId == Guid.Empty)
             SetError("Pick a person before resetting a PIN.");
         else
         {
-            await gate.ClearPinAsync(userId, ct);
+            await gate.ClearPinAsync(userId, actor, ct);
             SetSuccess("PIN reset — they'll set a new one on their next claim.");
         }
 

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -1,7 +1,9 @@
 using Hangfire;
+using Humans.Application;
 using Humans.Application.Interfaces.Gate;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
+using Humans.Domain.Enums;
 using Humans.Infrastructure.Jobs;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
@@ -161,8 +163,9 @@ public sealed class GateController(
 
     // Name-only people search for the claim screen. The route-locked kiosk can't reach
     // /api/profiles/search (that lock is what keeps the supervisor-override picker a tap-list),
-    // so the claim picker points here instead. Burner names only — no email, no broad fields —
-    // and it stays inside the /Gate route-lock.
+    // so the claim picker points here instead. Matching is burner-name only — never by email or
+    // broad fields — but each result shows a *masked* email as a disambiguator (see below), and it
+    // stays inside the /Gate route-lock.
     [HttpGet("Search")]
     public async Task<IActionResult> Search(string? q, CancellationToken ct)
     {
@@ -170,14 +173,49 @@ public sealed class GateController(
         if (query.Length < 2)
             return Json(Array.Empty<HumanLookupSearchResult>());
 
-        // Same typed shape /api/profiles/search returns to this picker (no Detail —
-        // the kiosk search is name-only). memory/code/search-endpoint-response-shape.md.
-        var matches = await UserService.SearchUsersAsync(query, PersonSearchFields.Name, 10, ct);
-        var rows = matches
+        // Name-only search (never email — see the note above). To tell same-name staffers apart
+        // (many volunteers share a first name), each result carries a *masked* primary email as a
+        // disambiguator — enough to recognise your own address, not enough to broadcast it. The
+        // effective email is read per result (cached) and masked here at the presentation layer, so
+        // the search itself and its response shape stay email-free. Mirrors BuildSupervisorOptionsAsync.
+        var matches = (await UserService.SearchUsersAsync(query, PersonSearchFields.Name, 10, ct))
             .OrderByRelevance()
-            .Select(m => new HumanLookupSearchResult(m.UserId, m.BurnerName, ProfilePictureUrl: m.ProfilePictureUrl))
             .ToList();
+        var rows = new List<HumanLookupSearchResult>(matches.Count);
+        foreach (var m in matches)
+        {
+            var info = await UserService.GetUserInfoAsync(m.UserId, ct);
+            rows.Add(new HumanLookupSearchResult(
+                m.UserId, m.BurnerName, Detail: MaskEmail(PublicEmail(info)), ProfilePictureUrl: m.ProfilePictureUrl));
+        }
         return Json(rows);
+    }
+
+    // The one email safe to hint on a shared, role-less kiosk: a verified address the owner set to
+    // org-public (AllActiveProfiles) visibility — never a Board/coordinator/team-scoped address, and
+    // never a merged/GDPR tombstone. Mirrors the Bio-bucket public-email rule; if the person has no
+    // org-public email, the picker simply shows no disambiguator (the photo still helps).
+    private static string? PublicEmail(UserInfo? info) =>
+        info is null || info.IsTombstone
+            ? null
+            : info.UserEmails
+                .Where(e => e.IsVerified && e.Visibility == ContactFieldVisibility.AllActiveProfiles)
+                .OrderByDescending(e => e.IsPrimary)
+                .Select(e => e.Email)
+                .FirstOrDefault();
+
+    // Masks an email for the shared kiosk picker: first char + bullets + last char of the local
+    // part, then the full domain (paul.smith@gmail.com → p•••h@gmail.com). Recognisable to its
+    // owner, minimal to a bystander. Presentation-only — never used for matching.
+    private static string? MaskEmail(string? email)
+    {
+        if (string.IsNullOrWhiteSpace(email)) return null;
+        var at = email.IndexOf('@', StringComparison.Ordinal);
+        if (at <= 0 || at == email.Length - 1) return null;
+        var local = email[..at];
+        var domain = email[(at + 1)..];
+        var shown = local.Length <= 2 ? $"{local[0]}•••" : $"{local[0]}•••{local[^1]}";
+        return $"{shown}@{domain}";
     }
 
     [HttpGet("Leaderboard")]

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -121,7 +121,7 @@ public sealed class GateController(
             return RedirectToAction(nameof(Claim));
 
         // Don't stamp the session yet — resolve the staffer's PIN status and hand off to the
-        // keypad (set a new PIN, verify the existing one, or block an un-enrolled supervisor).
+        // keypad (set a new PIN, or verify the existing one).
         var status = await gate.GetPinStatusAsync(userId, ct);
         return View("Pin", GatePinViewModel.ForClaim(userId, info.BurnerName, status));
     }
@@ -140,10 +140,6 @@ public sealed class GateController(
         // Re-derive the mode from the server (never trust a client-supplied set/verify hint).
         var status = await gate.GetPinStatusAsync(userId, ct);
         var name = info.BurnerName;
-
-        // A supervisor with no PIN can't self-enrol at the anonymous kiosk — re-show the block.
-        if (status is { HasPin: false, IsSupervisor: true })
-            return View("Pin", GatePinViewModel.ForClaim(userId, name, status));
 
         return status.HasPin
             ? await VerifyClaimAsync(userId, name, status, pin, ct)
@@ -278,10 +274,9 @@ public sealed class GateController(
         await gate.SetOwnPinAsync(userId, pin ?? string.Empty, ct) switch
         {
             GatePinSetResult.Ok => StampAndScan(userId),
-            GatePinSetResult.InvalidPin => View("Pin", GatePinViewModel.ForClaim(
+            // InvalidPin (or any non-Ok) → re-show the keypad with the "pick a better PIN" hint.
+            _ => View("Pin", GatePinViewModel.ForClaim(
                 userId, name, status, "Pick a less obvious PIN — not 1234, 0000, or repeats")),
-            // Role changed to supervisor between the GET and this POST — show the admin-enrol block.
-            _ => View("Pin", new GatePinViewModel(userId, name, GatePinMode.BlockedSupervisor, null)),
         };
 
     private IActionResult StampAndScan(Guid userId)

--- a/src/Humans.Web/Models/Gate/GateViewModels.cs
+++ b/src/Humans.Web/Models/Gate/GateViewModels.cs
@@ -130,9 +130,6 @@ public enum GatePinMode
 
     /// <summary>Returning — enter the existing PIN to take over the scanner.</summary>
     Verify,
-
-    /// <summary>A supervisor with no PIN — they can't self-enrol; an admin must set it up.</summary>
-    BlockedSupervisor,
 }
 
 /// <summary>The full-screen PIN keypad shown after a name is picked on the claim screen.</summary>
@@ -140,12 +137,9 @@ public sealed record GatePinViewModel(Guid UserId, string DisplayName, GatePinMo
 {
     /// <summary>
     /// Resolve the keypad mode from the server-derived PIN status (never a client-supplied hint):
-    /// has a PIN → Verify; no PIN but a supervisor → Blocked (admin must enrol them); otherwise Set.
+    /// has a PIN → Verify; otherwise Set. Everyone — supervisors included — may self-enrol a claim
+    /// PIN; it attributes scans only, never authorizes an override (that stays admin-enrolled).
     /// </summary>
     public static GatePinViewModel ForClaim(Guid userId, string displayName, GatePinStatus status, string? error = null) =>
-        new(userId, displayName,
-            status.HasPin ? GatePinMode.Verify
-            : status.IsSupervisor ? GatePinMode.BlockedSupervisor
-            : GatePinMode.Set,
-            error);
+        new(userId, displayName, status.HasPin ? GatePinMode.Verify : GatePinMode.Set, error);
 }

--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -15,10 +15,12 @@
         <span>Scanning as <strong>@Model.ScannerName</strong></span>
         <span class="gate-asof" data-asof="@Model.DataAsOf"
               title="Tap to reload">loaded…</span>
-        @* "Change" abandons the session (re-enter PIN), so it's a deliberate two-tap (gate.js) to
-           stop a mid-queue fat-finger from dumping the operator back to the roster. *@
-        <a asp-action="Claim" class="gate-topbar-link" data-confirm-change>Change</a>
         <a asp-action="Leaderboard" class="gate-topbar-link">Leaderboard</a>
+        @* "End shift" clears the scanner session (the next person re-claims with their PIN), so it's a
+           deliberate two-tap (gate.js) to stop a mid-queue fat-finger from dumping the operator out. *@
+        <form method="post" asp-action="EndShift" class="gate-endshift-form">
+            <button type="submit" class="gate-endshift-btn" data-confirm-change="Tap again to end shift">End shift</button>
+        </form>
     </div>
 
     @if (!Model.CutoffConfigured)

--- a/src/Humans.Web/Views/Gate/Pin.cshtml
+++ b/src/Humans.Web/Views/Gate/Pin.cshtml
@@ -25,7 +25,7 @@
     {
         <div class="gate-pin-head">
             <div class="gate-pin-name">@Model.DisplayName</div>
-            <div class="gate-pin-prompt">@(Model.Mode == GatePinMode.Set ? "Set a 4-digit PIN" : "Enter your PIN")</div>
+            <div class="gate-pin-prompt" data-gate-prompt>@(Model.Mode == GatePinMode.Set ? "Set a 4-digit PIN" : "Enter your PIN")</div>
             @if (Model.Mode == GatePinMode.Set)
             {
                 <div class="gate-pin-sub">You'll reuse this each shift to claim the gate.</div>
@@ -34,9 +34,23 @@
             {
                 <div class="gate-pin-error" role="alert">@Model.Error</div>
             }
+            @* Client-side message for a double-entry mismatch (set mode) — filled by gate-pin.js. *@
+            <div class="gate-pin-error d-none" role="alert" data-gate-error></div>
         </div>
 
-        <form id="gate-pin-form" method="post" asp-action="ClaimPin" autocomplete="off">
+        @* First-time set only: confirm the staffer is the person they picked before minting a PIN in
+           their name (every scan is attributed to them). The keypad stays hidden until they confirm. *@
+        @if (Model.Mode == GatePinMode.Set)
+        {
+            <div class="gate-pin-confirm" data-gate-confirm>
+                <div class="gate-pin-confirm-q">Is this you?</div>
+                <p class="gate-pin-confirm-note">Every ticket you scan will be recorded as <strong>@Model.DisplayName</strong>.</p>
+                <button type="button" class="gate-pin-confirm-yes" data-gate-confirm-yes>Yes — that's me</button>
+            </div>
+        }
+
+        <form id="gate-pin-form" method="post" asp-action="ClaimPin" autocomplete="off"
+              class="@(Model.Mode == GatePinMode.Set ? "d-none" : "")">
             <input type="hidden" name="userId" value="@Model.UserId" />
             <input type="hidden" name="pin" id="gate-pin-value" />
             <partial name="_PinPad" />
@@ -59,7 +73,12 @@
             initClaimPin({
                 container: document.querySelector('[data-gate-keypad]'),
                 form: document.getElementById('gate-pin-form'),
-                valueInput: document.getElementById('gate-pin-value')
+                valueInput: document.getElementById('gate-pin-value'),
+                confirmTwice: @(Model.Mode == GatePinMode.Set ? "true" : "false"),
+                confirmEl: document.querySelector('[data-gate-confirm]'),
+                confirmYes: document.querySelector('[data-gate-confirm-yes]'),
+                promptEl: document.querySelector('[data-gate-prompt]'),
+                errorEl: document.querySelector('[data-gate-error]')
             });
         </script>
     }

--- a/src/Humans.Web/Views/Gate/Pin.cshtml
+++ b/src/Humans.Web/Views/Gate/Pin.cshtml
@@ -9,77 +9,59 @@
 }
 
 <div class="gate-pin-screen">
-    @if (Model.Mode == GatePinMode.BlockedSupervisor)
-    {
-        <div class="gate-pin-blocked" role="alert">
-            <div class="gate-pin-icon" aria-hidden="true"><i class="fa-solid fa-user-shield"></i></div>
-            <div class="gate-pin-name">@Model.DisplayName</div>
-            <p class="gate-pin-blocked-text">
-                Supervisor PINs carry override authority, so they're set up ahead of time — not here at
-                the gate. <strong>Ask the gate lead to set up your PIN</strong>, then come back and tap your name.
-            </p>
-            <a asp-action="Claim" class="gate-pin-back">&larr; Back to names</a>
-        </div>
-    }
-    else
-    {
-        <div class="gate-pin-head">
-            <div class="gate-pin-name">@Model.DisplayName</div>
-            <div class="gate-pin-prompt" data-gate-prompt>@(Model.Mode == GatePinMode.Set ? "Set a 4-digit PIN" : "Enter your PIN")</div>
-            @if (Model.Mode == GatePinMode.Set)
-            {
-                <div class="gate-pin-sub">You'll reuse this each shift to claim the gate.</div>
-            }
-            @if (!string.IsNullOrEmpty(Model.Error))
-            {
-                <div class="gate-pin-error" role="alert">@Model.Error</div>
-            }
-            @* Client-side message for a double-entry mismatch (set mode) — filled by gate-pin.js. *@
-            <div class="gate-pin-error d-none" role="alert" data-gate-error></div>
-        </div>
-
-        @* First-time set only: confirm the staffer is the person they picked before minting a PIN in
-           their name (every scan is attributed to them). The keypad stays hidden until they confirm. *@
+    <div class="gate-pin-head">
+        <div class="gate-pin-name">@Model.DisplayName</div>
+        <div class="gate-pin-prompt" data-gate-prompt>@(Model.Mode == GatePinMode.Set ? "Set a 4-digit PIN" : "Enter your PIN")</div>
         @if (Model.Mode == GatePinMode.Set)
         {
-            <div class="gate-pin-confirm" data-gate-confirm>
-                <div class="gate-pin-confirm-q">Is this you?</div>
-                <p class="gate-pin-confirm-note">Every ticket you scan will be recorded as <strong>@Model.DisplayName</strong>.</p>
-                <button type="button" class="gate-pin-confirm-yes" data-gate-confirm-yes>Yes — that's me</button>
-            </div>
+            <div class="gate-pin-sub">You'll reuse this each shift to claim the gate.</div>
         }
+        @if (!string.IsNullOrEmpty(Model.Error))
+        {
+            <div class="gate-pin-error" role="alert">@Model.Error</div>
+        }
+        @* Client-side message for a double-entry mismatch (set mode) — filled by gate-pin.js. *@
+        <div class="gate-pin-error d-none" role="alert" data-gate-error></div>
+    </div>
 
-        <form id="gate-pin-form" method="post" asp-action="ClaimPin" autocomplete="off"
-              class="@(Model.Mode == GatePinMode.Set ? "d-none" : "")">
-            <input type="hidden" name="userId" value="@Model.UserId" />
-            <input type="hidden" name="pin" id="gate-pin-value" />
-            <partial name="_PinPad" />
-        </form>
-
-        <a asp-action="Claim" class="gate-pin-back">&larr; Not you? Pick a different name</a>
+    @* First-time set only: confirm the staffer is the person they picked before minting a PIN in
+       their name (every scan is attributed to them). The keypad stays hidden until they confirm. *@
+    @if (Model.Mode == GatePinMode.Set)
+    {
+        <div class="gate-pin-confirm" data-gate-confirm>
+            <div class="gate-pin-confirm-q">Is this you?</div>
+            <p class="gate-pin-confirm-note">Every ticket you scan will be recorded as <strong>@Model.DisplayName</strong>.</p>
+            <button type="button" class="gate-pin-confirm-yes" data-gate-confirm-yes>Yes — that's me</button>
+        </div>
     }
+
+    <form id="gate-pin-form" method="post" asp-action="ClaimPin" autocomplete="off"
+          class="@(Model.Mode == GatePinMode.Set ? "d-none" : "")">
+        <input type="hidden" name="userId" value="@Model.UserId" />
+        <input type="hidden" name="pin" id="gate-pin-value" />
+        <partial name="_PinPad" />
+    </form>
+
+    <a asp-action="Claim" class="gate-pin-back">&larr; Not you? Pick a different name</a>
 </div>
 
-@if (Model.Mode != GatePinMode.BlockedSupervisor)
-{
-    @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
-    @section Scripts {
-        @* The keypad itself is a cache-busted classic script (no module import to go stale); the
-           page module wires it to the claim form. *@
-        <script src="@Url.Content("~/js/gate/gate-keypad.js")" asp-append-version="true"
-                nonce="@Context.Items["CspNonce"]"></script>
-        <script nonce="@Context.Items["CspNonce"]" type="module">
-            import { initClaimPin } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/gate/gate-pin.js"))';
-            initClaimPin({
-                container: document.querySelector('[data-gate-keypad]'),
-                form: document.getElementById('gate-pin-form'),
-                valueInput: document.getElementById('gate-pin-value'),
-                confirmTwice: @(Model.Mode == GatePinMode.Set ? "true" : "false"),
-                confirmEl: document.querySelector('[data-gate-confirm]'),
-                confirmYes: document.querySelector('[data-gate-confirm-yes]'),
-                promptEl: document.querySelector('[data-gate-prompt]'),
-                errorEl: document.querySelector('[data-gate-error]')
-            });
-        </script>
-    }
+@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
+@section Scripts {
+    @* The keypad itself is a cache-busted classic script (no module import to go stale); the
+       page module wires it to the claim form. *@
+    <script src="@Url.Content("~/js/gate/gate-keypad.js")" asp-append-version="true"
+            nonce="@Context.Items["CspNonce"]"></script>
+    <script nonce="@Context.Items["CspNonce"]" type="module">
+        import { initClaimPin } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/gate/gate-pin.js"))';
+        initClaimPin({
+            container: document.querySelector('[data-gate-keypad]'),
+            form: document.getElementById('gate-pin-form'),
+            valueInput: document.getElementById('gate-pin-value'),
+            confirmTwice: @(Model.Mode == GatePinMode.Set ? "true" : "false"),
+            confirmEl: document.querySelector('[data-gate-confirm]'),
+            confirmYes: document.querySelector('[data-gate-confirm-yes]'),
+            promptEl: document.querySelector('[data-gate-prompt]'),
+            errorEl: document.querySelector('[data-gate-error]')
+        });
+    </script>
 }

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -132,9 +132,6 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
     border: none; border-radius: 14px; padding: 1.1rem; min-height: 78px; cursor: pointer;
 }
 .gate-pin-confirm-yes:active { background: #095e24; }
-.gate-pin-blocked { max-width: 460px; margin: 2rem auto 0; text-align: center; color: #1e2a33; }
-.gate-pin-icon { font-size: 3.2rem; color: #B26A00; }
-.gate-pin-blocked-text { font-size: 1.2rem; line-height: 1.5; margin-top: .75rem; color: #2b3440; }
 
 /* ── Supervisor-override panel (Index.cshtml) ───────────────────────────────
    Full-viewport scrim so the supervisor's name + PIN entry is the only focus. */

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -14,7 +14,14 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
     font-size: 1rem; color: #5f6b76; margin-bottom: .75rem;
 }
 .gate-topbar-link { margin-left: auto; font-weight: 600; }
-.gate-topbar-link + .gate-topbar-link { margin-left: .75rem; }
+.gate-topbar-link ~ .gate-endshift-form { margin: 0; }
+/* "End shift" is a button (not a faint link) so the handover to the next scanner is obvious. */
+.gate-endshift-btn {
+    font: inherit; font-weight: 700; cursor: pointer; line-height: 1.2;
+    color: #2b3440; background: transparent;
+    border: 2px solid #2b3440; border-radius: 6px; padding: .35rem .85rem;
+}
+.gate-endshift-btn:hover, .gate-endshift-btn:focus { background: #2b3440; color: #fff; }
 /* Freshness indicator — readable contrast; reddens once the terminal's been open a while. */
 .gate-asof { color: #2b3440; font-weight: 600; }
 .gate-asof-stale { color: #B11217; }
@@ -201,8 +208,8 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
     font-size: 1.05rem; font-weight: 600; cursor: pointer; margin-bottom: .25rem;
 }
 
-/* "Change" link while armed for the confirming second tap. */
-.gate-topbar-link.gate-armed { color: #B11217; font-weight: 700; }
+/* "End shift" button while armed for the confirming second tap. */
+.gate-endshift-btn.gate-armed { color: #fff; background: #B11217; border-color: #B11217; }
 
 /* The freshness line doubles as the reload control on the chromeless kiosk. */
 .gate-asof { cursor: pointer; }

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -111,6 +111,9 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 .gate-pin-head { margin-bottom: 1.25rem; }
 .gate-pin-name { font-size: 2.1rem; font-weight: 700; color: #1e2a33; line-height: 1.1; }
 .gate-pin-prompt { font-size: 1.4rem; color: #2b3440; margin-top: .35rem; }
+/* Re-enter (confirm) step of a first-time set — stands out from the neutral "set" prompt so the
+   volunteer notices the keypad is asking a second time, not repeating itself. */
+.gate-pin-prompt-confirm { color: #0B7A2F; font-weight: 700; }
 .gate-pin-sub { font-size: 1.05rem; color: #5f6b76; margin-top: .25rem; }
 .gate-pin-error {
     margin-top: .9rem; padding: .6rem 1rem; border-radius: 10px;
@@ -119,6 +122,16 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 .gate-pin-back {
     display: inline-block; margin-top: 1.5rem; font-size: 1.1rem; font-weight: 600; color: #5f6b76;
 }
+/* "Is this you?" confirm before a first-time PIN set — big, unmissable, glove-friendly. */
+.gate-pin-confirm { max-width: 440px; margin: 0 auto; }
+.gate-pin-confirm-q { font-size: 1.6rem; font-weight: 700; color: #1e2a33; }
+.gate-pin-confirm-note { font-size: 1.2rem; color: #2b3440; line-height: 1.45; margin: .5rem 0 1.5rem; }
+.gate-pin-confirm-note strong { color: #1e2a33; }
+.gate-pin-confirm-yes {
+    width: 100%; font-size: 1.6rem; font-weight: 700; color: #fff; background: #0B7A2F;
+    border: none; border-radius: 14px; padding: 1.1rem; min-height: 78px; cursor: pointer;
+}
+.gate-pin-confirm-yes:active { background: #095e24; }
 .gate-pin-blocked { max-width: 460px; margin: 2rem auto 0; text-align: center; color: #1e2a33; }
 .gate-pin-icon { font-size: 3.2rem; color: #B26A00; }
 .gate-pin-blocked-text { font-size: 1.2rem; line-height: 1.5; margin-top: .75rem; color: #2b3440; }

--- a/src/Humans.Web/wwwroot/js/gate/gate-pin.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate-pin.js
@@ -5,13 +5,51 @@
 // this page with an error and an empty keypad (state resets naturally on reload), so there's no
 // AJAX or error-merging to get wrong. The keypad itself comes from window.initGateKeypad, a
 // cache-busted classic script, so this module has no import to go stale on the kiosk.
+//
+// Two guards apply on *first-time set* only (confirmTwice), never on verify (which stays a single
+// snappy entry): (1) an "is this you?" step keeps the keypad hidden until the staffer confirms the
+// name they picked — a PIN is attributed to them; (2) the PIN must be entered twice and match, so
+// a mis-typed PIN can't silently lock a volunteer out (there's no self-service reset). All of this
+// lives here, in the claim-only module — the shared keypad and the override panel are untouched.
 export function initClaimPin(refs) {
-    const { container, form, valueInput } = refs;
+    const { container, form, valueInput, confirmTwice, confirmEl, confirmYes, promptEl, errorEl } = refs;
     if (!container || !form || !valueInput || !window.initGateKeypad) return;
 
+    const setPrompt = (text, isConfirmStep) => {
+        if (!promptEl) return;
+        promptEl.textContent = text;
+        promptEl.classList.toggle('gate-pin-prompt-confirm', !!isConfirmStep);
+    };
+    const showError = (text) => { if (errorEl) { errorEl.textContent = text; errorEl.classList.toggle('d-none', !text); } };
+
+    // "Is this you?" gate (set only): reveal the keypad only once the staffer confirms.
+    if (confirmEl && confirmYes) {
+        confirmYes.addEventListener('click', () => {
+            confirmEl.classList.add('d-none');
+            form.classList.remove('d-none');
+        });
+    }
+
     let submitted = false;
-    window.initGateKeypad(container, (pin) => {
+    let firstPin = null; // holds the first entry while we wait for the confirming re-entry (set mode)
+    const pad = window.initGateKeypad(container, (pin) => {
         if (submitted) return;
+
+        if (confirmTwice && firstPin === null) {
+            firstPin = pin; // first entry captured — ask for a confirming re-entry
+            setPrompt('Re-enter your PIN to confirm', true);
+            showError('');
+            pad.reset();
+            return;
+        }
+        if (confirmTwice && pin !== firstPin) {
+            firstPin = null; // mismatch — start the pair over from a clean "set" prompt
+            setPrompt('Set a 4-digit PIN', false);
+            showError("PINs didn't match — start over");
+            pad.reset();
+            return;
+        }
+
         submitted = true; // one submit per page load — a double-tap can't double-post
         valueInput.value = pin;
         form.submit();

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -105,24 +105,26 @@ export function initGate(refs) {
     }
     result.addEventListener('pointerdown', bumpReset, { passive: true });
 
-    // "Change" abandons the session (re-enter PIN), so require a deliberate second tap.
+    // "End shift" clears the scanner session (next person re-claims with their PIN), so require
+    // a deliberate second tap.
     initChangeConfirm();
     // The freshness line is a reload affordance on the chromeless kiosk (no browser reload button).
     const asofEl = document.querySelector('.gate-asof');
     if (asofEl) asofEl.addEventListener('click', () => location.reload());
 
     function initChangeConfirm() {
-        const link = document.querySelector('[data-confirm-change]');
-        if (!link) return;
+        const btn = document.querySelector('[data-confirm-change]');
+        if (!btn) return;
         let armed = false;
-        link.addEventListener('click', (e) => {
-            if (armed) return; // second tap within the window → allow the link to navigate
+        const original = btn.textContent;
+        const armedLabel = btn.getAttribute('data-confirm-change') || 'Tap again';
+        btn.addEventListener('click', (e) => {
+            if (armed) return; // second tap within the window → allow the submit to proceed
             e.preventDefault();
             armed = true;
-            const original = link.textContent;
-            link.textContent = 'Tap again to switch';
-            link.classList.add('gate-armed');
-            setTimeout(() => { armed = false; link.textContent = original; link.classList.remove('gate-armed'); }, 3000);
+            btn.textContent = armedLabel;
+            btn.classList.add('gate-armed');
+            setTimeout(() => { armed = false; btn.textContent = original; btn.classList.remove('gate-armed'); }, 3000);
         });
     }
 

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Humans.Application;
+using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.EarlyEntry;
 using Humans.Application.Interfaces.Gate;
 using Humans.Application.Interfaces.Gdpr;
@@ -36,6 +37,7 @@ public class GateServiceTests : ServiceTestHarness
     private readonly IShiftManagementService _shifts = Substitute.For<IShiftManagementService>();
     private readonly IRoleAssignmentService _roles = Substitute.For<IRoleAssignmentService>();
     private readonly IPasswordHasher<GateStaffPin> _pinHasher = new PasswordHasher<GateStaffPin>();
+    private readonly IAuditLogService _auditLog = Substitute.For<IAuditLogService>();
     private readonly GateService _svc;
 
     public GateServiceTests()
@@ -43,7 +45,7 @@ public class GateServiceTests : ServiceTestHarness
         _burn.GetActiveAsync(Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
         _earlyEntry.GetForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns((UserEarlyEntry?)null);
-        _svc = new GateService(new GateRepository(DbFactory), _tickets, _earlyEntry, _burn, _shifts, _roles, _pinHasher, Clock);
+        _svc = new GateService(new GateRepository(DbFactory), _tickets, _earlyEntry, _burn, _shifts, _roles, _pinHasher, _auditLog, Clock);
 
         // Baseline: an admin has set the cutoff in the past, so general entry is open.
         // Seeded directly (sync) since the ctor can't await; Db shares the in-memory
@@ -397,6 +399,25 @@ public class GateServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task PinSetAndReset_AreAudited_WithTheActingUser()
+    {
+        var user = Guid.NewGuid();
+        var admin = Guid.NewGuid();
+
+        await _svc.SetOwnPinAsync(user, "2580");                 // self-enrol: actor == the staffer
+        await _auditLog.Received(1).LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), user,
+            Arg.Any<string>(), user);
+
+        await _svc.AdminSetPinAsync(user, "1357", admin);        // admin set: actor == the admin
+        await _auditLog.Received(1).LogAsync(AuditAction.GateStaffPinSet, nameof(GateStaffPin), user,
+            Arg.Any<string>(), admin);
+
+        await _svc.ClearPinAsync(user, admin);                   // admin reset: actor == the admin
+        await _auditLog.Received(1).LogAsync(AuditAction.GateStaffPinReset, nameof(GateStaffPin), user,
+            Arg.Any<string>(), admin);
+    }
+
+    [HumansFact]
     public async Task SetOwnPin_RejectsTrivialOrMalformedPins()
     {
         var user = Guid.NewGuid();
@@ -413,7 +434,7 @@ public class GateServiceTests : ServiceTestHarness
         (await _svc.SetOwnPinAsync(sup, "2580")).Should().Be(GatePinSetResult.SupervisorMustBeAdminEnrolled);
         (await _svc.GetPinStatusAsync(sup)).Should().Be(new GatePinStatus(HasPin: false, IsSupervisor: true));
 
-        (await _svc.AdminSetPinAsync(sup, "2580")).Should().BeTrue();
+        (await _svc.AdminSetPinAsync(sup, "2580", Guid.NewGuid())).Should().BeTrue();
         (await _svc.VerifyPinAsync(sup, "2580")).Should().BeTrue();
     }
 
@@ -422,7 +443,7 @@ public class GateServiceTests : ServiceTestHarness
     {
         var sup = Guid.NewGuid();
         _roles.HasActiveRoleAsync(sup, RoleNames.Board, Arg.Any<CancellationToken>()).Returns(true);
-        await _svc.AdminSetPinAsync(sup, "2580");
+        await _svc.AdminSetPinAsync(sup, "2580", Guid.NewGuid());
 
         (await _svc.AuthorizeOverrideAsync(sup, "2580")).Should().BeTrue();
         (await _svc.AuthorizeOverrideAsync(sup, "1357")).Should().BeFalse();          // wrong PIN
@@ -446,7 +467,7 @@ public class GateServiceTests : ServiceTestHarness
             .Returns(new[] { notEnrolled });
         _roles.GetActiveUserIdsInRoleAsync(RoleNames.TicketAdmin, Arg.Any<CancellationToken>())
             .Returns(Array.Empty<Guid>());
-        await _svc.AdminSetPinAsync(enrolled, "2580");
+        await _svc.AdminSetPinAsync(enrolled, "2580", Guid.NewGuid());
 
         var ids = await _svc.GetEnrolledSupervisorIdsAsync();
 

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -426,16 +426,20 @@ public class GateServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
-    public async Task SetOwnPin_Supervisor_Blocked_ButAdminCanEnrol()
+    public async Task SetOwnPin_Supervisor_SelfSetsClaimPin_ButItCannotOverride()
     {
         var sup = Guid.NewGuid();
         _roles.HasActiveRoleAsync(sup, RoleNames.TicketAdmin, Arg.Any<CancellationToken>()).Returns(true);
 
-        (await _svc.SetOwnPinAsync(sup, "2580")).Should().Be(GatePinSetResult.SupervisorMustBeAdminEnrolled);
-        (await _svc.GetPinStatusAsync(sup)).Should().Be(new GatePinStatus(HasPin: false, IsSupervisor: true));
+        // A supervisor may now self-enrol a CLAIM PIN (attribution — everyone can)...
+        (await _svc.SetOwnPinAsync(sup, "2580")).Should().Be(GatePinSetResult.Ok);
+        (await _svc.VerifyPinAsync(sup, "2580")).Should().BeTrue();          // can claim the scanner
+        // ...but a self-set PIN never carries override authority (AdminEnrolled = false).
+        (await _svc.AuthorizeOverrideAsync(sup, "2580")).Should().BeFalse();
 
-        (await _svc.AdminSetPinAsync(sup, "2580", Guid.NewGuid())).Should().BeTrue();
-        (await _svc.VerifyPinAsync(sup, "2580")).Should().BeTrue();
+        // Admin enrolment (AdminEnrolled = true) is the only thing that confers override.
+        (await _svc.AdminSetPinAsync(sup, "1357", Guid.NewGuid())).Should().BeTrue();
+        (await _svc.AuthorizeOverrideAsync(sup, "1357")).Should().BeTrue();
     }
 
     [HumansFact]
@@ -455,22 +459,29 @@ public class GateServiceTests : ServiceTestHarness
         var unenrolledSup = Guid.NewGuid();                                            // supervisor, no PIN
         _roles.HasActiveRoleAsync(unenrolledSup, RoleNames.Admin, Arg.Any<CancellationToken>()).Returns(true);
         (await _svc.AuthorizeOverrideAsync(unenrolledSup, "2580")).Should().BeFalse();
+
+        var selfSetSup = Guid.NewGuid();                                               // supervisor who SELF-set a claim PIN
+        _roles.HasActiveRoleAsync(selfSetSup, RoleNames.Admin, Arg.Any<CancellationToken>()).Returns(true);
+        await _svc.SetOwnPinAsync(selfSetSup, "2580");                                 // AdminEnrolled = false
+        (await _svc.AuthorizeOverrideAsync(selfSetSup, "2580")).Should().BeFalse();    // correct PIN + role, but not admin-enrolled
     }
 
     [HumansFact]
-    public async Task GetEnrolledSupervisorIds_ReturnsOnlySupervisorsWithAPin()
+    public async Task GetEnrolledSupervisorIds_ReturnsOnlySupervisorsWithAnAdminEnrolledPin()
     {
-        Guid enrolled = Guid.NewGuid(), notEnrolled = Guid.NewGuid();
+        Guid enrolled = Guid.NewGuid(), selfSetOnly = Guid.NewGuid();
         _roles.GetActiveUserIdsInRoleAsync(RoleNames.Board, Arg.Any<CancellationToken>())
             .Returns(new[] { enrolled });
         _roles.GetActiveUserIdsInRoleAsync(RoleNames.Admin, Arg.Any<CancellationToken>())
-            .Returns(new[] { notEnrolled });
+            .Returns(new[] { selfSetOnly });
         _roles.GetActiveUserIdsInRoleAsync(RoleNames.TicketAdmin, Arg.Any<CancellationToken>())
             .Returns(Array.Empty<Guid>());
-        await _svc.AdminSetPinAsync(enrolled, "2580", Guid.NewGuid());
+        await _svc.AdminSetPinAsync(enrolled, "2580", Guid.NewGuid());   // admin-enrolled → override-capable
+        await _svc.SetOwnPinAsync(selfSetOnly, "1357");                  // self-set claim PIN → NOT override-capable
 
         var ids = await _svc.GetEnrolledSupervisorIdsAsync();
 
+        // Only the admin-enrolled supervisor is offered in the override picker.
         ids.Should().ContainSingle().Which.Should().Be(enrolled);
     }
 }


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production. This batch is the Gate section: personal staff PINs, override-authority decoupling, the explicit End-shift button, and the masked-email claim disambiguator.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `0c30ebc3` feat(gate): PIN set/reset audit + first-time-set confirm & double-entry (peterdrier/Humans#1071)
- `774f6ab0` feat(gate): decouple claim PIN from override authority (AdminEnrolled) (peterdrier/Humans#1074)
- `1fc0f478` feat(gate): replace "Change" link with explicit two-tap "End shift" button (peterdrier/Humans#1072)
- `d6a5c26b` feat(gate): masked-email disambiguator on the claim picker (name-only search) (peterdrier/Humans#1073)

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly (`AddGateStaffPinAdminEnrolled` chains after `AddGateSection`)