### PR TITLE
Promote QA → production (4 commits)

### DIFF
--- a/docs/architecture/debt-ledger.yml
+++ b/docs/architecture/debt-ledger.yml
@@ -227,6 +227,9 @@ inbox:
   # sweep scope entirely); PasswordGenerator CSPRNG (explicitly deferred by
   # Peter, 2026-04-24); BudgetRepository ResponsibleTeam .Include (covered by
   # grandfathered-hum0024-nav-strip).
+  - added: 2026-07-02
+    what: "GateService.EvaluateAsync CheckedInAtVendor uses Status==CheckedIn, but the /check_ins sync stamps CheckedInAt and leaves Status Valid — the 'already checked in at vendor' dedupe signal on the gate card never fires; switch to CheckedInAt (found via Codex on peterdrier/Humans#1080)"
+    review: per-item
   - added: 2026-06-12
     what: "UsersAdminController.Audience direct DbContext reads — route through IAdminDatabaseDiagnosticsService"
     review: panel

--- a/docs/sections/Gate.md
+++ b/docs/sections/Gate.md
@@ -160,6 +160,10 @@ but are unreachable since peterdrier#1075 — nothing links to them.)
   never stop the line, while the shared PIN can't be ground through the ~10k space at the kiosk.
 - Scan **attribution is the shared gate account** (peterdrier#1075): the personal-PIN claim flow is
   bypassed, so the leaderboard and `ScannedByUserId` no longer identify individual staffers.
+- An admit with a matched guest immediately writes the guest's Attended participation row for the
+  active event's year — consumed-Early-Entry guards (Camps) and other attendance readers see a gate
+  check-in in real time, never contingent on the vendor mirror or the ticket sync. Unmatched
+  barcodes and no-active-event still admit; only the projection is skipped.
 - Gate participates in GDPR export (`IUserDataContributor`), account merge (`IUserMerge` re-FKs
   `GuestUserId`/`ScannedByUserId`), and retention purge.
 - The gate view shows name + verdict + one reason line only; Early-Entry source, the previous
@@ -196,7 +200,13 @@ but are unreachable since peterdrier#1075 — nothing links to them.)
   mirroring how other controllers read shift signups — no new Shifts surface.
   _Cross-section read approved by Peter (verbal, 2026-06-29)._
 - **Users** — `IUserServiceRead` (scanner name; supervisor/claim display names; leaderboard
-  rendering via `<vc:human>`).
+  rendering via `<vc:human>`); and `IUserService.SetParticipationFromTicketSyncAsync` — on an
+  admit with a matched guest, `GateService` projects the check-in onto the guest's
+  `EventParticipation` row (Attended, `CheckedInAt` = admit instant, year = the active event's).
+  Same upsert the ticket sync uses; its Attended-is-permanent / CheckedInAt-write-once rules make
+  the two writers commute. Without this write the consumed-Early-Entry guards (Camps) never learn
+  of a gate check-in, because the vendor mirror is best-effort and off by default.
+  _Cross-section write approved by Peter (2026-07-02, camp-EE-revoke-after-check-in fix)._
 - **Auth** — `IRoleAssignmentService.HasActiveRoleAsync` (is this user a supervisor?) and
   `GetActiveUserIdsInRoleAsync` (enumerate enrolled supervisors for the override tap-list).
 
@@ -229,5 +239,6 @@ person), mirroring the read-through Scanner section.
 rugged tablet shows only the gate UI. The admin settings page (`Admin`) overrides back to
 `_AdminLayout` (a desktop admin task). The shared `GateTerminal` system account (no roles/teams)
 sees only this kiosk; on the device, Edge Assigned Access removes browser chrome too.
-**Status:** new section (gate-scanner feature). Posture change (attendance gateway) pending Peter's
-sign-off.
+**Status:** new section (gate-scanner feature). Attendance-gateway posture signed off by Peter
+(2026-07-02): a gate admit is the check-in of record and writes the Attended participation row
+directly (see Users under Cross-Section Dependencies).

--- a/src/Humans.Application/Interfaces/Gate/IGateService.cs
+++ b/src/Humans.Application/Interfaces/Gate/IGateService.cs
@@ -39,6 +39,13 @@ public interface IGateService : IApplicationService
     Task<int> PurgeScansBeforeAsync(Instant cutoff, CancellationToken ct = default);
 
     /// <summary>
+    /// Diff of local admits (<c>gate_scan_events</c>) against the vendor's check-in status
+    /// as of the last ticket sync, for the one-off vendor check-in backfill page — recovers
+    /// admits the fire-and-forget mirror (<c>GateVendorCheckInJob</c>) never delivered.
+    /// </summary>
+    Task<GateVendorBackfillSnapshot> GetVendorCheckInBackfillAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// The de-duplicated volunteers signed up for gate shifts on <paramref name="rosterTeamId"/>
     /// whose shift starts within ±2 hours of now (event-local time) — the people likely working
     /// the gate around shift change. Used to pre-fill the claim screen. Empty when there's no
