### PR TITLE
Promote QA → production (1 commit)

### DIFF
--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -44,12 +44,15 @@ admission record. Distinct from the read-only `Scanner` section, which must neve
   cutoff in `Gate ▸ Admin` before opening the doors. To run with no Early-Entry gating at all,
   set the cutoff to a past instant (explicitly "general entry already open") — never leave it unset.
 - **Server-authoritative decision** — `RecordDecisionAsync` re-evaluates server-side, so a client
-  "ID confirmed" can never turn a STOP into an admit. `scannedByUserId` is the session-claimed
-  staffer, taken from the session, never the request body. The child/ID-waiver and the too-early
-  override both admit only when an authorizing supervisor was recorded (`OverrideByUserId`), which
-  the controller sets **only** after `AuthorizeOverrideAsync` verifies that supervisor's personal
-  PIN and active role — a forged `childWithAdult`/`overrideEarly` flag alone never admits.
-- **Personal staff PINs (`gate_staff_pins`)** — each staffer sets a 4-digit PIN the first time they
+  "ID confirmed" can never turn a STOP into an admit. `scannedByUserId` is the authenticated gate
+  account, taken from the principal, never the request body. The child/ID-waiver and the early
+  overrides admit only when `OverrideByUserId` was recorded, which the controller sets **only**
+  after verifying the shared supervisor override PIN (`Gate:SupervisorPin`) server-side — a forged
+  `childWithAdult`/`overrideEarly` flag alone never admits, and an unset PIN fails closed
+  (overrides refused, never a free pass).
+- **Personal staff PINs (`gate_staff_pins`)** — _disabled since peterdrier#1075: the claim step is
+  bypassed (the terminal scans as the gate account) and the flow below is unreachable, though the
+  table, service methods, admin page, and views remain in place._ Each staffer sets a 4-digit PIN the first time they
   claim the gate (`SetOwnPinAsync`, hashed via Identity's `IPasswordHasher`), reused across shifts.
   Claiming the scanner becomes a PIN entry (`/Gate/ClaimPin`), so the leaderboard attribution is a
   real per-person claim rather than honour-system. **Claim vs override are decoupled by the
@@ -68,14 +71,17 @@ admission record. Distinct from the read-only `Scanner` section, which must neve
   staffer on self-enrol, the admin on admin-set/reset); PIN values are never logged.
 - **Supervisor override** — a too-early scan (e.g. a Friday Early-Entry ticket scanned on Wednesday)
   STOPs with a precise reason (the holder's EE date vs today, or "no early entry · general entry
-  opens …" — date only, never the EE source) and offers a **supervisor override**: the supervisor
-  taps their name from the enrolled-supervisor list (the route-locked kiosk can't reach free-text
-  people search) and enters their PIN. On success the admit is recorded as `AdmittedEarlyOverride`
-  with `OverrideByUserId` = the authorizing supervisor — the audit trail for "who let this person in
-  early". The same mechanism backs the child-without-ID waiver (`AdmittedChildWithAdult`).
+  opens …" — date only, never the EE source); an **unconfirmed-Early-Entry** scan (the guest may
+  hold EE the terminal can't see) goes AMBER with "search by name". Both cards offer a
+  **supervisor override**: the supervisor enters the shared override PIN (`Gate:SupervisorPin`) on
+  the keypad in the override panel. On success the admit is recorded as `AdmittedEarlyOverride`.
+  One PIN for all supervisors: it **authorizes but cannot attribute** — `OverrideByUserId` records
+  the gate account, not which supervisor typed the PIN. The same mechanism backs the
+  child-without-ID waiver (`AdmittedChildWithAdult`).
 - **PIN brute-force throttle** — `GatePinThrottle`: 5 failures → a 15-minute lockout that does **not**
-  self-reset (only a correct PIN clears it), keyed on **both** the target user-id and the source
-  device/IP, so neither one supervisor's PIN nor one kiosk can be ground through the ~10k space.
+  self-reset (only a correct PIN clears it). The shared override PIN throttles on a single
+  terminal-wide bucket (`override:shared`) — a lockout blocks only the override path, never
+  scanning — capping brute-force at 5 tries / 15 min across the ~10k PIN space.
 - **Dedupe authority** — a unique index on `GateScanEvent.AdmitDedupeKey` (the barcode for admit
   verdicts, null otherwise) makes the first admit per barcode win atomically across all lanes;
   Postgres excludes nulls so reject rows never collide. An explicit pre-check covers the common case.
@@ -131,33 +137,29 @@ admission record. Distinct from the read-only `Scanner` section, which must neve
 The **write** actions (`Decision`, `Claim`/`ClaimPin` POST) require the dedicated `GateAdmit`
 policy rather than the read-only `ScannerAccess`, so the gate's admit surface never rides on the
 Scanner read gate. Both are satisfied by the shared gate-terminal account today; they are
-kept separate so they can diverge. PIN entry (claim verify, and the supervisor override on
-`Decision`) is brute-force throttled via `GatePinThrottle` on **both** the target user-id and the
-source device — see Invariants. The supervisor override picks from the enrolled-supervisor
-tap-list because the `GateTerminal` account is route-locked to `/Gate` and so cannot reach the
-`/api/profiles/search` people-search the admin pages use.
+kept separate so they can diverge. The supervisor override on `Decision` is authorized by the
+shared override PIN (`Gate:SupervisorPin`), brute-force throttled via `GatePinThrottle` on a
+single terminal-wide bucket — see Invariants. (The `Claim`/`ClaimPin`/`Admin` PIN routes remain
+but are unreachable since peterdrier#1075 — nothing links to them.)
 
 ## Invariants
 
 - The cutoff is evaluated against the server clock; `ClientScanAt` never influences it.
 - A barcode can be admitted at most once (atomic unique index + pre-check); re-entry is governed
   by a physical wristband, not a second scan.
-- `scannedByUserId` is server-derived from the claimed session; an override (child/ID-waiver or
-  too-early) needs a server-verified supervisor PIN **and** an active supervisor role
-  (`AuthorizeOverrideAsync`), recorded as `OverrideByUserId`.
-- **Override authorization is verify-only and double-checked.** `AuthorizeOverrideAsync` admits an
-  override only if the asserted supervisor is enrolled, the PIN matches (timing-safe), **and** they
-  currently hold Admin/Board/TicketAdmin — re-derived server-side, never trusted from the request.
-  It never enrols. Supervisor PIN **enrolment** is privileged (admin-only, `/Gate/Admin`); a
-  supervisor PIN can never be cold-set at the anonymous kiosk.
-- **PIN entry is throttled on two keys.** `GatePinThrottle` (5 tries → 15-min non-self-resetting
-  lockout) is checked/recorded on **both** the target user-id and the source device/IP, so neither a
-  single supervisor's PIN nor one kiosk can be brute-forced. Claim-keypad *enrolment* (choosing a new
-  PIN) is not throttled — there's no secret to guess — only verification is.
-- **Attribution is now a personal PIN claim**, not honour-system: claiming the scanner verifies the
-  staffer's PIN (`/Gate/ClaimPin`), and `ScannedByUserId` is stamped server-side from that verified
-  id. It is still a shared physical device, so treat the attribution as a strong claim for the
-  leaderboard/audit trail, not as cryptographic proof of who held the tablet.
+- `scannedByUserId` is server-derived from the authenticated principal (the gate account); an
+  override (child/ID-waiver, too-early, or unconfirmed-EE) needs the server-verified shared
+  supervisor PIN (`Gate:SupervisorPin`), recorded as `OverrideByUserId`.
+- **Override authorization fails closed.** The PIN comparison is timing-safe (fixed-width hashes),
+  and an unset `Gate:SupervisorPin` refuses every override with an explicit "not configured" card —
+  a missing key is never a free pass. The shared PIN authorizes but cannot attribute:
+  `OverrideByUserId` is the gate account, not the individual supervisor.
+- **Override PIN entry is throttled terminal-wide.** `GatePinThrottle` (5 tries → 15-min
+  non-self-resetting lockout; a correct PIN clears it) on the single `override:shared` bucket. A
+  lockout blocks only overrides — scanning and every other card continue — so a fumbled PIN can
+  never stop the line, while the shared PIN can't be ground through the ~10k space at the kiosk.
+- Scan **attribution is the shared gate account** (peterdrier#1075): the personal-PIN claim flow is
+  bypassed, so the leaderboard and `ScannedByUserId` no longer identify individual staffers.
 - Gate participates in GDPR export (`IUserDataContributor`), account merge (`IUserMerge` re-FKs
   `GuestUserId`/`ScannedByUserId`), and retention purge.
 - The gate view shows name + verdict + one reason line only; Early-Entry source, the previous
@@ -200,8 +202,11 @@ tap-list because the `GateTerminal` account is route-locked to `/Gate` and so ca
 
 ## Configuration
 
-- _(retired)_ `Gate:SupervisorPin` — the shared override PIN is gone; overrides now use per-staffer
-  PINs (`gate_staff_pins`) verified against an active supervisor role. No config key.
+- `Gate:SupervisorPin` — the shared supervisor override PIN (one PIN for all supervisors),
+  required for the too-early / unconfirmed-EE override and the child-without-ID waiver. **Unset →
+  overrides fail closed** (refused with a "not configured" card) — set it before doors open.
+  _(History: retired 2026-07-01 in favour of per-staffer enrolled PINs, restored after
+  peterdrier#1075 dropped the per-staffer PIN flow.)_
 - `Gate:VendorMirrorEnabled` — default off; gates the TicketTailor check-in mirror (see Vendor
   check-in mirror above).
 - `Gate:RosterTeamId` — **optional** GUID of the Shifts department/team that staffs the gate.

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -333,9 +333,11 @@ public sealed class GateService(
         GatePreCheckOutcome.Invalid => GateVerdict.RejectedInvalid,
         GatePreCheckOutcome.Duplicate => GateVerdict.RejectedDuplicate,
         GatePreCheckOutcome.CutoffNotConfigured => GateVerdict.Unresolved,
-        GatePreCheckOutcome.EarlyEntryUnknown => GateVerdict.Unresolved,
-        // A too-early scan is admissible only by a supervisor override; the controller sets
-        // OverrideByUserId solely after AuthorizeOverrideAsync, so a non-null value is proof.
+        // Early-entry scans blocked before the cutoff (too early, or EE can't be confirmed) are
+        // admissible only by a supervisor override; the controller sets OverrideByUserId solely
+        // after verifying the supervisor PIN, so a non-null value is proof.
+        GatePreCheckOutcome.EarlyEntryUnknown =>
+            input.OverrideByUserId is not null ? GateVerdict.AdmittedEarlyOverride : GateVerdict.Unresolved,
         GatePreCheckOutcome.TooEarly =>
             input.OverrideByUserId is not null ? GateVerdict.AdmittedEarlyOverride : GateVerdict.RejectedTooEarly,
         GatePreCheckOutcome.NeedsIdCheck or GatePreCheckOutcome.NeedsIdCheckEarly =>

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Hangfire;
 using Humans.Application;
 using Humans.Application.Interfaces.Gate;
@@ -25,8 +27,10 @@ namespace Humans.Web.Controllers;
 /// (Index/Evaluate/Leaderboard); the write action (Decision) requires the dedicated
 /// <see cref="PolicyNames.GateAdmit"/> policy so it never rides on the read-only
 /// Scanner gate. Scans are attributed to the authenticated gate account, taken from
-/// the principal (never the request body). Too-early and child-without-ID admits are
-/// a plain operator override — a button tap, no PIN.
+/// the principal (never the request body). Too-early / unconfirmed-Early-Entry and
+/// child-without-ID admits are a supervisor override authorized by the shared
+/// override PIN (<c>Gate:SupervisorPin</c>), server-verified and brute-force
+/// throttled via <see cref="GatePinThrottle"/>.
 /// </summary>
 [Authorize(Policy = PolicyNames.ScannerAccess)]
 [Route("Gate")]
@@ -38,6 +42,11 @@ public sealed class GateController(
     IClock clock) : HumansControllerBase(users)
 {
     private const string ScannerSessionKey = "GateScannerId";
+    private const string SupervisorPinConfigKey = "Gate:SupervisorPin";
+
+    // Throttle bucket for the shared override PIN — one bucket for the terminal, distinct
+    // from the per-user claim buckets so a fumbled override can never lock a claim (or vice versa).
+    private const string SharedOverridePinKey = "override:shared";
 
     [HttpGet("")]
     public async Task<IActionResult> Index(CancellationToken ct)
@@ -61,14 +70,21 @@ public sealed class GateController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Decision(
         string barcode, bool idConfirmed, bool childWithAdult, bool overrideEarly,
-        string? laneId, CancellationToken ct)
+        string? supervisorPin, string? laneId, CancellationToken ct)
     {
         if (GetCurrentUserId() is not { } scanner)
             return Unauthorized();
 
-        // Too-early and child-without-ID admits are a plain no-PIN override now: the operator's tap on
-        // the override button IS the authorization. Record it against the gate account (no supervisor).
-        Guid? overrideBy = childWithAdult || overrideEarly ? scanner : null;
+        // Overrides (too-early / unconfirmed-EE admit, child-without-ID waiver) require the shared
+        // supervisor PIN, verified server-side before anything is recorded. One PIN for all
+        // supervisors: it authorizes but cannot attribute, so the event records the gate account.
+        Guid? overrideBy = null;
+        if (childWithAdult || overrideEarly)
+        {
+            if (AuthorizeOverride(supervisorPin, barcode, childWithAdult) is { } errorCard)
+                return PartialView("_VerdictCard", errorCard);
+            overrideBy = scanner;
+        }
 
         var decision = await gate.RecordDecisionAsync(
             new GateDecisionInput(barcode, idConfirmed, childWithAdult, laneId,
@@ -318,6 +334,51 @@ public sealed class GateController(
         HttpContext.Session.SetString(ScannerSessionKey, userId.ToString());
         return RedirectToAction(nameof(Index));
     }
+
+    // ── Override authorization (shared supervisor PIN) ──────────────────────
+    // Returns null when the override is authorized; otherwise the error card to show.
+    private GateScanCardViewModel? AuthorizeOverride(string? pin, string barcode, bool childWithAdult)
+    {
+        // Fail closed: no configured PIN means no overrides — never a free pass. Say so
+        // explicitly on the card (it's a staff-only kiosk; the fix is an admin action).
+        if (string.IsNullOrEmpty(configuration[SupervisorPinConfigKey]))
+            return OverrideErrorCard(barcode, childWithAdult,
+                "Override PIN not configured — an admin must set it before overrides work");
+
+        // One throttle bucket for the whole terminal: a single shared PIN has no per-user key.
+        // A lockout blocks only the override path — scanning is unaffected — and caps
+        // brute-force at 5 tries / 15 min across the 10k PIN space.
+        if (ThrottleWait(SharedOverridePinKey) is { } wait)
+            return OverrideErrorCard(barcode, childWithAdult, $"Too many PIN attempts — wait {wait}s");
+
+        if (!SupervisorPinValid(pin))
+        {
+            RecordPinFailure(SharedOverridePinKey);
+            return OverrideErrorCard(barcode, childWithAdult, "PIN not accepted — try again");
+        }
+
+        ResetPinThrottle(SharedOverridePinKey);
+        return null;
+    }
+
+    private bool SupervisorPinValid(string? pin)
+    {
+        var configured = configuration[SupervisorPinConfigKey];
+        if (string.IsNullOrEmpty(configured) || string.IsNullOrEmpty(pin))
+            return false;
+
+        // Compare fixed-width hashes so neither equality nor PIN length leaks via timing.
+        var a = SHA256.HashData(Encoding.UTF8.GetBytes(pin));
+        var b = SHA256.HashData(Encoding.UTF8.GetBytes(configured));
+        return CryptographicOperations.FixedTimeEquals(a, b);
+    }
+
+    private static GateScanCardViewModel OverrideErrorCard(string barcode, bool childWithAdult, string reason) =>
+        new(GateCardKind.Amber, "Supervisor", null, reason, IsEarly: false, barcode,
+            AllowChildWithAdult: false,
+            // An early override can retry inline (the barcode is preserved on the card). The child
+            // waiver lives on the ID-confirm card, so a failed child auth just re-scans.
+            AllowSupervisorOverride: !childWithAdult);
 
     // ── Throttle helpers (keyed on the target user-id only) ──────────────────────
     // Per-target-user, never per shared device/IP: a 4-digit PIN's brute-force ceiling is

--- a/src/Humans.Web/Models/Gate/GateViewModels.cs
+++ b/src/Humans.Web/Models/Gate/GateViewModels.cs
@@ -50,8 +50,10 @@ public sealed record GateScanCardViewModel(
         // all), and offer a supervisor override either way (the reason is what informs the decision).
         GatePreCheckOutcome.TooEarly =>
             new(GateCardKind.Stop, "Stop", r.GuestName, TooEarlyReason(r), false, r.Barcode, false, AllowSupervisorOverride: true),
+        // Early Entry unknown: the search-by-name fallback stays the primary route, but the card
+        // is otherwise a dead end at the doors — offer the supervisor override here too.
         GatePreCheckOutcome.EarlyEntryUnknown =>
-            new(GateCardKind.Amber, "Supervisor", r.GuestName, "Early Entry can't be confirmed — search by name", false, r.Barcode, false),
+            new(GateCardKind.Amber, "Supervisor", r.GuestName, "Early Entry can't be confirmed — search by name", false, r.Barcode, false, AllowSupervisorOverride: true),
         // NeedsIdCheck / NeedsIdCheckEarly → ask the agent to confirm the ID.
         _ => new(GateCardKind.IdConfirm, "Does the ID say", r.GuestName,
             r.IsEarly ? "Early entry OK" : null, r.IsEarly, r.Barcode, AllowChildWithAdult: true),

--- a/src/Humans.Web/Views/Gate/Index.cshtml
+++ b/src/Humans.Web/Views/Gate/Index.cshtml
@@ -49,16 +49,18 @@
         </div>
     </div>
 
-    @* Override panel — shown over the card for a too-early override or a child-without-ID admit.
-       No PIN and no supervisor pick: a single deliberate confirm tap is the authorization. *@
+    @* Override panel — shown over the card for a too-early / unconfirmed-EE override or a
+       child-without-ID admit. Authorized by the shared supervisor PIN: the keypad auto-submits
+       on the 4th digit and the server verifies before recording anything. *@
     <div id="gate-override" class="gate-override d-none" aria-hidden="true">
         <div class="gate-override-head">
-            <span class="gate-override-title" data-override-title>Override</span>
+            <span class="gate-override-title" data-override-title>Supervisor override</span>
             <button type="button" class="gate-override-cancel" data-override-cancel>Cancel</button>
         </div>
         <div class="gate-override-step">
             <p class="gate-override-prompt" data-override-prompt>Admit this guest anyway?</p>
-            <button type="button" class="gate-override-confirm" data-override-confirm>Override — admit</button>
+            <p class="gate-override-hint">Supervisor — enter the override PIN</p>
+            <partial name="_PinPad" />
         </div>
     </div>
 
@@ -82,8 +84,11 @@
 
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @section Scripts {
-    @* Cache-bust the gate.js module import (the tag-helper asp-append-version can't reach an import
-       statement) so a deployed update reaches the kiosk. *@
+    @* Shared keypad is a cache-busted classic script (no module import to go stale on the kiosk);
+       the override panel uses it. Cache-bust the gate.js module import too (the tag-helper
+       asp-append-version can't reach an import statement) so a deployed update reaches the kiosk. *@
+    <script src="@Url.Content("~/js/gate/gate-keypad.js")" asp-append-version="true"
+            nonce="@Context.Items["CspNonce"]"></script>
     <script nonce="@Context.Items["CspNonce"]" type="module">
         import { initGate } from '@FileVersionProvider.AddFileVersionToPath(Context.Request.PathBase, Url.Content("~/js/gate/gate.js"))';
         initGate({

--- a/src/Humans.Web/wwwroot/css/gate/gate.css
+++ b/src/Humans.Web/wwwroot/css/gate/gate.css
@@ -170,13 +170,8 @@ body.gate-kiosk { margin: 0; min-height: 100vh; background: #f4ede1; }
 .gate-override-step {
     width: 100%; max-width: 480px; background: #f4ede1; border-radius: 16px; padding: 1.25rem;
 }
-.gate-override-prompt { font-size: 1.25rem; font-weight: 600; color: #1e2a33; text-align: center; margin: 0 0 1rem; }
-/* No-PIN override: one big green confirm tap admits the too-early / child-without-ID scan. */
-.gate-override-confirm {
-    width: 100%; font-size: 1.5rem; font-weight: 700; color: #fff; background: #0B7A2F;
-    border: none; border-radius: 14px; padding: 1.1rem; min-height: 78px; cursor: pointer;
-}
-.gate-override-confirm:active { background: #095e24; }
+.gate-override-prompt { font-size: 1.25rem; font-weight: 600; color: #1e2a33; text-align: center; margin: 0 0 .5rem; }
+.gate-override-hint { font-size: 1.05rem; color: #5a6672; text-align: center; margin: 0 0 1rem; }
 .gate-supervisor-list { display: flex; flex-direction: column; gap: .6rem; max-height: 60vh; overflow-y: auto; }
 .gate-supervisor-pick {
     font-size: 1.35rem; font-weight: 700; padding: 1.1rem 1.25rem; border: none; border-radius: 12px;

--- a/src/Humans.Web/wwwroot/js/gate/gate.js
+++ b/src/Humans.Web/wwwroot/js/gate/gate.js
@@ -282,28 +282,33 @@ export function initGate(refs) {
         }
     }
 
-    // The override panel: a single confirm tap admits a too-early or child-without-ID scan. No PIN
-    // and no supervisor pick — the confirm button IS the authorization (recorded against the gate
-    // account server-side). It's a deliberate second tap so a stray tap on the card can't admit.
+    // The override panel: admits a too-early / unconfirmed-EE or child-without-ID scan, authorized
+    // by the shared supervisor PIN. The keypad auto-submits on the 4th digit; the server verifies
+    // the PIN (and throttles failures) before recording anything.
     function initOverride() {
         if (!override) return { open: () => {} };
 
         const titleEl = override.querySelector('[data-override-title]');
         const promptEl = override.querySelector('[data-override-prompt]');
         const cancelBtn = override.querySelector('[data-override-cancel]');
-        const confirmBtn = override.querySelector('[data-override-confirm]');
+        const keypadEl = override.querySelector('[data-gate-keypad]');
 
         let mode = 'early';
         let barcode = null;
 
+        const keypad = keypadEl && window.initGateKeypad
+            ? window.initGateKeypad(keypadEl, (pin) => submit(pin))
+            : { reset: () => {} };
+
         function open(nextMode, nextBarcode) {
-            clearResetTimer(); // hold the auto-return while the operator confirms the override
+            clearResetTimer(); // hold the auto-return while the supervisor enters the PIN
             mode = nextMode;
             barcode = nextBarcode;
             if (titleEl) titleEl.textContent = mode === 'child' ? 'Admit: child without ID' : 'Supervisor override';
             if (promptEl) promptEl.textContent = mode === 'child'
                 ? 'Admit this child with the accompanying adult?'
                 : 'Admit this guest before general entry?';
+            keypad.reset();
             override.classList.remove('d-none');
             override.setAttribute('aria-hidden', 'false');
         }
@@ -311,6 +316,7 @@ export function initGate(refs) {
         function close() {
             override.classList.add('d-none');
             override.setAttribute('aria-hidden', 'true');
+            keypad.reset();
             focusInput();
         }
 
@@ -325,12 +331,13 @@ export function initGate(refs) {
 
         if (cancelBtn) cancelBtn.addEventListener('click', closeAndReArm);
 
-        if (confirmBtn) confirmBtn.addEventListener('click', () => {
+        function submit(pin) {
             if (!barcode) return;
-            const opts = mode === 'child' ? { childWithAdult: true } : { overrideEarly: true };
+            const opts = { supervisorPin: pin };
+            if (mode === 'child') opts.childWithAdult = true; else opts.overrideEarly = true;
             close();
             submitDecision(barcode, opts);
-        });
+        }
 
         return { open };
     }

--- a/tests/Humans.Application.Tests/Controllers/GateControllerOverridePinTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateControllerOverridePinTests.cs
@@ -1,0 +1,146 @@
+using System.Security.Claims;
+using Humans.Application.Interfaces.Gate;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Enums;
+using Humans.Web.Controllers;
+using Humans.Web.Infrastructure;
+using Humans.Web.Models.Gate;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Controllers;
+
+/// <summary>
+/// The shared supervisor override PIN on <c>/Gate/Decision</c>: overrides are refused
+/// without the correct <c>Gate:SupervisorPin</c> (including when the key is unset — fail
+/// closed), authorized overrides record the gate account, and the terminal-wide throttle
+/// locks only the override path — plain decisions keep flowing.
+/// </summary>
+public class GateControllerOverridePinTests
+{
+    private const string Barcode = "TIX-1";
+    private const string Pin = "2468";
+
+    private readonly Guid _gateAccount = Guid.NewGuid();
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 7, 2, 12, 0));
+    private readonly IGateService _gate = Substitute.For<IGateService>();
+    private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
+
+    public GateControllerOverridePinTests()
+    {
+        _gate.RecordDecisionAsync(Arg.Any<GateDecisionInput>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new GateDecisionResult(GateVerdict.AdmittedEarlyOverride, "Guest", null,
+                IsEarly: true, null, null));
+    }
+
+    private GateController BuildController(string? configuredPin)
+    {
+        Dictionary<string, string?> settings = new(StringComparer.OrdinalIgnoreCase);
+        if (configuredPin is not null)
+            settings["Gate:SupervisorPin"] = configuredPin;
+        var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+        var throttle = new GatePinThrottle(new MemoryCache(new MemoryCacheOptions()), _clock);
+        var controller = new GateController(_gate, _users, config, throttle, _clock);
+
+        var http = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, _gateAccount.ToString())], "test")),
+        };
+        controller.ControllerContext = new ControllerContext { HttpContext = http };
+        controller.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
+        return controller;
+    }
+
+    private Task<IActionResult> Decide(GateController c, bool overrideEarly = false, bool child = false, string? pin = null) =>
+        c.Decision(Barcode, idConfirmed: false, childWithAdult: child, overrideEarly: overrideEarly,
+            supervisorPin: pin, laneId: null, TestContext.Current.CancellationToken);
+
+    private static GateScanCardViewModel CardOf(IActionResult result) =>
+        Assert.IsType<GateScanCardViewModel>(Assert.IsType<PartialViewResult>(result).Model);
+
+    [HumansFact]
+    public async Task Override_WrongPin_IsRefused_AndNothingIsRecorded()
+    {
+        var controller = BuildController(Pin);
+
+        var card = CardOf(await Decide(controller, overrideEarly: true, pin: "0000"));
+
+        Assert.Equal(GateCardKind.Amber, card.Kind);
+        Assert.True(card.AllowSupervisorOverride); // inline retry stays available
+        await _gate.DidNotReceive().RecordDecisionAsync(
+            Arg.Any<GateDecisionInput>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Override_CorrectPin_RecordsOverrideByTheGateAccount()
+    {
+        var controller = BuildController(Pin);
+
+        await Decide(controller, overrideEarly: true, pin: Pin);
+
+        await _gate.Received(1).RecordDecisionAsync(
+            Arg.Is<GateDecisionInput>(i => i.OverrideByUserId == _gateAccount),
+            _gateAccount, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Override_NoConfiguredPin_FailsClosed()
+    {
+        var controller = BuildController(configuredPin: null);
+
+        var card = CardOf(await Decide(controller, overrideEarly: true, pin: "1111"));
+
+        Assert.Equal(GateCardKind.Amber, card.Kind);
+        Assert.Contains("not configured", card.Reason, StringComparison.OrdinalIgnoreCase);
+        await _gate.DidNotReceive().RecordDecisionAsync(
+            Arg.Any<GateDecisionInput>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Override_Throttle_LocksOverridesOnly_PlainDecisionsKeepFlowing()
+    {
+        var controller = BuildController(Pin);
+
+        for (var i = 0; i < GatePinThrottle.MaxFailures; i++)
+            await Decide(controller, overrideEarly: true, pin: "0000");
+
+        // Even the CORRECT pin is now refused (locked out)…
+        var locked = CardOf(await Decide(controller, overrideEarly: true, pin: Pin));
+        Assert.Contains("wait", locked.Reason, StringComparison.OrdinalIgnoreCase);
+        await _gate.DidNotReceive().RecordDecisionAsync(
+            Arg.Any<GateDecisionInput>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+
+        // …but a plain (non-override) decision on the same terminal still records.
+        await Decide(controller);
+        await _gate.Received(1).RecordDecisionAsync(
+            Arg.Is<GateDecisionInput>(i => i.OverrideByUserId == null),
+            _gateAccount, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task ChildWaiver_RequiresTheSamePin()
+    {
+        var controller = BuildController(Pin);
+
+        var card = CardOf(await Decide(controller, child: true, pin: "9999"));
+
+        Assert.Equal(GateCardKind.Amber, card.Kind);
+        Assert.False(card.AllowSupervisorOverride); // child waiver retries by re-scanning
+        await _gate.DidNotReceive().RecordDecisionAsync(
+            Arg.Any<GateDecisionInput>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+
+        await Decide(controller, child: true, pin: Pin);
+        await _gate.Received(1).RecordDecisionAsync(
+            Arg.Is<GateDecisionInput>(i => i.ChildWithAdult && i.OverrideByUserId == _gateAccount),
+            _gateAccount, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -257,6 +257,30 @@ public class GateServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task BeforeCutoff_Unmatched_WithoutOverride_StaysUnresolved()
+    {
+        StubTicket(matchedUserId: null);
+        await _svc.SaveSettingsAsync(new GateSettingsDto(
+            Clock.GetCurrentInstant().Plus(Duration.FromHours(6)), 16));
+
+        // Even a client-asserted "ID confirmed" never turns the unconfirmed-EE amber into an admit.
+        (await Record(idConfirmed: true))
+            .Verdict.Should().Be(GateVerdict.Unresolved);
+    }
+
+    [HumansFact]
+    public async Task BeforeCutoff_Unmatched_WithSupervisorOverride_AdmitsEarlyOverride()
+    {
+        StubTicket(matchedUserId: null);
+        await _svc.SaveSettingsAsync(new GateSettingsDto(
+            Clock.GetCurrentInstant().Plus(Duration.FromHours(6)), 16));
+
+        // A recorded supervisor override admits an unconfirmed-EE scan, mirroring the too-early case.
+        (await Record(idConfirmed: false, overrideBy: Guid.NewGuid()))
+            .Verdict.Should().Be(GateVerdict.AdmittedEarlyOverride);
+    }
+
+    [HumansFact]
     public async Task BeforeCutoff_EarlyEntryToday_AdmitsEarly()
     {
         StubTicket(matchedUserId: GuestId);


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

Implements nobodies-collective/Humans#913 — restores a supervisor gate on gate-terminal overrides (shared PIN, `Gate:SupervisorPin`) and makes the AMBER "Early Entry can't be confirmed" card overridable.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `9e1ad9a5` feat(gate): supervisor override on the unconfirmed-EE card, gated by a shared override PIN (peterdrier/Humans#1079)

## Deploy note

⚠️ **Set `Gate:SupervisorPin` in the production environment before doors open on 7 Jul.** Unset fails closed: every gate override is refused with an explicit "not configured" card (scanning is unaffected).

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly (none in this batch)
- [ ] `Gate:SupervisorPin` set in prod env before 7 Jul

🤖 Generated with [Claude Code](https://claude.com/claude-code)