### PR TITLE
Promote QA → production (3 commits)

### DIFF
--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -42,16 +42,11 @@ public sealed class GateController(
     [HttpGet("")]
     public async Task<IActionResult> Index(CancellationToken ct)
     {
-        // No claim step: the terminal scans as its authenticated gate account (never a per-staffer
-        // PIN). The attribution id is taken from the principal — never the request body.
-        if (GetCurrentUserId() is not { } scanner)
-            return Unauthorized();
-
-        var info = await UserService.GetUserInfoAsync(scanner, ct);
+        // No claim step and no per-scanner identity shown: the terminal simply scans as its
+        // authenticated gate account (attribution is taken from the principal on Decision).
         var settings = await gate.GetSettingsAsync(ct);
         var asOf = InstantPattern.ExtendedIso.Format(clock.GetCurrentInstant());
-        return View(new GateIndexViewModel(
-            info?.BurnerName ?? "Gate staff", DataStale: false, asOf, settings.CutoffConfigured, []));
+        return View(new GateIndexViewModel(DataStale: false, asOf, settings.CutoffConfigured, []));
     }
 
     [HttpGet("Evaluate")]

--- a/src/Humans.Web/Models/Gate/GateViewModels.cs
+++ b/src/Humans.Web/Models/Gate/GateViewModels.cs
@@ -94,7 +94,7 @@ public sealed record GateScanCardViewModel(
 /// warning banner: while the general-entry cutoff is unset, every scan fails safe to
 /// AMBER, so the terminal tells staff to have an admin set it before doors.</summary>
 public sealed record GateIndexViewModel(
-    string ScannerName, bool DataStale, string DataAsOf, bool CutoffConfigured,
+    bool DataStale, string DataAsOf, bool CutoffConfigured,
     IReadOnlyList<GateSupervisorOption> Supervisors);
 
 /// <summary>One enrolled supervisor offered as a tap-pick on the override panel (kiosk has no free-text search).</summary>

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -572,7 +572,15 @@ app.Use(async (context, next) =>
     await next();
 });
 
-app.UseStaticFiles();
+// "no-cache" = cache but always revalidate (cheap 304s at this scale). Without an explicit policy,
+// browsers heuristically cache static files (~10% of time since Last-Modified) with NO request at
+// all, so after a release some long-running kiosk tablets kept serving week-old CSS/JS while others
+// didn't. Fingerprinted URLs (asp-append-version / FileVersionProvider) change per release, but
+// unfingerprinted paths — and nested JS module imports, which no tag helper can reach — need this.
+app.UseStaticFiles(new StaticFileOptions
+{
+    OnPrepareResponse = ctx => ctx.Context.Response.Headers.CacheControl = "no-cache",
+});
 
 // Serve .well-known directory (blocked by default since it starts with a dot)
 if (app.Environment.IsDevelopment())

--- a/src/Humans.Web/Views/CityPlanning/Admin.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Admin.cshtml
@@ -272,5 +272,5 @@
 
 @section Scripts {
     <script src="https://unpkg.com/&#64;turf/turf@7.1.0/turf.min.js"></script>
-    <script src="~/js/city-planning/barrio-map/admin-import.js"></script>
+    <script src="~/js/city-planning/barrio-map/admin-import.js" asp-append-version="true"></script>
 }

--- a/src/Humans.Web/Views/CityPlanning/BarrioMap.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/BarrioMap.cshtml
@@ -124,5 +124,5 @@
     <script src="https://unpkg.com/&#64;mapbox/mapbox-gl-draw@1.5.1/dist/mapbox-gl-draw.js"></script>
     <script src="https://unpkg.com/&#64;turf/turf@7.1.0/turf.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/&#64;microsoft/signalr@8.0.7/dist/browser/signalr.min.js"></script>
-    <script type="module" src="~/js/city-planning/barrio-map/main.js"></script>
+    <script type="module" src="~/js/city-planning/barrio-map/main.js" asp-append-version="true"></script>
 }

--- a/src/Humans.Web/Views/CityPlanning/ContainerMap.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/ContainerMap.cshtml
@@ -149,5 +149,5 @@
 @section Scripts {
     <script src="https://unpkg.com/maplibre-gl@5.20.1/dist/maplibre-gl.js"></script>
     <script src="https://unpkg.com/&#64;turf/turf@7.1.0/turf.min.js"></script>
-    <script type="module" src="~/js/city-planning/container-map/main.js"></script>
+    <script type="module" src="~/js/city-planning/container-map/main.js" asp-append-version="true"></script>
 }