@@ -164,3 +171,22 @@ public sealed record GateLeaderboard(int TotalAdmitted, int TotalScanned, IReadO
 /// </summary>
 public sealed record GateSettingsDto(
     Instant GeneralEntryOpensAt, int MinorAgeThresholdYears, bool CutoffConfigured = false);
+
+/// <summary>
+/// One local admit in the vendor check-in backfill diff. <paramref name="VendorTicketId"/>
+/// is non-null for mirrorable rows and null for unmirrorable ones (no matched attendee
+/// or the attendee row carries no vendor ticket id).
+/// </summary>
+public sealed record GateVendorBackfillRow(
+    string Barcode, string? AttendeeName, Instant AdmittedAt, string? VendorTicketId);
+
+/// <summary>
+/// Local admits diffed against the vendor's check-in status (as of the last ticket sync).
+/// <paramref name="Pending"/> can be mirrored via <c>GateVendorCheckInJob</c>;
+/// <paramref name="Unmirrorable"/> can only be fixed on the vendor dashboard.
+/// </summary>
+public sealed record GateVendorBackfillSnapshot(
+    int AdmitCount,
+    int AlreadyCheckedInCount,
+    IReadOnlyList<GateVendorBackfillRow> Pending,
+    IReadOnlyList<GateVendorBackfillRow> Unmirrorable);

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -202,9 +202,14 @@ public sealed class GateService(
     public Task<int> PurgeScansBeforeAsync(Instant cutoff, CancellationToken ct = default) =>
         repository.PurgeScansBeforeAsync(cutoff, ct);
 
+    /// <summary>Backfill diff window. Covers the whole event including the Early-Entry run-up,
+    /// while keeping prior editions' scans (retention is 365 days) out of the diff — the
+    /// attendee join is current-event-only, so older admits would only pollute Unmirrorable.</summary>
+    private static readonly Duration VendorBackfillWindow = Duration.FromDays(30);
+
     public async Task<GateVendorBackfillSnapshot> GetVendorCheckInBackfillAsync(CancellationToken ct = default)
     {
-        var scans = await repository.GetScansSinceAsync(Instant.MinValue, ct);
+        var scans = await repository.GetScansSinceAsync(clock.GetCurrentInstant().Minus(VendorBackfillWindow), ct);
         var admits = scans.Where(s => IsAdmit(s.Verdict)).ToList();
 
         var orders = await tickets.GetTicketOrdersAsync(ct);

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -13,6 +13,7 @@ using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
 using NodaTime;
 
 namespace Humans.Application.Services.Gate;
@@ -32,8 +33,10 @@ public sealed class GateService(
     IBurnSettingsService burnSettings,
     IShiftManagementService shifts,
     IRoleAssignmentService roles,
+    IUserService users,
     IPasswordHasher<GateStaffPin> pinHasher,
     IAuditLogService auditLog,
+    ILogger<GateService> logger,
     IClock clock) : IGateService, IUserMerge, IUserDataContributor
 {
     /// <summary>How far either side of "now" a gate shift may start to count as current.</summary>
@@ -120,11 +123,50 @@ public sealed class GateService(
                 IsEarly: false, prior?.OccurredAt, prior?.ScannedByUserId);
         }
 
+        if (admit)
+            await MarkAttendedAsync(eval.GuestUserId);
+
         return new GateDecisionResult(verdict, eval.GuestName, eval.TicketTypeName,
             IsEarly: admit && eval.IsEarly,
             eval.PreviousAdmitAt, eval.PreviousAdmitByUserId,
             // Only surface the vendor ticket id when there's an admit to mirror.
             VendorTicketId: admit ? eval.VendorTicketId : null);
+    }
+
+    /// <summary>
+    /// Project a recorded admit onto the guest's EventParticipation row (Attended,
+    /// permanent). The gate is the system of record for admission: the vendor
+    /// check-in mirror is best-effort and off by default, so without this write the
+    /// ticket sync may never learn of a gate check-in — and the consumed-Early-Entry
+    /// guards (e.g. Camps EE revocation) read participation. Same target year as the
+    /// ticket sync (the active event's), skipped when the guest is unmatched or no
+    /// event is active.
+    /// </summary>
+    private async Task MarkAttendedAsync(Guid? guestUserId)
+    {
+        if (guestUserId is null)
+            return;
+
+        // The admit row is already durable, so the projection must (a) not observe the
+        // request token — a kiosk disconnect mustn't skip it — and (b) never fail the
+        // decision response: it races the ticket sync on the same (UserId, Year) row,
+        // and a first-insert unique-index collision there is benign (the sync wrote the
+        // same fact). Log and move on; the next sync converges the row.
+        try
+        {
+            var activeEvent = await shifts.GetActiveAsync();
+            if (activeEvent is null || activeEvent.Year == 0)
+                return;
+
+            await users.SetParticipationFromTicketSyncAsync(
+                guestUserId.Value, activeEvent.Year, ParticipationStatus.Attended,
+                clock.GetCurrentInstant(), CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Attendance projection failed for admitted guest {GuestUserId}; participation row not marked Attended", guestUserId);
+        }
     }
 
     public async Task<GateLeaderboard> GetLeaderboardAsync(Instant since, CancellationToken ct = default)

--- a/src/Humans.Application/Services/Gate/GateService.cs
+++ b/src/Humans.Application/Services/Gate/GateService.cs
@@ -160,6 +160,39 @@ public sealed class GateService(
     public Task<int> PurgeScansBeforeAsync(Instant cutoff, CancellationToken ct = default) =>
         repository.PurgeScansBeforeAsync(cutoff, ct);
 
+    public async Task<GateVendorBackfillSnapshot> GetVendorCheckInBackfillAsync(CancellationToken ct = default)
+    {
+        var scans = await repository.GetScansSinceAsync(Instant.MinValue, ct);
+        var admits = scans.Where(s => IsAdmit(s.Verdict)).ToList();
+
+        var orders = await tickets.GetTicketOrdersAsync(ct);
+        var attendees = orders
+            .Where(o => o.IsCurrentEvent)
+            .SelectMany(o => o.Attendees)
+            .ToDictionary(a => a.Id);
+
+        List<GateVendorBackfillRow> pending = [];
+        List<GateVendorBackfillRow> unmirrorable = [];
+        var alreadyCheckedIn = 0;
+
+        foreach (var admit in admits)
+        {
+            var attendee = admit.TicketAttendeeId is { } id ? attendees.GetValueOrDefault(id) : null;
+            if (attendee is null || string.IsNullOrEmpty(attendee.VendorTicketId))
+                unmirrorable.Add(new GateVendorBackfillRow(
+                    admit.Barcode, attendee?.AttendeeName, admit.OccurredAt, VendorTicketId: null));
+            // CheckedInAt is the vendor check-in signal — a checked-in issued ticket keeps
+            // Status Valid, so testing Status alone would re-post every synced check-in.
+            else if (attendee.CheckedInAt is not null || attendee.Status == TicketAttendeeStatus.CheckedIn)
+                alreadyCheckedIn++;
+            else
+                pending.Add(new GateVendorBackfillRow(
+                    admit.Barcode, attendee.AttendeeName, admit.OccurredAt, attendee.VendorTicketId));
+        }
+
+        return new GateVendorBackfillSnapshot(admits.Count, alreadyCheckedIn, pending, unmirrorable);
+    }
+
     public async Task<IReadOnlyList<GateRosterEntry>> GetShiftRosterAsync(
         Guid rosterTeamId, CancellationToken ct = default)
     {

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -795,7 +795,8 @@ public sealed class TicketQueryService(
                 MatchedUserId: a.MatchedUserId,
                 Barcode: a.Barcode,
                 TransferredToName: hasTransfer ? tr!.ReceiverLegalName : null,
-                TransferredAt: hasTransfer ? tr!.DecidedAt : null);
+                TransferredAt: hasTransfer ? tr!.DecidedAt : null,
+                CheckedInAt: a.CheckedInAt);
         }).ToList(),
         StripeFee: o.StripeFee,
         ApplicationFee: o.ApplicationFee);

--- a/src/Humans.Application/TicketOrderInfo.cs
+++ b/src/Humans.Application/TicketOrderInfo.cs
@@ -6,6 +6,9 @@ namespace Humans.Application;
 /// <summary>
 /// Compact projection of a <see cref="Humans.Domain.Entities.TicketAttendee"/>
 /// row carried inside <see cref="TicketOrderInfo"/>. One per issued ticket.
+/// <paramref name="CheckedInAt"/> is the vendor check-in signal (from the
+/// <c>/check_ins</c> sync) — the issued ticket's <paramref name="Status"/> stays
+/// <c>Valid</c> when checked in, so consumers must test <paramref name="CheckedInAt"/>.
 /// </summary>
 public sealed record TicketAttendeeInfo(
     Guid Id,
@@ -18,7 +21,8 @@ public sealed record TicketAttendeeInfo(
     Guid? MatchedUserId,
     string? Barcode = null,
     string? TransferredToName = null,
-    Instant? TransferredAt = null);
+    Instant? TransferredAt = null,
+    Instant? CheckedInAt = null);
 
 /// <summary>
 /// Compact projection of a <see cref="Humans.Domain.Entities.TicketOrder"/>

--- a/src/Humans.Infrastructure/Jobs/GateVendorCheckInJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GateVendorCheckInJob.cs
@@ -32,7 +32,19 @@ public sealed class GateVendorCheckInJob(
     IConfiguration configuration,
     ILogger<GateVendorCheckInJob> logger)
 {
-    public async Task ExecuteAsync(string vendorTicketId, CancellationToken cancellationToken = default)
+    // Live mirror: the check-in time is "now" (the scan just happened). Hangfire-invoked —
+    // this signature is frozen per memory/code/hangfire-method-signature-stable.md; the
+    // backfill variant below is a SEPARATE method for the same reason.
+    public Task ExecuteAsync(string vendorTicketId, CancellationToken cancellationToken = default) =>
+        ExecuteCoreAsync(vendorTicketId, clock.GetCurrentInstant(), cancellationToken);
+
+    // Backfill mirror: preserves the original gate admit time (unix seconds — a primitive,
+    // so it serializes stably through Hangfire) instead of stamping the admin's click time.
+    // Also Hangfire-invoked: signature frozen once shipped.
+    public Task ExecuteBackfillAsync(string vendorTicketId, long admittedAtUnixSeconds, CancellationToken cancellationToken = default) =>
+        ExecuteCoreAsync(vendorTicketId, Instant.FromUnixTimeSeconds(admittedAtUnixSeconds), cancellationToken);
+
+    private async Task ExecuteCoreAsync(string vendorTicketId, Instant occurredAt, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(vendorTicketId))
             return;
@@ -47,7 +59,7 @@ public sealed class GateVendorCheckInJob(
 
         try
         {
-            await vendor.CreateCheckInAsync(vendorTicketId, clock.GetCurrentInstant(), cancellationToken);
+            await vendor.CreateCheckInAsync(vendorTicketId, occurredAt, cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode is { } status && (int)status is >= 400 and < 500)
         {

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -102,7 +102,7 @@ public sealed class GateController(
         {
             BackgroundJob.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(vendorTicketId, CancellationToken.None));
             if (configuration.GetValue<bool>(VendorMirrorEnabledKey))
-                mirrorLedger.MarkSent(vendorTicketId);
+                mirrorLedger.TryMarkSent(vendorTicketId);
         }
 
         return PartialView("_VerdictCard", GateScanCardViewModel.FromDecision(decision, barcode));

--- a/src/Humans.Web/Controllers/GateController.cs
+++ b/src/Humans.Web/Controllers/GateController.cs
@@ -39,10 +39,12 @@ public sealed class GateController(
     IUserServiceRead users,
     IConfiguration configuration,
     GatePinThrottle pinThrottle,
+    GateVendorMirrorLedger mirrorLedger,
     IClock clock) : HumansControllerBase(users)
 {
     private const string ScannerSessionKey = "GateScannerId";
     private const string SupervisorPinConfigKey = "Gate:SupervisorPin";
+    private const string VendorMirrorEnabledKey = "Gate:VendorMirrorEnabled";
 
     // Throttle bucket for the shared override PIN — one bucket for the terminal, distinct
     // from the per-user claim buckets so a fumbled override can never lock a claim (or vice versa).
@@ -92,8 +94,16 @@ public sealed class GateController(
             scanner, ct);
 
         // Best-effort vendor check-in mirror on admit — fire-and-forget so the gate never waits.
+        // Marked in the mirror ledger so the vendor check-in backfill page never re-sends a live
+        // admit that hasn't flowed back through the ticket sync yet (TT check-ins double-record).
+        // Marked ONLY when the mirror flag is on: with it off the job no-ops, and a ledger mark
+        // would hide exactly the rows the backfill page exists to recover.
         if (decision.VendorTicketId is { Length: > 0 } vendorTicketId)
+        {
             BackgroundJob.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(vendorTicketId, CancellationToken.None));
+            if (configuration.GetValue<bool>(VendorMirrorEnabledKey))
+                mirrorLedger.MarkSent(vendorTicketId);
+        }
 
         return PartialView("_VerdictCard", GateScanCardViewModel.FromDecision(decision, barcode));
     }

--- a/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
@@ -53,7 +53,7 @@ public sealed class GateVendorBackfillAdminController(
             return RedirectToAction(nameof(Index));
         }
 
-        Enqueue(row.VendorTicketId!);
+        Enqueue(row);
         SetSuccess($"Test check-in enqueued for {row.AttendeeName ?? row.Barcode} ({row.VendorTicketId}). " +
                    "Verify it on the TicketTailor dashboard, then send the rest.");
         return RedirectToAction(nameof(Index));
@@ -68,7 +68,7 @@ public sealed class GateVendorBackfillAdminController(
 
         var (_, pending, _) = await GetPendingSplitAsync(ct);
         foreach (var row in pending)
-            Enqueue(row.VendorTicketId!);
+            Enqueue(row);
 
         SetSuccess($"Enqueued {pending.Count} vendor check-in(s). " +
                    "Sent rows are excluded from re-sending; counts update after the next ticket sync.");
@@ -86,9 +86,14 @@ public sealed class GateVendorBackfillAdminController(
         return (snapshot, pending, sent);
     }
 
-    private void Enqueue(string vendorTicketId)
+    // ExecuteBackfillAsync (not the live ExecuteAsync) so TicketTailor records the ORIGINAL
+    // gate admit time as check_in_at, not the moment the admin clicked Send.
+    private void Enqueue(GateVendorBackfillRow row)
     {
-        backgroundJobs.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(vendorTicketId, CancellationToken.None));
+        var vendorTicketId = row.VendorTicketId!;
+        var admittedAtUnixSeconds = row.AdmittedAt.ToUnixTimeSeconds();
+        backgroundJobs.Enqueue<GateVendorCheckInJob>(j =>
+            j.ExecuteBackfillAsync(vendorTicketId, admittedAtUnixSeconds, CancellationToken.None));
         ledger.MarkSent(vendorTicketId);
     }
 

--- a/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
@@ -47,13 +47,12 @@ public sealed class GateVendorBackfillAdminController(
         var (_, pending, _) = await GetPendingSplitAsync(ct);
         var row = pending.FirstOrDefault(r =>
             string.Equals(r.VendorTicketId, vendorTicketId, StringComparison.Ordinal));
-        if (row is null)
+        if (row is null || !TryEnqueue(row))
         {
             SetError("That ticket is no longer pending — already sent, checked in at the vendor, or unknown.");
             return RedirectToAction(nameof(Index));
         }
 
-        Enqueue(row);
         SetSuccess($"Test check-in enqueued for {row.AttendeeName ?? row.Barcode} ({row.VendorTicketId}). " +
                    "Verify it on the TicketTailor dashboard, then send the rest.");
         return RedirectToAction(nameof(Index));
@@ -67,10 +66,9 @@ public sealed class GateVendorBackfillAdminController(
             return error;
 
         var (_, pending, _) = await GetPendingSplitAsync(ct);
-        foreach (var row in pending)
-            Enqueue(row);
+        var enqueued = pending.Count(TryEnqueue);
 
-        SetSuccess($"Enqueued {pending.Count} vendor check-in(s). " +
+        SetSuccess($"Enqueued {enqueued} vendor check-in(s). " +
                    "Sent rows are excluded from re-sending; counts update after the next ticket sync.");
         return RedirectToAction(nameof(Index));
     }
@@ -87,14 +85,19 @@ public sealed class GateVendorBackfillAdminController(
     }
 
     // ExecuteBackfillAsync (not the live ExecuteAsync) so TicketTailor records the ORIGINAL
-    // gate admit time as check_in_at, not the moment the admin clicked Send.
-    private void Enqueue(GateVendorBackfillRow row)
+    // gate admit time as check_in_at, not the moment the admin clicked Send. The ledger claim
+    // is atomic and happens BEFORE the enqueue: two overlapping requests (double-click, second
+    // admin) must never both enqueue the same non-idempotent vendor check-in.
+    private bool TryEnqueue(GateVendorBackfillRow row)
     {
         var vendorTicketId = row.VendorTicketId!;
+        if (!ledger.TryMarkSent(vendorTicketId))
+            return false;
+
         var admittedAtUnixSeconds = row.AdmittedAt.ToUnixTimeSeconds();
         backgroundJobs.Enqueue<GateVendorCheckInJob>(j =>
             j.ExecuteBackfillAsync(vendorTicketId, admittedAtUnixSeconds, CancellationToken.None));
-        ledger.MarkSent(vendorTicketId);
+        return true;
     }
 
     private IActionResult? MirrorDisabledError()

--- a/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/GateVendorBackfillAdminController.cs
@@ -1,0 +1,108 @@
+using Hangfire;
+using Humans.Application.Interfaces.Gate;
+using Humans.Application.Interfaces.Users;
+using Humans.Infrastructure.Jobs;
+using Humans.Web.Authorization;
+using Humans.Web.Infrastructure;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+// One-off vendor check-in backfill (temp page, remove after use). Recovers gate admits that
+// GateVendorCheckInJob never mirrored to TicketTailor while Gate:VendorMirrorEnabled was unset:
+// shows the diff of local admits vs the vendor's check-in status (last ticket sync), lets an
+// admin send a single test check-in first, then the whole pending set. TicketTailor check-ins
+// double-record on repeat, so two guards apply: both POSTs recompute the diff server-side (a
+// client-supplied id is never enqueued blindly), and GateVendorMirrorLedger keeps every
+// already-enqueued id out of both send paths until the ticket sync confirms it.
+[Authorize(Policy = PolicyNames.AdminOnly)]
+[Route("Gate/Admin/VendorCheckInBackfill")]
+public sealed class GateVendorBackfillAdminController(
+    IUserServiceRead users,
+    IGateService gate,
+    IConfiguration configuration,
+    GateVendorMirrorLedger ledger,
+    IBackgroundJobClient backgroundJobs) : HumansControllerBase(users)
+{
+    private const string MirrorEnabledKey = "Gate:VendorMirrorEnabled";
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken ct)
+    {
+        var (snapshot, pending, sent) = await GetPendingSplitAsync(ct);
+        return View(new GateVendorBackfillViewModel(
+            snapshot, pending, sent, MirrorEnabled: configuration.GetValue<bool>(MirrorEnabledKey)));
+    }
+
+    // Send ONE pending check-in so the result can be verified on the vendor dashboard
+    // before the bulk run.
+    [HttpPost("RunOne")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RunOne(string vendorTicketId, CancellationToken ct)
+    {
+        if (MirrorDisabledError() is { } error)
+            return error;
+
+        var (_, pending, _) = await GetPendingSplitAsync(ct);
+        var row = pending.FirstOrDefault(r =>
+            string.Equals(r.VendorTicketId, vendorTicketId, StringComparison.Ordinal));
+        if (row is null)
+        {
+            SetError("That ticket is no longer pending — already sent, checked in at the vendor, or unknown.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        Enqueue(row.VendorTicketId!);
+        SetSuccess($"Test check-in enqueued for {row.AttendeeName ?? row.Barcode} ({row.VendorTicketId}). " +
+                   "Verify it on the TicketTailor dashboard, then send the rest.");
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost("Run")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Run(CancellationToken ct)
+    {
+        if (MirrorDisabledError() is { } error)
+            return error;
+
+        var (_, pending, _) = await GetPendingSplitAsync(ct);
+        foreach (var row in pending)
+            Enqueue(row.VendorTicketId!);
+
+        SetSuccess($"Enqueued {pending.Count} vendor check-in(s). " +
+                   "Sent rows are excluded from re-sending; counts update after the next ticket sync.");
+        return RedirectToAction(nameof(Index));
+    }
+
+    // Pending split into not-yet-sent vs sent-awaiting-sync (the ledger remembers enqueued
+    // ids until the vendor's check-in flows back through the ticket sync).
+    private async Task<(GateVendorBackfillSnapshot Snapshot, IReadOnlyList<GateVendorBackfillRow> Pending, IReadOnlyList<GateVendorBackfillRow> Sent)>
+        GetPendingSplitAsync(CancellationToken ct)
+    {
+        var snapshot = await gate.GetVendorCheckInBackfillAsync(ct);
+        var pending = snapshot.Pending.Where(r => !ledger.WasSent(r.VendorTicketId!)).ToList();
+        var sent = snapshot.Pending.Where(r => ledger.WasSent(r.VendorTicketId!)).ToList();
+        return (snapshot, pending, sent);
+    }
+
+    private void Enqueue(string vendorTicketId)
+    {
+        backgroundJobs.Enqueue<GateVendorCheckInJob>(j => j.ExecuteAsync(vendorTicketId, CancellationToken.None));
+        ledger.MarkSent(vendorTicketId);
+    }
+
+    private IActionResult? MirrorDisabledError()
+    {
+        if (configuration.GetValue<bool>(MirrorEnabledKey))
+            return null;
+        SetError("Gate:VendorMirrorEnabled is off — enqueued jobs would silently skip. Set it in the environment first.");
+        return RedirectToAction(nameof(Index));
+    }
+}
+
+public sealed record GateVendorBackfillViewModel(
+    GateVendorBackfillSnapshot Snapshot,
+    IReadOnlyList<GateVendorBackfillRow> Pending,
+    IReadOnlyList<GateVendorBackfillRow> SentAwaitingSync,
+    bool MirrorEnabled);

--- a/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
+++ b/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
@@ -3,8 +3,9 @@ using Microsoft.Extensions.Caching.Memory;
 namespace Humans.Web.Infrastructure;
 
 /// <summary>
-/// Remembers which vendor ticket ids the check-in backfill page has already enqueued,
-/// so neither the single-row test nor the bulk send can re-post one while the vendor's
+/// Remembers which vendor ticket ids already have a check-in mirror enqueued — by the
+/// live gate path (<c>GateController.Decision</c>) or by the backfill page — so the
+/// backfill's single-row test and bulk send can never re-post one while the vendor's
 /// check-in hasn't flowed back through the ticket sync yet (TicketTailor check-ins
 /// double-record on repeat). Single-server in-memory state, like
 /// <see cref="GatePinThrottle"/>; entries expire after <see cref="Retention"/> — by

--- a/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
+++ b/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
@@ -17,10 +17,26 @@ public sealed class GateVendorMirrorLedger(IMemoryCache cache)
     /// <summary>How long a sent id stays remembered — generously past any sync cadence.</summary>
     public static readonly TimeSpan Retention = TimeSpan.FromHours(24);
 
+    private readonly Lock _lock = new();
+
     private static string Key(string vendorTicketId) => $"GateVendorMirrorSent:{vendorTicketId}";
 
-    public void MarkSent(string vendorTicketId) =>
-        cache.Set(Key(vendorTicketId), true, Retention);
+    /// <summary>
+    /// Atomically claim an id: true when THIS call marked it (caller may enqueue), false
+    /// when it was already claimed. Check-then-act under one lock — two overlapping "Send
+    /// all" requests must not both enqueue the same non-idempotent vendor check-in.
+    /// </summary>
+    public bool TryMarkSent(string vendorTicketId)
+    {
+        lock (_lock)
+        {
+            var key = Key(vendorTicketId);
+            if (cache.TryGetValue(key, out _))
+                return false;
+            cache.Set(key, true, Retention);
+            return true;
+        }
+    }
 
     public bool WasSent(string vendorTicketId) =>
         cache.TryGetValue(Key(vendorTicketId), out _);

--- a/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
+++ b/src/Humans.Web/Infrastructure/GateVendorMirrorLedger.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Humans.Web.Infrastructure;
+
+/// <summary>
+/// Remembers which vendor ticket ids the check-in backfill page has already enqueued,
+/// so neither the single-row test nor the bulk send can re-post one while the vendor's
+/// check-in hasn't flowed back through the ticket sync yet (TicketTailor check-ins
+/// double-record on repeat). Single-server in-memory state, like
+/// <see cref="GatePinThrottle"/>; entries expire after <see cref="Retention"/> — by
+/// then the sync has long since moved the row out of pending (or the app restarted,
+/// in which case the page's "wait for the sync" copy is the guard).
+/// </summary>
+public sealed class GateVendorMirrorLedger(IMemoryCache cache)
+{
+    /// <summary>How long a sent id stays remembered — generously past any sync cadence.</summary>
+    public static readonly TimeSpan Retention = TimeSpan.FromHours(24);
+
+    private static string Key(string vendorTicketId) => $"GateVendorMirrorSent:{vendorTicketId}";
+
+    public void MarkSent(string vendorTicketId) =>
+        cache.Set(Key(vendorTicketId), true, Retention);
+
+    public bool WasSent(string vendorTicketId) =>
+        cache.TryGetValue(Key(vendorTicketId), out _);
+}

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -86,6 +86,7 @@ if (!builder.Environment.IsProduction())
 builder.Services.AddScoped<GateTerminalAccountSeeder>();
 builder.Services.AddSingleton<GateLoginThrottle>();
 builder.Services.AddSingleton<GatePinThrottle>();
+builder.Services.AddSingleton<GateVendorMirrorLedger>();
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -149,7 +149,8 @@ public static class AdminNavTree
         ]),
         new("Temp", System: true, Items: [
             new("Picture migration",          "ProfilePictureMigrationAdmin", "Index", null, null, "fa-solid fa-image",     PolicyNames.AdminOnly),
-            new("Stub profile backfill",      "ProfileBackfillAdmin", "Index",          null, null, "fa-solid fa-user-plus", PolicyNames.AdminOnly)
+            new("Stub profile backfill",      "ProfileBackfillAdmin", "Index",          null, null, "fa-solid fa-user-plus", PolicyNames.AdminOnly),
+            new("Vendor check-in backfill",   "GateVendorBackfillAdmin", "Index",       null, null, "fa-solid fa-cloud-arrow-up", PolicyNames.AdminOnly)
         ])
     ];
 }

--- a/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
@@ -16,10 +16,11 @@
 
 <p class="text-muted">
     Gate admits recorded locally in <code>gate_scan_events</code> but not yet checked in at
-    TicketTailor (as of the last ticket sync). Sending a row enqueues the existing
-    <code>GateVendorCheckInJob</code> mirror. TicketTailor check-ins <strong>double-record on
-    repeat</strong>, so already-sent rows are excluded from both send buttons until the next
-    ticket sync confirms them.
+    TicketTailor (as of the last ticket sync). Sending a row enqueues the
+    <code>GateVendorCheckInJob</code> mirror with the <strong>original gate admit time</strong>
+    as the vendor check-in time. TicketTailor check-ins <strong>double-record on repeat</strong>,
+    so anything already enqueued — by these buttons or by a live gate scan — is excluded from
+    both send buttons until the next ticket sync confirms it.
 </p>
 
 @if (!Model.MirrorEnabled)

--- a/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/GateVendorBackfillAdmin/Index.cshtml
@@ -1,0 +1,213 @@
+@using Humans.Application.Extensions
+@model Humans.Web.Controllers.GateVendorBackfillViewModel
+@{
+    ViewData["Title"] = "Vendor check-in backfill";
+    Layout = "_AdminLayout";
+    var snapshot = Model.Snapshot;
+    var pending = Model.Pending.OrderBy(r => r.AdmittedAt).ToList();
+    var sent = Model.SentAwaitingSync.OrderBy(r => r.AdmittedAt).ToList();
+    var unmirrorable = snapshot.Unmirrorable.OrderBy(r => r.AdmittedAt).ToList();
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Vendor check-in backfill</h1>
+    <small class="text-muted">Temp page — remove after use</small>
+</div>
+
+<p class="text-muted">
+    Gate admits recorded locally in <code>gate_scan_events</code> but not yet checked in at
+    TicketTailor (as of the last ticket sync). Sending a row enqueues the existing
+    <code>GateVendorCheckInJob</code> mirror. TicketTailor check-ins <strong>double-record on
+    repeat</strong>, so already-sent rows are excluded from both send buttons until the next
+    ticket sync confirms them.
+</p>
+
+@if (!Model.MirrorEnabled)
+{
+    <div class="alert alert-danger">
+        <i class="fa-solid fa-triangle-exclamation me-1" aria-hidden="true"></i>
+        <strong><code>Gate:VendorMirrorEnabled</code> is off.</strong> Every enqueued job will
+        silently skip — set the environment variable before sending anything.
+    </div>
+}
+
+<div class="row g-3 mb-4">
+    <div class="col-md">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Local admits</h6>
+                <p class="h2 mb-0">@snapshot.AdmitCount</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Already at vendor</h6>
+                <p class="h2 mb-0 text-success">@snapshot.AlreadyCheckedInCount</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Pending mirror</h6>
+                <p class="h2 mb-0 @(pending.Count == 0 ? "text-success" : "text-warning")">@pending.Count</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Sent — awaiting sync</h6>
+                <p class="h2 mb-0 text-info">@sent.Count</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md">
+        <div class="card h-100">
+            <div class="card-body">
+                <h6 class="card-subtitle text-muted mb-2">Unmirrorable</h6>
+                <p class="h2 mb-0 @(unmirrorable.Count == 0 ? "text-success" : "text-danger")">@unmirrorable.Count</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (pending.Count == 0)
+{
+    <div class="card mb-4">
+        <div class="card-body">
+            <p class="mb-0">
+                Nothing pending —
+                @(sent.Count > 0
+                    ? $"{sent.Count} sent check-in(s) awaiting the next ticket sync."
+                    : "every mirrorable admit is checked in at the vendor.")
+            </p>
+        </div>
+    </div>
+}
+else
+{
+    <div class="card mb-4">
+        <div class="card-body">
+            <p>
+                <strong>@pending.Count</strong> admit@(pending.Count == 1 ? "" : "s") to send.
+                Test one first (the <em>Send</em> button on a row — pick yourself if you're listed),
+                confirm it lands on the TicketTailor dashboard, then send the rest.
+            </p>
+            <form method="post" asp-action="Run">
+                @Html.AntiForgeryToken()
+                <button type="submit" class="btn btn-primary">
+                    <i class="fa-solid fa-cloud-arrow-up me-1" aria-hidden="true"></i>
+                    Send all @pending.Count pending check-in@(pending.Count == 1 ? "" : "s") to TicketTailor
+                </button>
+            </form>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">Pending check-ins</div>
+        <div class="table-responsive">
+            <table class="table table-sm table-hover mb-0 align-middle">
+                <thead>
+                    <tr>
+                        <th>Attendee</th>
+                        <th>Barcode</th>
+                        <th>Vendor ticket</th>
+                        <th>Admitted (UTC)</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in pending)
+                    {
+                        <tr>
+                            <td>@(row.AttendeeName ?? "—")</td>
+                            <td><code>@row.Barcode</code></td>
+                            <td><code>@row.VendorTicketId</code></td>
+                            <td>@row.AdmittedAt.ToInvariantTimestamp()</td>
+                            <td class="text-end">
+                                <form method="post" asp-action="RunOne" class="d-inline">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="vendorTicketId" value="@row.VendorTicketId" />
+                                    <button type="submit" class="btn btn-sm btn-outline-primary">Send</button>
+                                </form>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+@if (sent.Count > 0)
+{
+    <div class="card mb-4">
+        <div class="card-header">Sent — awaiting the next ticket sync</div>
+        <div class="card-body pb-0">
+            <p class="text-muted">
+                Already enqueued; excluded from re-sending. They disappear from this page once the
+                ticket sync confirms the vendor-side check-in.
+            </p>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-sm mb-0 align-middle">
+                <thead>
+                    <tr>
+                        <th>Attendee</th>
+                        <th>Barcode</th>
+                        <th>Vendor ticket</th>
+                        <th>Admitted (UTC)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in sent)
+                    {
+                        <tr>
+                            <td>@(row.AttendeeName ?? "—")</td>
+                            <td><code>@row.Barcode</code></td>
+                            <td><code>@row.VendorTicketId</code></td>
+                            <td>@row.AdmittedAt.ToInvariantTimestamp()</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+@if (unmirrorable.Count > 0)
+{
+    <div class="card mb-4">
+        <div class="card-header">Unmirrorable — fix on the TicketTailor dashboard by hand</div>
+        <div class="card-body pb-0">
+            <p class="text-muted">
+                These admits have no matched attendee / vendor ticket id (name-search or
+                unmatched-barcode overrides), so the API can't check them in.
+            </p>
+        </div>
+        <div class="table-responsive">
+            <table class="table table-sm mb-0 align-middle">
+                <thead>
+                    <tr>
+                        <th>Attendee</th>
+                        <th>Barcode</th>
+                        <th>Admitted (UTC)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in unmirrorable)
+                    {
+                        <tr>
+                            <td>@(row.AttendeeName ?? "—")</td>
+                            <td><code>@row.Barcode</code></td>
+                            <td>@row.AdmittedAt.ToInvariantTimestamp()</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}

--- a/src/Humans.Web/appsettings.json
+++ b/src/Humans.Web/appsettings.json
@@ -48,7 +48,7 @@
   "TicketVendor": {
     "Provider": "TicketTailor",
     "EventId": "ev_7718745",
-    "SyncIntervalMinutes": 15,
+    "SyncIntervalMinutes": 5,
     "BreakEvenTarget": 2000
   },
   "OpenTelemetry": {

--- a/tests/Humans.Application.Tests/Controllers/GateControllerClaimTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateControllerClaimTests.cs
@@ -41,7 +41,8 @@ public class GateControllerClaimTests
     {
         _throttle = new GatePinThrottle(new MemoryCache(new MemoryCacheOptions()), _clock);
         _controller = new GateController(
-            _gate, _users, new ConfigurationBuilder().Build(), _throttle, _clock);
+            _gate, _users, new ConfigurationBuilder().Build(), _throttle,
+            new GateVendorMirrorLedger(new MemoryCache(new MemoryCacheOptions())), _clock);
 
         var http = new DefaultHttpContext { Session = _session };
         _controller.ControllerContext = new ControllerContext { HttpContext = http };

--- a/tests/Humans.Application.Tests/Controllers/GateControllerOverridePinTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateControllerOverridePinTests.cs
@@ -48,7 +48,8 @@ public class GateControllerOverridePinTests
             settings["Gate:SupervisorPin"] = configuredPin;
         var config = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
         var throttle = new GatePinThrottle(new MemoryCache(new MemoryCacheOptions()), _clock);
-        var controller = new GateController(_gate, _users, config, throttle, _clock);
+        var mirrorLedger = new GateVendorMirrorLedger(new MemoryCache(new MemoryCacheOptions()));
+        var controller = new GateController(_gate, _users, config, throttle, mirrorLedger, _clock);
 
         var http = new DefaultHttpContext
         {

--- a/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
@@ -141,6 +141,16 @@ public class GateVendorBackfillControllerTests
     }
 
     [HumansFact]
+    public void TryMarkSent_ClaimsAnIdExactlyOnce()
+    {
+        // The atomic claim is the double-post guard: of two overlapping requests
+        // (double-click / second admin), exactly one may enqueue a given ticket.
+        Assert.True(_ledger.TryMarkSent("vt-X"));
+        Assert.False(_ledger.TryMarkSent("vt-X"));
+        Assert.True(_ledger.WasSent("vt-X"));
+    }
+
+    [HumansFact]
     public async Task Index_SplitsPendingFromSentAwaitingSync()
     {
         var controller = BuildController();

--- a/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
@@ -3,6 +3,7 @@ using Hangfire.Common;
 using Hangfire.States;
 using Humans.Application.Interfaces.Gate;
 using Humans.Application.Interfaces.Users;
+using Humans.Infrastructure.Jobs;
 using Humans.Web.Controllers;
 using Humans.Web.Infrastructure;
 using Microsoft.AspNetCore.Http;
@@ -85,6 +86,22 @@ public class GateVendorBackfillControllerTests
         Assert.Equal(["vt-A"], EnqueuedVendorIds());
         Assert.True(_ledger.WasSent("vt-A"));
         Assert.False(_ledger.WasSent("vt-B"));
+    }
+
+    [HumansFact]
+    public async Task RunOne_PreservesTheOriginalAdmitTime()
+    {
+        var controller = BuildController();
+
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        // ExecuteBackfillAsync(vendorTicketId, admittedAtUnixSeconds, ct) — the vendor
+        // check-in must carry the gate admit time, not the moment the admin clicked Send.
+        var job = (Job)_jobs.ReceivedCalls().Single(c =>
+            string.Equals(c.GetMethodInfo().Name, nameof(IBackgroundJobClient.Create), StringComparison.Ordinal))
+            .GetArguments()[0]!;
+        Assert.Equal(nameof(GateVendorCheckInJob.ExecuteBackfillAsync), job.Method.Name);
+        Assert.Equal(RowA.AdmittedAt.ToUnixTimeSeconds(), (long)job.Args[1]!);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/GateVendorBackfillControllerTests.cs
@@ -1,0 +1,138 @@
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Humans.Application.Interfaces.Gate;
+using Humans.Application.Interfaces.Users;
+using Humans.Web.Controllers;
+using Humans.Web.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Controllers;
+
+/// <summary>
+/// The vendor check-in backfill page's double-post guards: a just-sent ticket is
+/// excluded from both the single test send and the bulk send until the ticket sync
+/// confirms it (TicketTailor check-ins double-record on repeat), and nothing is
+/// enqueued while <c>Gate:VendorMirrorEnabled</c> is off.
+/// </summary>
+public class GateVendorBackfillControllerTests
+{
+    private static readonly GateVendorBackfillRow RowA =
+        new("TIX-A", "Ada", Instant.FromUtc(2026, 7, 2, 9, 0), "vt-A");
+
+    private static readonly GateVendorBackfillRow RowB =
+        new("TIX-B", "Ben", Instant.FromUtc(2026, 7, 2, 9, 5), "vt-B");
+
+    private readonly IGateService _gate = Substitute.For<IGateService>();
+    private readonly IUserServiceRead _users = Substitute.For<IUserServiceRead>();
+    private readonly IBackgroundJobClient _jobs = Substitute.For<IBackgroundJobClient>();
+    private readonly GateVendorMirrorLedger _ledger = new(new MemoryCache(new MemoryCacheOptions()));
+
+    public GateVendorBackfillControllerTests()
+    {
+        _gate.GetVendorCheckInBackfillAsync(Arg.Any<CancellationToken>())
+            .Returns(new GateVendorBackfillSnapshot(2, 0, [RowA, RowB], []));
+    }
+
+    private GateVendorBackfillAdminController BuildController(bool mirrorEnabled = true)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Gate:VendorMirrorEnabled"] = mirrorEnabled ? "true" : null,
+            }).Build();
+        var controller = new GateVendorBackfillAdminController(_users, _gate, config, _ledger, _jobs);
+
+        // SetError resolves ILoggerFactory from RequestServices and reads the action
+        // descriptor; RedirectToAction lazily resolves Url — stub all three.
+        var http = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider(),
+        };
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = http,
+            ActionDescriptor = new ControllerActionDescriptor(),
+        };
+        controller.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
+        controller.Url = Substitute.For<IUrlHelper>();
+        return controller;
+    }
+
+    private string[] EnqueuedVendorIds() =>
+        _jobs.ReceivedCalls()
+            .Where(c => string.Equals(c.GetMethodInfo().Name, nameof(IBackgroundJobClient.Create), StringComparison.Ordinal))
+            .Select(c => (string)((Job)c.GetArguments()[0]!).Args[0]!)
+            .ToArray();
+
+    [HumansFact]
+    public async Task RunOne_EnqueuesThatTicket_AndMarksItSent()
+    {
+        var controller = BuildController();
+
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        Assert.Equal(["vt-A"], EnqueuedVendorIds());
+        Assert.True(_ledger.WasSent("vt-A"));
+        Assert.False(_ledger.WasSent("vt-B"));
+    }
+
+    [HumansFact]
+    public async Task Run_AfterRunOne_ExcludesTheTestTicket()
+    {
+        var controller = BuildController();
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        // The vendor record now exists but the local sync hasn't run — RowA is still in
+        // the service's Pending. The bulk send must not re-post it.
+        await controller.Run(TestContext.Current.CancellationToken);
+
+        Assert.Equal(["vt-A", "vt-B"], EnqueuedVendorIds());
+    }
+
+    [HumansFact]
+    public async Task RunOne_ForAnAlreadySentTicket_IsRefused()
+    {
+        var controller = BuildController();
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        Assert.Equal(["vt-A"], EnqueuedVendorIds()); // second attempt enqueued nothing
+    }
+
+    [HumansFact]
+    public async Task MirrorDisabled_NothingIsEnqueued()
+    {
+        var controller = BuildController(mirrorEnabled: false);
+
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+        await controller.Run(TestContext.Current.CancellationToken);
+
+        Assert.Empty(EnqueuedVendorIds());
+        Assert.False(_ledger.WasSent("vt-A"));
+    }
+
+    [HumansFact]
+    public async Task Index_SplitsPendingFromSentAwaitingSync()
+    {
+        var controller = BuildController();
+        await controller.RunOne("vt-A", TestContext.Current.CancellationToken);
+
+        var model = Assert.IsType<GateVendorBackfillViewModel>(
+            Assert.IsType<ViewResult>(await controller.Index(TestContext.Current.CancellationToken)).Model);
+
+        Assert.Equal(["vt-B"], model.Pending.Select(r => r.VendorTicketId));
+        Assert.Equal(["vt-A"], model.SentAwaitingSync.Select(r => r.VendorTicketId));
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -7,6 +7,7 @@ using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Gate;
 using Humans.Domain.Constants;
 using Humans.Application.Tests.Infrastructure;
@@ -14,8 +15,10 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Repositories.Gate;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Humans.Application.Tests.Services.Gate;
 
@@ -38,6 +41,7 @@ public class GateServiceTests : ServiceTestHarness
     private readonly IRoleAssignmentService _roles = Substitute.For<IRoleAssignmentService>();
     private readonly IPasswordHasher<GateStaffPin> _pinHasher = new PasswordHasher<GateStaffPin>();
     private readonly IAuditLogService _auditLog = Substitute.For<IAuditLogService>();
+    private readonly IUserService _users = Substitute.For<IUserService>();
     private readonly GateService _svc;
 
     public GateServiceTests()
@@ -45,7 +49,7 @@ public class GateServiceTests : ServiceTestHarness
         _burn.GetActiveAsync(Arg.Any<CancellationToken>()).Returns((BurnSettingsInfo?)null);
         _earlyEntry.GetForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns((UserEarlyEntry?)null);
-        _svc = new GateService(new GateRepository(DbFactory), _tickets, _earlyEntry, _burn, _shifts, _roles, _pinHasher, _auditLog, Clock);
+        _svc = new GateService(new GateRepository(DbFactory), _tickets, _earlyEntry, _burn, _shifts, _roles, _users, _pinHasher, _auditLog, NullLogger<GateService>.Instance, Clock);
 
         // Baseline: an admin has set the cutoff in the past, so general entry is open.
         // Seeded directly (sync) since the ctor can't await; Db shares the in-memory
@@ -179,6 +183,85 @@ public class GateServiceTests : ServiceTestHarness
         // No authorizing supervisor → the waiver is not granted (a forged child flag can't admit).
         (await Record(idConfirmed: false, child: true))
             .Verdict.Should().Be(GateVerdict.RejectedNameMismatch);
+    }
+
+    // ── Attendance projection (admit → participation Attended) ──────────────
+
+    private void StubActiveEvent(int year = 2026) =>
+        _shifts.GetActiveAsync().Returns(new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = "Test",
+            Year = year,
+            TimeZoneId = "Europe/Madrid",
+            GateOpeningDate = new LocalDate(year, 3, 1),
+        });
+
+    [HumansFact]
+    public async Task RecordDecision_Admit_MarksParticipationAttended()
+    {
+        StubTicket(matchedUserId: GuestId);
+        StubActiveEvent(year: 2026);
+
+        var r = await Record(idConfirmed: true);
+
+        r.Verdict.Should().Be(GateVerdict.Admitted);
+        // CancellationToken.None pinned: the admit is durable, so a kiosk disconnect
+        // (aborted request token) must not skip the projection.
+        await _users.Received(1).SetParticipationFromTicketSyncAsync(
+            GuestId, 2026, ParticipationStatus.Attended,
+            Clock.GetCurrentInstant(), CancellationToken.None);
+    }
+
+    [HumansFact]
+    public async Task RecordDecision_Admit_ParticipationWriteThrows_StillAdmits()
+    {
+        // The projection races the ticket sync on the same (UserId, Year) row; its
+        // failure must never turn an already-recorded admit into an error response.
+        StubTicket(matchedUserId: GuestId);
+        StubActiveEvent();
+        _users.SetParticipationFromTicketSyncAsync(
+                default, default, default, default, default)
+            .ThrowsAsyncForAnyArgs(new InvalidOperationException("unique index collision"));
+
+        (await Record(idConfirmed: true)).Verdict.Should().Be(GateVerdict.Admitted);
+    }
+
+    [HumansFact]
+    public async Task RecordDecision_Reject_DoesNotTouchParticipation()
+    {
+        StubTicket(matchedUserId: GuestId);
+        StubActiveEvent();
+
+        (await Record(idConfirmed: false)).Verdict.Should().Be(GateVerdict.RejectedNameMismatch);
+
+        await _users.DidNotReceiveWithAnyArgs()
+            .SetParticipationFromTicketSyncAsync(default, default, default, default);
+    }
+
+    [HumansFact]
+    public async Task RecordDecision_Admit_UnmatchedGuest_DoesNotTouchParticipation()
+    {
+        // Barcode not matched to a Humans account: there is no user to mark Attended.
+        StubTicket(matchedUserId: null);
+        StubActiveEvent();
+
+        (await Record(idConfirmed: true)).Verdict.Should().Be(GateVerdict.Admitted);
+
+        await _users.DidNotReceiveWithAnyArgs()
+            .SetParticipationFromTicketSyncAsync(default, default, default, default);
+    }
+
+    [HumansFact]
+    public async Task RecordDecision_Admit_NoActiveEvent_StillAdmits()
+    {
+        // No active event → no year to record against; the admit itself must not fail.
+        StubTicket(matchedUserId: GuestId);
+
+        (await Record(idConfirmed: true)).Verdict.Should().Be(GateVerdict.Admitted);
+
+        await _users.DidNotReceiveWithAnyArgs()
+            .SetParticipationFromTicketSyncAsync(default, default, default, default);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -659,6 +659,21 @@ public class GateServiceTests : ServiceTestHarness
     }
 
     [HumansFact]
+    public async Task VendorBackfill_IgnoresAdmitsOlderThanTheWindow()
+    {
+        StubTicket();
+        await Record(idConfirmed: true);
+        // Prior-edition admits (retention is 365 days) must not pollute the diff.
+        Clock.Advance(Duration.FromDays(31));
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AdmitCount.Should().Be(0);
+        snapshot.Pending.Should().BeEmpty();
+        snapshot.Unmirrorable.Should().BeEmpty();
+    }
+
+    [HumansFact]
     public async Task VendorBackfill_RejectedScansAreNotCounted()
     {
         StubTicket();

--- a/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gate/GateServiceTests.cs
@@ -64,10 +64,12 @@ public class GateServiceTests : ServiceTestHarness
     private void StubTicket(
         TicketAttendeeStatus status = TicketAttendeeStatus.Valid,
         Guid? matchedUserId = null,
-        string barcode = Barcode)
+        string barcode = Barcode,
+        Guid? attendeeId = null,
+        Instant? checkedInAt = null)
     {
         var attendee = new TicketAttendeeInfo(
-            Id: Guid.NewGuid(),
+            Id: attendeeId ?? Guid.NewGuid(),
             VendorTicketId: "v1",
             AttendeeName: "Jane Donovan",
             AttendeeEmail: "jane@example.com",
@@ -75,7 +77,8 @@ public class GateServiceTests : ServiceTestHarness
             Price: 100m,
             Status: status,
             MatchedUserId: matchedUserId,
-            Barcode: barcode);
+            Barcode: barcode,
+            CheckedInAt: checkedInAt);
 
         var order = new TicketOrderInfo(
             Id: Guid.NewGuid(),
@@ -507,5 +510,81 @@ public class GateServiceTests : ServiceTestHarness
 
         // Only the admin-enrolled supervisor is offered in the override picker.
         ids.Should().ContainSingle().Which.Should().Be(enrolled);
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_AdmitNotCheckedInAtVendor_IsPending()
+    {
+        StubTicket();
+        await Record(idConfirmed: true);
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AdmitCount.Should().Be(1);
+        snapshot.AlreadyCheckedInCount.Should().Be(0);
+        snapshot.Unmirrorable.Should().BeEmpty();
+        var row = snapshot.Pending.Should().ContainSingle().Subject;
+        row.VendorTicketId.Should().Be("v1");
+        row.AttendeeName.Should().Be("Jane Donovan");
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_VendorAlreadyCheckedIn_IsNotPending()
+    {
+        var attendeeId = Guid.NewGuid();
+        StubTicket(attendeeId: attendeeId);
+        await Record(idConfirmed: true);
+        // The next /check_ins sync stamps CheckedInAt — the issued ticket's Status stays
+        // Valid (vendor semantics), so CheckedInAt alone must drop the row out of pending.
+        StubTicket(attendeeId: attendeeId, checkedInAt: Clock.GetCurrentInstant());
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AdmitCount.Should().Be(1);
+        snapshot.AlreadyCheckedInCount.Should().Be(1);
+        snapshot.Pending.Should().BeEmpty();
+        snapshot.Unmirrorable.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_CheckedInStatusWithoutTimestamp_AlsoNotPending()
+    {
+        var attendeeId = Guid.NewGuid();
+        StubTicket(attendeeId: attendeeId);
+        await Record(idConfirmed: true);
+        StubTicket(status: TicketAttendeeStatus.CheckedIn, attendeeId: attendeeId);
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AlreadyCheckedInCount.Should().Be(1);
+        snapshot.Pending.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_AttendeeNoLongerInOrders_IsUnmirrorable()
+    {
+        StubTicket();
+        await Record(idConfirmed: true);
+        _tickets.GetTicketOrdersAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<TicketOrderInfo>());
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.Pending.Should().BeEmpty();
+        var row = snapshot.Unmirrorable.Should().ContainSingle().Subject;
+        row.VendorTicketId.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task VendorBackfill_RejectedScansAreNotCounted()
+    {
+        StubTicket();
+        await Record(idConfirmed: false); // ID says no → rejected, nothing to mirror
+
+        var snapshot = await _svc.GetVendorCheckInBackfillAsync();
+
+        snapshot.AdmitCount.Should().Be(0);
+        snapshot.Pending.Should().BeEmpty();
+        snapshot.Unmirrorable.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

The centerpiece is the one-off **temp** admin page recovering the gate admits that never mirrored to TicketTailor while `Gate:VendorMirrorEnabled` was unset (live-ops incident, 2026-07-02), plus review fixes and Peter's consumed-EE participation fix.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md`.

## Commits

- `5fca130a` feat(gate): one-off vendor check-in backfill page (temp) (peterdrier/Humans#1080)
- `241a4fcc` fix(gate): admit writes Attended participation so consumed camp EE can't be revoked (peterdrier/Humans#1081)
- `e26609a5` fix(gate): backfill sends original admit time; live mirrors marked in the ledger (peterdrier/Humans#1082)
- `22f2d34c` fix(gate): atomic ledger claim (TryMarkSent) + 30-day backfill window (peterdrier/Humans#1083)

Review threads: 4 findings fixed and resolved; 1 architecture suggestion declined with reasoning (thread open for Peter).

## Deploy notes

⚠️ Before using the backfill page (`/Gate/Admin/VendorCheckInBackfill`, AdminOnly, Temp nav group):

1. Set `Gate__VendorMirrorEnabled=true` in the prod environment — the page refuses to enqueue while it's off (and live scans keep silently skipping the mirror).
2. Confirm the TicketTailor API key has **Event-manager or Admin** scope — an Order-manager key 403s on `/v1/check_ins`.

Recommended flow: send **one** test row → verify on the TicketTailor dashboard (check-in should carry the original gate admit time) → *Send all pending* → wait for the next ticket sync → pending count drops to zero. Remove the page after the backlog is cleared.

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly (none in this batch)
- [ ] `Gate__VendorMirrorEnabled=true` set in prod before running the backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)