--- a/src/Humans.Web/Views/CityPlanning/Index.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Index.cshtml
@@ -55,5 +55,5 @@
 @section Scripts {
     <script src="https://unpkg.com/maplibre-gl@5.20.1/dist/maplibre-gl.js"></script>
     <script src="https://unpkg.com/&#64;turf/turf@7.1.0/turf.min.js"></script>
-    <script type="module" src="~/js/city-planning/main.js"></script>
+    <script type="module" src="~/js/city-planning/main.js" asp-append-version="true"></script>
 }

--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -28,10 +28,17 @@
         </div>
     }
 
+    @* inputmode="none" keeps the tablet's touch keyboard down: the field stays focused for the
+       keyboard-wedge imager (HID input still lands), but a tap never summons the OS keyboard over
+       the verdict card. The keyboard button flips to manual typing for damaged/unreadable codes. *@
     <form id="gate-scan-form" autocomplete="off">
-        <input id="gate-scan-input" type="text" inputmode="text" autocomplete="off"
+        <input id="gate-scan-input" type="text" inputmode="none" autocomplete="off"
                autocapitalize="off" spellcheck="false" placeholder="Scan a ticket"
                aria-label="Scan a ticket" />
+        <button type="button" id="gate-manual-toggle" class="gate-manual-toggle"
+                title="Type a code manually" aria-label="Type a code manually" aria-pressed="false">
+            <i class="fa-solid fa-keyboard" aria-hidden="true"></i>
+        </button>
     </form>
 
     <div id="gate-result">

--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -12,7 +12,6 @@
 
 <div class="gate-shell">
     <div class="gate-topbar">
-        <span>Scanning as <strong>@Model.ScannerName</strong></span>
         <span class="gate-asof" data-asof="@Model.DataAsOf"
               title="Tap to reload">loaded…</span>
         <a asp-action="Leaderboard" class="gate-topbar-link">Leaderboard</a>

--- a/src/Humans.Web/Views/Scanner/Barcode.cshtml
+++ b/src/Humans.Web/Views/Scanner/Barcode.cshtml
@@ -62,9 +62,12 @@
     </div>
 </div>
 
+@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @section Scripts {
+    @* Cache-bust the module import (the tag-helper asp-append-version can't reach an import
+       statement) so a deployed update reaches long-cached tablets. Mirrors Gate/Index. *@
     <script nonce="@Context.Items["CspNonce"]" type="module">
-        import { initBarcodeScanner } from '@Url.Content("~/js/scanner/barcode.js")';
+        import { initBarcodeScanner } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/scanner/barcode.js"))';
 
         initBarcodeScanner({
             startButton: document.getElementById('scanner-start'),

--- a/src/Humans.Web/Views/Scanner/Tickets.cshtml
+++ b/src/Humans.Web/Views/Scanner/Tickets.cshtml
@@ -63,9 +63,12 @@
     </div>
 </div>
 
+@inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @section Scripts {
+    @* Cache-bust the module import (the tag-helper asp-append-version can't reach an import
+       statement) so a deployed update reaches long-cached tablets. Mirrors Gate/Index. *@
     <script nonce="@Context.Items["CspNonce"]" type="module">
-        import { initTicketScanner } from '@Url.Content("~/js/scanner/tickets.js")';
+        import { initTicketScanner } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/scanner/tickets.js"))';
 
         initTicketScanner({
             startButton: document.getElementById('scanner-start'),

--- a/src/Humans.Web/Views/Shared/_AdminLayout.cshtml
+++ b/src/Humans.Web/Views/Shared/_AdminLayout.cshtml
@@ -22,9 +22,9 @@
     <link rel="icon" href="~/img/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="~/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="512x512" href="~/icon-512.png">
-    <link rel="stylesheet" href="~/css/tokens.css" />
-    <link rel="stylesheet" href="~/css/site.css" />
-    <link rel="stylesheet" href="~/css/admin-shell.css" />
+    <link rel="stylesheet" href="~/css/tokens.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/admin-shell.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body class="admin-shell">

--- a/src/Humans.Web/Views/Shared/_GateLayout.cshtml
+++ b/src/Humans.Web/Views/Shared/_GateLayout.cshtml
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Source+Sans+3:wght@400;500;600;700&display=swap">
     <link rel="icon" href="~/favicon.ico" sizes="any">
     <link rel="icon" href="~/img/favicon.svg" type="image/svg+xml">
-    <link rel="stylesheet" href="~/css/tokens.css" />
-    <link rel="stylesheet" href="~/css/site.css" />
+    <link rel="stylesheet" href="~/css/tokens.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body class="gate-kiosk">

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -28,8 +28,8 @@
     <link rel="icon" href="~/img/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="~/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="512x512" href="~/icon-512.png">
-    <link rel="stylesheet" href="~/css/tokens.css" />
-    <link rel="stylesheet" href="~/css/site.css" />
+    <link rel="stylesheet" href="~/css/tokens.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 </head>
 <body class="@(ViewData["BodyClass"])">

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -39,11 +39,18 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 .gate-config-warning > i { margin-top: .15rem; flex: none; color: #e0962b; }
 .gate-config-warning strong { color: #fff; }
 
+#gate-scan-form { display: flex; gap: .6rem; }
 #gate-scan-input {
     width: 100%; font-size: 1.6rem; padding: .9rem 1.1rem; border-radius: 12px;
     border: 2px solid #c9d2da;
 }
 #gate-scan-input:focus { outline: none; border-color: #1e2a33; box-shadow: 0 0 0 4px rgba(30,42,51,.15); }
+/* Manual-entry toggle — brings the touch keyboard up for typing a damaged/unreadable code. */
+.gate-manual-toggle {
+    flex: none; font-size: 1.4rem; color: #5f6b76; background: transparent; cursor: pointer;
+    border: 2px solid #c9d2da; border-radius: 12px; padding: .5rem .9rem; min-width: 64px;
+}
+.gate-manual-toggle.gate-manual-on { color: #fff; background: #2b3440; border-color: #2b3440; }
 
 .gate-card {
     margin-top: 1rem; border-radius: 18px; padding: 2rem 1.5rem; text-align: center;

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -141,8 +141,39 @@ export function initGate(refs) {
         }
     });
 
+    // Don't depend on the imager's Enter-suffix config to submit: a wedge scan arrives as a fast
+    // burst of characters, so once the field has a plausible barcode and goes quiet for a beat,
+    // submit anyway. An Enter suffix still submits immediately (the form handler clears the timer).
+    // Manual mode turns the quiet-timer off — a human typing pauses far longer than a wedge burst
+    // and presses Enter/Go themselves.
+    const SCAN_QUIET_MS = 300;
+    const SCAN_MIN_LENGTH = 5;
+    let scanTimer = null;
+    let manualMode = false;
+    const clearScanTimer = () => { if (scanTimer) { clearTimeout(scanTimer); scanTimer = null; } };
+    input.addEventListener('input', () => {
+        clearScanTimer();
+        if (manualMode || input.value.trim().length < SCAN_MIN_LENGTH) return;
+        scanTimer = setTimeout(() => form.requestSubmit(), SCAN_QUIET_MS);
+    });
+
+    // Manual-entry toggle: flips inputmode so the touch keyboard comes up (it stays suppressed in
+    // scan mode) for typing a damaged/unreadable code. Blur-then-focus forces the keyboard to
+    // follow the new inputmode while the field keeps receiving wedge input either way.
+    const manualToggle = document.getElementById('gate-manual-toggle');
+    if (manualToggle) manualToggle.addEventListener('click', () => {
+        manualMode = !manualMode;
+        clearScanTimer();
+        input.setAttribute('inputmode', manualMode ? 'text' : 'none');
+        manualToggle.setAttribute('aria-pressed', String(manualMode));
+        manualToggle.classList.toggle('gate-manual-on', manualMode);
+        input.blur();
+        input.focus();
+    });
+
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
+        clearScanTimer();
         const code = input.value.trim();
         if (!code || busy || overrideOpen()) return; // ignore scans mid-override
         busy = true;


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `034a1722` fix(web): cache-bust all local static assets + always-revalidate static file policy (peterdrier/Humans#1078)
- `fca2bd20` fix(gate): suppress touch keyboard on scan field; auto-submit wedge burst without Enter suffix (peterdrier/Humans#1077)
- `8d69c921` feat(gate): remove "Scanning as" operator label from the terminal (peterdrier/Humans#1076)

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly (none in this batch)