### PR TITLE
Promote QA → production (12 commits)

### DIFF
--- a/docs/sections/Agent.md
+++ b/docs/sections/Agent.md
@@ -124,7 +124,7 @@ Read-only HTTP surface for QA/prod chat-history review by dev tooling and a dev-
 
 | Endpoint | Purpose |
 |----------|---------|
-| `GET /api/agent/conversations?refusalsOnly&handoffsOnly&userId&take&skip` | Conversation summaries. `take` clamped 1–200 (default 50). Each row includes `RefusalCount`, `HandoffCount`, `LastUserMessagePreview` (200 char cap), `UserDisplayName` resolved via `IUserService.GetByIdsAsync`. |
+| `GET /api/agent/conversations?refusalsOnly&handoffsOnly&userId&take&skip` | Conversation summaries. `take` clamped 1–200 (default 50). Each row includes `RefusalCount` (messages with `RefusalReason`), `HandoffCount` (legacy `HandedOffToFeedbackId` links plus `route_to_issue` invocations recorded in `FetchedDocs`), `LastUserMessagePreview` (200 char cap), `UserDisplayName` resolved via `IUserService.GetByIdsAsync`. |
 | `GET /api/agent/conversations/{id}` | Full conversation envelope + ordered messages (Role, Content, CreatedAt, Model, RefusalReason, HandedOffToFeedbackId, FetchedDocs). |
 | `GET /api/agent/conversations/{id}/messages` | Messages-only view (same per-message shape). |
 

--- a/src/Humans.Application/Interfaces/Legal/IGitHubLegalDocumentConnector.cs
+++ b/src/Humans.Application/Interfaces/Legal/IGitHubLegalDocumentConnector.cs
@@ -57,3 +57,33 @@ public interface IGitHubLegalDocumentConnector
 /// Raw content + SHA of a GitHub repository file fetch.
 /// </summary>
 public sealed record GitHubFileContent(string Content, string Sha);
+
+/// <summary>
+/// Application-layer translation of Octokit's <c>ApiException</c> (Legal's
+/// analogue of <c>HoldedApiException</c>'s transient/permanent split) so Legal
+/// services can distinguish GitHub API failures from other errors without an
+/// Octokit dependency. Thrown by the Infrastructure connector, which classifies
+/// <see cref="IsTransient"/>: outages (5xx) and rate limits self-heal on the
+/// next run (log Warning); auth/scope/config failures (401/403/422…) repeat
+/// forever and must escalate (log Error). The message carries only the status
+/// code, never GitHub's HTML error body.
+/// </summary>
+public sealed class GitHubApiException : Exception
+{
+    public System.Net.HttpStatusCode StatusCode { get; }
+
+    public bool IsTransient { get; }
+
+    public GitHubApiException() { }
+
+    public GitHubApiException(string message) : base(message) { }
+
+    public GitHubApiException(string message, Exception inner) : base(message, inner) { }
+
+    public GitHubApiException(System.Net.HttpStatusCode statusCode, bool isTransient, Exception inner)
+        : base($"GitHub API error ({(int)statusCode} {statusCode})", inner)
+    {
+        StatusCode = statusCode;
+        IsTransient = isTransient;
+    }
+}

--- a/src/Humans.Application/Models/AnthropicRequest.cs
+++ b/src/Humans.Application/Models/AnthropicRequest.cs
@@ -7,7 +7,11 @@ public sealed record AnthropicRequest(
     string SystemCacheablePrefix,
     IReadOnlyList<AnthropicMessage> Messages,
     IReadOnlyList<AnthropicToolDefinition> Tools,
-    int MaxOutputTokens);
+    int MaxOutputTokens,
+    // Sent as tool_choice "none" so the model must answer in text from the tool
+    // results already in Messages. Tools stay defined — the API rejects requests
+    // whose history contains tool_use blocks without tool definitions.
+    bool DisallowToolUse = false);
 
 public sealed record AnthropicMessage(
     string Role,          // "user" | "assistant" | "tool"

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -145,8 +145,21 @@ public sealed class AgentService : IAgentService
         var toolCallCount = 0;
         AgentIssueProposal? issueProposal = null;
         AgentTurnFinalizer? finalFinalizer = null;
+        // Each loop iteration is a separate provider request with its own usage.
+        // Accumulate across all of them — recording only the last finalizer would
+        // drop tool-loop (and cap-hit synthesis) requests from admin spend and
+        // the DailyTokenCap accounting.
+        var promptTokensTotal = 0;
+        var outputTokensTotal = 0;
+        var cacheReadTokensTotal = 0;
+        var cacheCreationTokensTotal = 0;
         // Wall-clock turn duration (streaming + tool loop) for the admin status latency panel.
         var turnStart = _clock.GetCurrentInstant();
+
+        // Set when the tool-call cap is hit: the next (final) model call withholds tool
+        // use so the model must synthesize an answer from the tool results it already
+        // has, instead of the turn dead-ending on interim preamble text.
+        var withholdTools = false;
 
         while (true)
         {
@@ -154,7 +167,8 @@ public sealed class AgentService : IAgentService
             var pendingToolCalls = new List<AnthropicToolCall>();
 
             await foreach (var token in _client.StreamAsync(
-                new AnthropicRequest(settings.Model, systemPrompt, sdkMessages, tools, MaxOutputTokens: 1024),
+                new AnthropicRequest(settings.Model, systemPrompt, sdkMessages, tools, MaxOutputTokens: 1024,
+                    DisallowToolUse: withholdTools),
                 cancellationToken))
             {
                 if (token.TextDelta is { Length: > 0 } delta)
@@ -170,10 +184,14 @@ public sealed class AgentService : IAgentService
                 else if (token.Finalizer is { } f)
                 {
                     finalFinalizer = f;
+                    promptTokensTotal += f.InputTokens;
+                    outputTokensTotal += f.OutputTokens;
+                    cacheReadTokensTotal += f.CacheReadTokens;
+                    cacheCreationTokensTotal += f.CacheCreationTokens;
                 }
             }
 
-            if (pendingToolCalls.Count == 0 || !string.Equals(finalFinalizer?.StopReason, "tool_use", StringComparison.Ordinal))
+            if (withholdTools || pendingToolCalls.Count == 0 || !string.Equals(finalFinalizer?.StopReason, "tool_use", StringComparison.Ordinal))
                 break;
 
             sdkMessages.Add(new AnthropicMessage(
@@ -188,9 +206,12 @@ public sealed class AgentService : IAgentService
                 toolCallCount++;
                 if (toolCallCount > _anthropicOptions.MaxToolCallsPerTurn)
                 {
+                    // Not `break`: every tool_use block needs a matching tool_result or
+                    // the follow-up synthesis call is rejected by the API.
                     results.Add(new AnthropicToolResult(call.Id,
-                        "Too many lookups. Try a narrower question.", IsError: true));
-                    break;
+                        "Lookup budget for this turn is used up. Answer now from the information already gathered.",
+                        IsError: true));
+                    continue;
                 }
 
                 var result = await _tools.DispatchAsync(call, request.UserId, cancellationToken);
@@ -218,8 +239,14 @@ public sealed class AgentService : IAgentService
 
             sdkMessages.Add(new AnthropicMessage("tool", Text: null, ToolCalls: null, ToolResults: results));
 
-            if (issueProposal is not null || toolCallCount >= _anthropicOptions.MaxToolCallsPerTurn)
+            // route_to_issue handoff: the proposal frame is the terminal output; no synthesis call.
+            if (issueProposal is not null)
                 break;
+
+            // Cap reached: loop once more with tool use withheld so the model answers
+            // from the results above instead of stranding the user mid-lookup.
+            if (toolCallCount >= _anthropicOptions.MaxToolCallsPerTurn)
+                withholdTools = true;
         }
 
         // Proposal frame signals client to open pre-filled Issues modal.
@@ -239,9 +266,9 @@ public sealed class AgentService : IAgentService
             Role = AgentRole.Assistant,
             Content = assistantBuffer.ToString(),
             CreatedAt = turnEnd,
-            PromptTokens = finalFinalizer?.InputTokens ?? 0,
-            OutputTokens = finalFinalizer?.OutputTokens ?? 0,
-            CachedTokens = finalFinalizer?.CacheReadTokens ?? 0,
+            PromptTokens = promptTokensTotal,
+            OutputTokens = outputTokensTotal,
+            CachedTokens = cacheReadTokensTotal,
             Model = settings.Model,
             DurationMs = durationMs,
             FetchedDocs = fetchedDocs.ToArray(),
@@ -253,8 +280,17 @@ public sealed class AgentService : IAgentService
         _rateLimit.Record(request.UserId, today, hour, messagesDelta: 1, tokensDelta: totalTokens);
 
         var fallbackFinalizer = finalFinalizer ?? new AgentTurnFinalizer(0, 0, 0, 0, _settings.Current.Model, "unknown");
-        // Stamp the conversation id so the client can reuse it on the next send.
-        yield return new AgentTurnToken(null, null, fallbackFinalizer with { ConversationId = conversation.Id });
+        // Stamp the conversation id so the client can reuse it on the next send, and
+        // the turn-wide token sums so the finalizer reflects the whole turn, not just
+        // the last provider request. Other fields (stop reason, model) stay from the last one.
+        yield return new AgentTurnToken(null, null, fallbackFinalizer with
+        {
+            ConversationId = conversation.Id,
+            InputTokens = promptTokensTotal,
+            OutputTokens = outputTokensTotal,
+            CacheReadTokens = cacheReadTokensTotal,
+            CacheCreationTokens = cacheCreationTokensTotal
+        });
     }
 
     /// <summary>How many prior user/assistant turns to replay (bounded for context budget).</summary>

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -195,12 +195,24 @@ public sealed class AgentService : IAgentService
 
                 var result = await _tools.DispatchAsync(call, request.UserId, cancellationToken);
                 results.Add(result);
-                // Normalize slug so admin "Top fetched docs" groups by document, not tool-name+args.
-                fetchedDocs.Add(NormalizeFetchedDocSlug(call.Name, call.JsonArguments, _logger));
 
-                if (string.Equals(call.Name, AgentToolNames.RouteToIssue, StringComparison.Ordinal) && !result.IsError)
+                if (string.Equals(call.Name, AgentToolNames.RouteToIssue, StringComparison.Ordinal))
                 {
-                    issueProposal = ParseIssueProposalArgs(call.JsonArguments, conversation.Id);
+                    var proposal = result.IsError ? null : ParseIssueProposalArgs(call.JsonArguments, conversation.Id);
+                    if (proposal is not null)
+                    {
+                        issueProposal = proposal;
+                        // The route_to_issue slug in FetchedDocs is the handoff marker
+                        // (AgentRepository handoffsOnly / AgentApiController.IsHandoff),
+                        // so record it only when the proposal actually reaches the user —
+                        // failed dispatches must not inflate handoff counts.
+                        fetchedDocs.Add(NormalizeFetchedDocSlug(call.Name, call.JsonArguments, _logger));
+                    }
+                }
+                else
+                {
+                    // Normalize slug so admin "Top fetched docs" groups by document, not tool-name+args.
+                    fetchedDocs.Add(NormalizeFetchedDocSlug(call.Name, call.JsonArguments, _logger));
                 }
             }
 

--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -171,6 +171,10 @@ public class DashboardService(
                 hasTicket = userTicketCount > 0;
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // request aborted — let it abort, don't log as an error
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to load ticket status for user {UserId}", userId);
@@ -186,6 +190,10 @@ public class DashboardService(
                 participationStatus = info?.EventParticipations
                     .FirstOrDefault(p => p.Year == activeEvent.Year)?.Status;
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // request aborted — let it abort, don't log as an error
         }
         catch (OperationCanceledException ex)
         {

--- a/src/Humans.Application/Services/Legal/LegalDocumentService.cs
+++ b/src/Humans.Application/Services/Legal/LegalDocumentService.cs
@@ -50,6 +50,14 @@ public sealed class LegalDocumentService(
             cache.Set(cacheKey, content, CacheTtl);
             return content;
         }
+        catch (GitHubApiException ex)
+        {
+            // Status code only — the inner Octokit exception can carry GitHub's HTML error body.
+            logger.LogWarning("GitHub API error fetching legal document {Slug}: {StatusCode}", slug, ex.StatusCode);
+            var emptyContent = new Dictionary<string, string>(StringComparer.Ordinal);
+            cache.Set(cacheKey, emptyContent, FailureCacheTtl);
+            return emptyContent;
+        }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to fetch legal document {Slug} from GitHub", slug);

--- a/src/Humans.Application/Services/Legal/LegalDocumentSyncService.cs
+++ b/src/Humans.Application/Services/Legal/LegalDocumentSyncService.cs
@@ -37,6 +37,23 @@ public sealed class LegalDocumentSyncService(
                     updatedDocuments.Add(document);
                 }
             }
+            catch (GitHubApiException ex) when (ex.IsTransient)
+            {
+                // Transient GitHub outage — the next scheduled run self-heals. Log without
+                // the exception object so GitHub's HTML error page stays out of the logs
+                // (nobodies-collective/Humans#927).
+                logger.LogWarning(
+                    "Transient GitHub error syncing document {DocumentName} ({DocumentId}): {StatusCode}, will retry next run",
+                    document.Name, document.Id, ex.StatusCode);
+            }
+            catch (GitHubApiException ex)
+            {
+                // Permanent (auth/scope/config) — repeats every run until a human acts, so
+                // escalate to Error; still status-code only to keep the HTML body out.
+                logger.LogError(
+                    "GitHub API error syncing document {DocumentName} ({DocumentId}): {StatusCode} — not transient, check GitHub token/config",
+                    document.Name, document.Id, ex.StatusCode);
+            }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Error syncing document {DocumentName} ({DocumentId})",

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -1010,7 +1010,12 @@ public class StoreService(
         // Reprice Open orders to the live catalog, exactly like the order page
         // (MapOrderAsync) — summing raw snapshots here made summary totals drift
         // from order totals whenever a catalog price changed after lines were added.
-        var currentPrices = await LoadCurrentPricesAsync(ct);
+        // Priced from the requested year's products (already loaded above), not the
+        // active event's catalog — historical summaries must not reprice against a
+        // later year's prices.
+        var currentPrices = products.ToDictionary(
+            p => p.Id,
+            p => new BalanceCalculator.ProductPrice(p.UnitPriceEur, p.VatRatePercent, p.DepositAmountEur));
         var totalsByOrder = campOrdersInYear
             .Concat(teamOrders)
             .ToDictionary(o => o.Id, o => BalanceCalculator.Compute(o, currentPrices));
@@ -1120,22 +1125,19 @@ public class StoreService(
             p.DepositAmountEur, p.OrderableUntil, p.IsActive);
 
     /// <summary>
-    /// The single event year whose catalog drives repricing of Open orders. The org runs one
-    /// event year, so this is hardcoded rather than derived from each order's <c>Year</c> — which
-    /// is also why legacy <c>store_orders</c> rows still at <c>Year = 0</c> reprice correctly.
-    /// Bump it when a new event year starts (nobodies-collective/Humans#816).
-    /// </summary>
-    private const int CatalogYear = 2026;
-
-    /// <summary>
-    /// Loads the current catalog price components (incl. deactivated products) for
-    /// <see cref="CatalogYear"/>, keyed by product id, so Open orders reprice to the live price.
+    /// Loads the current catalog price components (incl. deactivated products) for the active
+    /// event's year, keyed by product id, so Open orders reprice to the live price. The org runs
+    /// one event year, so a single catalog year drives repricing rather than each order's
+    /// <c>Year</c> — which is also why legacy <c>store_orders</c> rows still at <c>Year = 0</c>
+    /// reprice correctly.
     /// </summary>
     private async Task<IReadOnlyDictionary<Guid, BalanceCalculator.ProductPrice>> LoadCurrentPricesAsync(
         CancellationToken ct)
     {
+        var activeEvent = await shifts.GetActiveAsync();
+        var catalogYear = activeEvent?.Year > 0 ? activeEvent.Year : clock.GetCurrentInstant().InUtc().Year;
         var prices = new Dictionary<Guid, BalanceCalculator.ProductPrice>();
-        foreach (var product in await repo.GetAllProductsForYearAsync(CatalogYear, ct))
+        foreach (var product in await repo.GetAllProductsForYearAsync(catalogYear, ct))
             prices[product.Id] = new BalanceCalculator.ProductPrice(
                 product.UnitPriceEur, product.VatRatePercent, product.DepositAmountEur);
         return prices;

--- a/src/Humans.Infrastructure/Repositories/AgentRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/AgentRepository.cs
@@ -1,3 +1,4 @@
+using Humans.Application.Constants;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Models;
 using Humans.Domain.Entities;
@@ -102,14 +103,26 @@ internal sealed class AgentRepository(HumansDbContext db, IClock clock) : IAgent
 
         if (userId is Guid u) q = q.Where(c => c.UserId == u);
         if (refusalsOnly) q = q.Where(c => c.Messages.Any(m => m.RefusalReason != null));
-        if (handoffsOnly) q = q.Where(c => c.Messages.Any(m => m.HandedOffToFeedbackId != null));
 
         // arch:db-sort-ok pagination top-N by LastMessageAt
-        return await q.OrderByDescending(c => c.LastMessageAt)
+        var ordered = q.OrderByDescending(c => c.LastMessageAt)
             // arch:db-sort-ok identity-ordered chronological message stream
-            .Include(c => c.Messages.OrderBy(m => m.CreatedAt))
+            .Include(c => c.Messages.OrderBy(m => m.CreatedAt));
+
+        if (!handoffsOnly)
+            return await ordered.Skip(skip).Take(take).ToListAsync(cancellationToken);
+
+        // Handoff = legacy server-side FeedbackReport link, or a successful
+        // route_to_issue recorded in the jsonb FetchedDocs array (propose-only flow,
+        // nobodies-collective/Humans#931). The FetchedDocs value converter blocks
+        // SQL translation of the array Contains, so materialize first and page in
+        // memory — fine at this scale (see CLAUDE.md scale notes).
+        var all = await ordered.ToListAsync(cancellationToken);
+        return all
+            .Where(c => c.Messages.Any(m => m.HandedOffToFeedbackId != null
+                || m.FetchedDocs.Contains(AgentToolNames.RouteToIssue, StringComparer.Ordinal)))
             .Skip(skip).Take(take)
-            .ToListAsync(cancellationToken);
+            .ToList();
     }
 
     public async Task<int> PurgeConversationsOlderThanAsync(Instant cutoff, CancellationToken cancellationToken)

--- a/src/Humans.Infrastructure/Services/Anthropic/AnthropicClient.cs
+++ b/src/Humans.Infrastructure/Services/Anthropic/AnthropicClient.cs
@@ -55,6 +55,7 @@ public sealed class AnthropicClient : IAnthropicClient
                     InputSchema = MapInputSchema(t.JsonSchema),
                 })
                 .ToList(),
+            ToolChoice = request.DisallowToolUse ? new ToolChoice(new ToolChoiceNone()) : null,
         };
 
         string? model = null;

--- a/src/Humans.Infrastructure/Services/GitHubLegalDocumentConnector.cs
+++ b/src/Humans.Infrastructure/Services/GitHubLegalDocumentConnector.cs
@@ -45,6 +45,18 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
         }
     }
 
+    /// <summary>
+    /// Classifies an Octokit failure for <see cref="GitHubApiException.IsTransient"/>:
+    /// rate limits and 5xx self-heal on the next scheduled run; other 4xx
+    /// (revoked PAT, missing scope, malformed request) repeat until a human acts.
+    /// </summary>
+    private static GitHubApiException Translate(ApiException ex) =>
+        new(ex.StatusCode,
+            isTransient: ex is RateLimitExceededException or SecondaryRateLimitExceededException or AbuseException
+                || (int)ex.StatusCode >= 500
+                || (int)ex.StatusCode == 429,
+            ex);
+
     public async Task<IReadOnlyDictionary<string, string>> DiscoverLanguageFilesAsync(
         string folderPath, CancellationToken ct = default)
     {
@@ -84,6 +96,10 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
         {
             _logger.LogWarning("Folder not found in GitHub: {FolderPath}", folderPath);
         }
+        catch (ApiException ex)
+        {
+            throw Translate(ex);
+        }
 
         return languageFiles;
     }
@@ -116,6 +132,10 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
         {
             return null;
         }
+        catch (ApiException ex)
+        {
+            throw Translate(ex);
+        }
     }
 
     public async Task<string?> GetCommitMessageAsync(string sha, CancellationToken ct = default)
@@ -127,6 +147,12 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
             var message = commit.Commit.Message;
             var firstLine = message.Split('\n', 2)[0].Trim();
             return firstLine.Length > 500 ? firstLine[..500] : firstLine;
+        }
+        catch (ApiException ex)
+        {
+            // Status code only — ApiException.Message can carry GitHub's raw HTML error body.
+            _logger.LogDebug("GitHub API error fetching commit message for {Sha}: {StatusCode}", sha, ex.StatusCode);
+            return null;
         }
         catch (Exception ex)
         {
@@ -147,6 +173,12 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
                 new ApiOptions { PageCount = 1, PageSize = 1 });
             return commits.FirstOrDefault()?.Sha;
         }
+        catch (ApiException ex)
+        {
+            // Status code only — ApiException.Message can carry GitHub's raw HTML error body.
+            _logger.LogWarning("GitHub API error getting latest commit SHA for {Path}: {StatusCode}", path, ex.StatusCode);
+            return null;
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error getting latest commit SHA for {Path}", path);
@@ -158,6 +190,19 @@ public sealed partial class GitHubLegalDocumentConnector : IGitHubLegalDocumentC
         string folderPath, string filePrefix, CancellationToken ct = default)
     {
         using var _ = _logger.TimeOperation();
+        try
+        {
+            return await FetchFolderContentByPrefixAsync(folderPath, filePrefix);
+        }
+        catch (ApiException ex)
+        {
+            throw Translate(ex);
+        }
+    }
+
+    private async Task<IReadOnlyDictionary<string, string>> FetchFolderContentByPrefixAsync(
+        string folderPath, string filePrefix)
+    {
         var files = await _client.Repository.Content.GetAllContents(
             _settings.Owner,
             _settings.Repository,

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDrivePermissionsClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/GoogleDrivePermissionsClient.cs
@@ -164,7 +164,9 @@ public sealed class GoogleDrivePermissionsClient(
         }
         catch (Google.GoogleApiException ex)
         {
-            logger.LogWarning(ex,
+            // Debug only — GoogleWorkspaceSyncService logs the failure with
+            // resource/role context (nobodies-collective/Humans#893).
+            logger.LogDebug(ex,
                 "Google API error granting {Role} to {Email} on {FileId}: Code={Code} Message={Message}",
                 role, userEmail, fileId, ex.Error?.Code, ex.Error?.Message);
             return new DrivePermissionMutationResult(
@@ -189,7 +191,9 @@ public sealed class GoogleDrivePermissionsClient(
         }
         catch (Google.GoogleApiException ex)
         {
-            logger.LogWarning(ex,
+            // Debug only — GoogleWorkspaceSyncService logs the failure with
+            // resource context (nobodies-collective/Humans#893).
+            logger.LogDebug(ex,
                 "Google API error deleting permission {PermissionId} on {FileId}: Code={Code} Message={Message}",
                 permissionId, fileId, ex.Error?.Code, ex.Error?.Message);
             return new GoogleClientError(ex.Error?.Code ?? 0, ex.Error?.Message);

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -22,6 +22,14 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
 {
     public const string HttpClientName = "mailerlite";
     private const string HumansGroupPrefix = "Humans - ";
+    private const int MaxSendAttempts = 3;
+
+    // ML's rate-limit window is 60s; used when a 429 carries no Retry-After header.
+    private static readonly TimeSpan DefaultRetryAfter = TimeSpan.FromSeconds(60);
+
+    // Ceiling on honoring Retry-After (60s window + skew headroom) — a malformed or
+    // far-future header must not block callers for minutes; values above clamp to this.
+    private static readonly TimeSpan MaxRetryAfter = TimeSpan.FromSeconds(90);
 
     private static readonly JsonSerializerOptions Json = BuildJson();
     private readonly TrackedLock _gate = new("MailerLiteClient.Gate");
@@ -246,24 +254,53 @@ public sealed class MailerLiteClient(IHttpClientFactory httpFactory, IClock cloc
     {
         using var _ = logger.TimeOperation(operation: caller);
         var http = httpFactory.CreateClient(HttpClientName);
-        using var req = new HttpRequestMessage(method, url);
-        if (content is not null) req.Content = content;
-        HttpResponseMessage resp;
-        try
+        for (var attempt = 1; ; attempt++)
         {
-            resp = await http.SendAsync(req, ct);
+            using var req = new HttpRequestMessage(method, url);
+            if (content is not null) req.Content = content;
+            HttpResponseMessage resp;
+            try
+            {
+                resp = await http.SendAsync(req, ct);
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "MailerLite HTTP call failed: {Method} {Url}", method, url);
+                throw;
+            }
+            catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+            {
+                // HttpClient timeout — surfaces as TaskCanceledException with no token cancel.
+                logger.LogError(ex, "MailerLite HTTP call timed out: {Method} {Url}", method, url);
+                throw;
+            }
+            if (resp.StatusCode == HttpStatusCode.TooManyRequests && attempt < MaxSendAttempts)
+            {
+                var retryAfter = resp.Headers.RetryAfter switch
+                {
+                    { Delta: { } delta } => delta,
+                    { Date: { } date } => date - clock.GetCurrentInstant().ToDateTimeOffset(),
+                    _ => DefaultRetryAfter,
+                };
+                if (retryAfter < TimeSpan.Zero) retryAfter = TimeSpan.Zero;
+                if (retryAfter > MaxRetryAfter) retryAfter = MaxRetryAfter;
+                logger.LogWarning(
+                    "MailerLite returned 429; retrying in {Delay:0.#}s (attempt {Attempt}/{MaxAttempts}): {Method} {Url}",
+                    retryAfter.TotalSeconds, attempt, MaxSendAttempts, method, url);
+                resp.Dispose();
+                // Detach the caller-owned content so disposing this request doesn't dispose it.
+                req.Content = null;
+                await Task.Delay(retryAfter, ct);
+                continue;
+            }
+            return await FinishSendAsync(resp, method, url, ct);
         }
-        catch (HttpRequestException ex)
-        {
-            logger.LogError(ex, "MailerLite HTTP call failed: {Method} {Url}", method, url);
-            throw;
-        }
-        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
-        {
-            // HttpClient timeout — surfaces as TaskCanceledException with no token cancel.
-            logger.LogError(ex, "MailerLite HTTP call timed out: {Method} {Url}", method, url);
-            throw;
-        }
+    }
+
+    // Post-response bookkeeping: proactive rate-limit backoff + non-2xx warning.
+    private async Task<HttpResponseMessage> FinishSendAsync(
+        HttpResponseMessage resp, HttpMethod method, string url, CancellationToken ct)
+    {
         if (resp.Headers.TryGetValues("X-RateLimit-Remaining", out var values)
             && int.TryParse(values.FirstOrDefault(), CultureInfo.InvariantCulture, out var remaining))
         {

--- a/src/Humans.Web/Controllers/AgentApiController.cs
+++ b/src/Humans.Web/Controllers/AgentApiController.cs
@@ -1,4 +1,5 @@
 using Humans.Application;
+using Humans.Application.Constants;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Enums;
@@ -59,7 +60,7 @@ public class AgentApiController : ControllerBase
             LastMessageAt = conv.LastMessageAt.ToDateTimeUtc(),
             conv.MessageCount,
             RefusalCount = conv.Messages.Count(m => m.RefusalReason is not null),
-            HandoffCount = conv.Messages.Count(m => m.HandedOffToFeedbackId is not null),
+            HandoffCount = conv.Messages.Count(IsHandoff),
             Messages = conv.Messages.OrderBy(m => m.CreatedAt).Select(ToMessageDto)
         });
     }
@@ -104,10 +105,20 @@ public class AgentApiController : ControllerBase
             LastMessageAt = c.LastMessageAt.ToDateTimeUtc(),
             c.MessageCount,
             RefusalCount = c.Messages.Count(m => m.RefusalReason is not null),
-            HandoffCount = c.Messages.Count(m => m.HandedOffToFeedbackId is not null),
+            HandoffCount = c.Messages.Count(IsHandoff),
             LastUserMessagePreview = preview
         };
     }
+
+    /// <summary>
+    /// Handoff = legacy server-side FeedbackReport link, or a successful
+    /// route_to_issue recorded in FetchedDocs at save time (the propose-only flow
+    /// never sets HandedOffToFeedbackId — nobodies-collective/Humans#931).
+    /// Mirrors the handoffsOnly filter in AgentRepository.
+    /// </summary>
+    private static bool IsHandoff(AgentMessageSnapshot m) =>
+        m.HandedOffToFeedbackId is not null
+        || m.FetchedDocs.Contains(AgentToolNames.RouteToIssue, StringComparer.Ordinal);
 
     private static object ToMessageDto(AgentMessageSnapshot m) => new
     {

--- a/src/Humans.Web/Controllers/AgentController.cs
+++ b/src/Humans.Web/Controllers/AgentController.cs
@@ -79,10 +79,11 @@ public class AgentController(
         if (missing is not null) return missing;
 
         var isAdmin = User.IsInRole(RoleNames.Admin);
-        var rows = await LoadConversationsAsync(
+        var (rows, hasNext) = await LoadConversationsAsync(
             isAdmin, currentUser.Id, refusalsOnly, userId, page, cancellationToken);
         var listRows = await StitchListRowsAsync(rows, isAdmin, cancellationToken);
-        return View(new AgentConversationsViewModel(listRows, IsAdminView: isAdmin));
+        return View(new AgentConversationsViewModel(
+            listRows, IsAdminView: isAdmin, Page: page < 0 ? 0 : page, HasNext: hasNext));
     }
 
     [HttpGet("Conversation/{id:guid}")]
@@ -114,7 +115,7 @@ public class AgentController(
         return View(new AgentConversationDetailViewModel(conv, displayName, IsAdminView: isAdmin));
     }
 
-    private async Task<IReadOnlyList<AgentConversationListSnapshot>> LoadConversationsAsync(
+    private async Task<(IReadOnlyList<AgentConversationListSnapshot> Rows, bool HasNext)> LoadConversationsAsync(
         bool isAdmin, Guid currentUserId,
         bool refusalsOnly, Guid? userId, int page,
         CancellationToken ct)
@@ -124,10 +125,14 @@ public class AgentController(
         // otherwise crash the EF paging call with a 500.
         var safePage = page < 0 ? 0 : page;
         if (!isAdmin)
-            return await agent.GetHistoryAsync(currentUserId, take: 50, ct);
+            return (await agent.GetHistoryAsync(currentUserId, take: 50, ct), false);
 
-        return await agent.ListAllConversationsForAdminAsync(
-            refusalsOnly, userId, adminPageSize, safePage * adminPageSize, ct);
+        // Fetch one extra row so the view knows whether an older page exists.
+        var rows = await agent.ListAllConversationsForAdminAsync(
+            refusalsOnly, userId, adminPageSize + 1, safePage * adminPageSize, ct);
+        return rows.Count > adminPageSize
+            ? (rows.Take(adminPageSize).ToList(), true)
+            : (rows, false);
     }
 
     private async Task<List<AgentConversationRow>> StitchListRowsAsync(
@@ -178,10 +183,15 @@ public class AgentController(
 }
 
 /// <summary>List of conversations + an admin flag the view uses to decide whether
-/// to surface admin-only chrome (Human column, refusal filters).</summary>
+/// to surface admin-only chrome (Human column, refusal filters). Paging applies to
+/// the admin view only (the non-admin history is a fixed most-recent window):
+/// <see cref="Page"/> is zero-based and <see cref="HasNext"/> means an older page
+/// exists (detected by over-fetching one row).</summary>
 public sealed record AgentConversationsViewModel(
     IReadOnlyList<AgentConversationRow> Rows,
-    bool IsAdminView);
+    bool IsAdminView,
+    int Page = 0,
+    bool HasNext = false);
 
 /// <summary>One row in the conversations list. <see cref="DisplayName"/> is null
 /// for non-admin views (the column is hidden) and stitched in from

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -40,6 +40,16 @@ public class CampController(
     [HttpGet("")]
     public async Task<IActionResult> Index(CampFilterViewModel? filters, CancellationToken ct = default)
     {
+        // Scanners stuff garbage into the bool filter params; rendering with the failed
+        // attempted values still in ModelState makes the checkbox tag helper throw
+        // (nobodies-collective/Humans#926). Drop them and render with whatever bound
+        // successfully, so stale shared links (e.g. an outdated ?Vibe= value) degrade
+        // gracefully instead of erroring.
+        if (!ModelState.IsValid)
+        {
+            ModelState.Clear();
+        }
+
         var user = await GetCurrentUserInfoAsync(ct);
         var settings = await _campService.GetSettingsAsync(ct);
         var year = settings.PublicYear;
@@ -53,36 +63,12 @@ public class CampController(
             ? new HashSet<Guid>()
             : camps.Where(camp => camp.IsLead(user.Id)).Select(camp => camp.Id).ToHashSet();
 
-        var directoryCards = camps
-            .Select(camp => new { Camp = camp, Season = camp.GetSeasonForYear(year) })
-            .Where(row => row.Season is { Status: CampSeasonStatus.Active or CampSeasonStatus.Full })
-            .Select(row => MapCampCard(row.Camp, row.Season!, roleSummaries));
-        if (filters?.Vibe.HasValue == true)
-        {
-            directoryCards = directoryCards.Where(card => card.Vibes.Contains(filters.Vibe.Value));
-        }
-
-        if (filters?.SoundZone.HasValue == true)
-        {
-            directoryCards = directoryCards.Where(card => card.SoundZone == filters.SoundZone.Value);
-        }
-
-        if (filters?.KidsFriendly == true)
-        {
-            directoryCards = directoryCards.Where(card => card.KidsWelcome == YesNoMaybe.Yes);
-        }
-
-        if (filters?.AcceptingMembers == true)
-        {
-            directoryCards = directoryCards.Where(card => card.AcceptingMembers == YesNoMaybe.Yes);
-        }
-
-        if (!string.IsNullOrWhiteSpace(filters?.Search))
-        {
-            var q = filters.Search.Trim();
-            directoryCards = directoryCards.Where(card =>
-                card.Name.Contains(q, StringComparison.OrdinalIgnoreCase));
-        }
+        var directoryCards = ApplyDirectoryFilters(
+            camps
+                .Select(camp => new { Camp = camp, Season = camp.GetSeasonForYear(year) })
+                .Where(row => row.Season is { Status: CampSeasonStatus.Active or CampSeasonStatus.Full })
+                .Select(row => MapCampCard(row.Camp, row.Season!, roleSummaries)),
+            filters);
 
         var cards = directoryCards
             .OrderBy(card => leadCampIds.Contains(card.Id) ? 0 : 1)
@@ -116,6 +102,40 @@ public class CampController(
         };
 
         return View(viewModel);
+    }
+
+    private static IEnumerable<CampCardViewModel> ApplyDirectoryFilters(
+        IEnumerable<CampCardViewModel> cards,
+        CampFilterViewModel? filters)
+    {
+        if (filters?.Vibe.HasValue == true)
+        {
+            cards = cards.Where(card => card.Vibes.Contains(filters.Vibe.Value));
+        }
+
+        if (filters?.SoundZone.HasValue == true)
+        {
+            cards = cards.Where(card => card.SoundZone == filters.SoundZone.Value);
+        }
+
+        if (filters?.KidsFriendly == true)
+        {
+            cards = cards.Where(card => card.KidsWelcome == YesNoMaybe.Yes);
+        }
+
+        if (filters?.AcceptingMembers == true)
+        {
+            cards = cards.Where(card => card.AcceptingMembers == YesNoMaybe.Yes);
+        }
+
+        if (!string.IsNullOrWhiteSpace(filters?.Search))
+        {
+            var q = filters.Search.Trim();
+            cards = cards.Where(card =>
+                card.Name.Contains(q, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return cards;
     }
 
     private static CampCardViewModel MapCampCard(

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -318,7 +318,7 @@ public class ShiftsController(
         }
         catch (InvalidOperationException ex)
         {
-            logger.LogWarning(ex, "Failed to bail shift range {SignupBlockId} for user {UserId}", signupBlockId, user.Id);
+            logger.LogWarning("Failed to bail shift range {SignupBlockId} for user {UserId}: {Reason}", signupBlockId, user.Id, ex.Message);
             SetError(ex.Message);
         }
 
@@ -371,6 +371,21 @@ public class ShiftsController(
         };
 
         var teamIds = ShiftSignupBucketer.GetTeamIds(signups);
+
+        // After early-entry close, the bail lock is per-team: the service gate
+        // (ShiftSignupService.BailAsync/BailRangeAsync) only exempts users who can
+        // approve signups for the signup's own department, so the UI mirrors that
+        // via the same CanApproveSignupsAsync check — once per distinct team, not per row.
+        var bailLockedTeamIds = new HashSet<Guid>();
+        if (es is not null && es.IsEarlyEntryClosed(now))
+        {
+            foreach (var teamId in teamIds)
+            {
+                if (!await shiftMgmt.CanApproveSignupsAsync(user.Id, teamId))
+                    bailLockedTeamIds.Add(teamId);
+            }
+        }
+
         IReadOnlyDictionary<Guid, string> mineTeamNames = new Dictionary<Guid, string>();
         if (teamIds.Count > 0)
         {
@@ -384,6 +399,10 @@ public class ShiftsController(
                 "Skipping shift signup {SignupId} for user {UserId} because related shift data was missing",
                 signup.Id,
                 user.Id));
+
+        foreach (var item in buckets.Upcoming.Concat(buckets.Pending))
+            item.BailLocked = item.Signup.Shift.IsEarlyEntry &&
+                              bailLockedTeamIds.Contains(item.Signup.Shift.Rota.TeamId);
 
         model.Upcoming = buckets.Upcoming;
         model.Pending = buckets.Pending;

--- a/src/Humans.Web/Middleware/ClientStatsMiddleware.cs
+++ b/src/Humans.Web/Middleware/ClientStatsMiddleware.cs
@@ -12,7 +12,9 @@ namespace Humans.Web.Middleware;
 /// count, so static assets, JSON APIs, health/metrics probes and the beacon
 /// endpoint are naturally excluded. Feeds the <c>/Admin/ClientStats</c> screen.
 /// Also records every error response (status &gt; 399, plus aborted requests as
-/// 499) into the tracker's rolling buffer for <c>/Debug/HttpErrors</c>. 429s are
+/// 499 — except authenticated profile-picture loads, see
+/// <see cref="MaybeRecordError"/>) into the tracker's rolling buffer for
+/// <c>/Debug/HttpErrors</c>. 429s are
 /// recorded by the rate limiter's OnRejected callback instead — its rejection
 /// short-circuits before this middleware runs.
 /// </summary>
@@ -57,6 +59,15 @@ public sealed class ClientStatsMiddleware(RequestDelegate next, IClientStatsTrac
     {
         var aborted = context.RequestAborted.IsCancellationRequested;
         if (context.Response.StatusCode <= 399 && !aborted)
+            return;
+
+        // List pages load ~30 profile pictures at once; navigating away aborts
+        // whatever is still in flight. For a logged-in user that's routine browsing,
+        // not an error — recording it floods /Debug/HttpErrors with 499s. Anonymous
+        // aborts still record: a 499 flood without a session is a scrape signal.
+        if (aborted
+            && context.User.Identity?.IsAuthenticated == true
+            && context.Request.Path.StartsWithSegments("/Profile/Picture", StringComparison.OrdinalIgnoreCase))
             return;
 
         // UseStatusCodePagesWithReExecute re-runs the pipeline (and this middleware)

--- a/src/Humans.Web/Models/AccessMatrixDefinitions.cs
+++ b/src/Humans.Web/Models/AccessMatrixDefinitions.cs
@@ -197,19 +197,6 @@ public static class AccessMatrixDefinitions
         },
     };
 
-    /// <summary>All features across all sections, with the roles that have Allowed access.</summary>
-    public static readonly IReadOnlyList<(string Feature, IReadOnlyList<string> AllowedRoles)> Rows =
-        Sections.Values
-            .SelectMany(section => section.Features.Select(f => (
-                Feature: $"{section.SectionName}: {f.Name}",
-                AllowedRoles: (IReadOnlyList<string>)f.RoleAccess
-                    .Where(kv => kv.Value == AccessLevel.Allowed)
-                    .Select(kv => kv.Key)
-                    .ToList()
-            )))
-            .Where(row => row.AllowedRoles.Count > 0)
-            .ToList();
-
     // Shorthand aliases for readability
     private const AccessLevel A = AccessLevel.Allowed;
     private const AccessLevel L = AccessLevel.Limited;

--- a/src/Humans.Web/Models/SectionHelpContent.cs
+++ b/src/Humans.Web/Models/SectionHelpContent.cs
@@ -511,7 +511,7 @@ public static class SectionHelpContent
 | **Drift** | A discrepancy between what the system expects and what Google actually has. |
 | **Legal Document** | A consent document (e.g., privacy policy) that humans must agree to. |
 | **Document Version** | A specific revision of a legal document. New versions require re-consent. |
-| **Audit Log** | An append-only record of significant system actions for accountability. |
+| **Audit Log** | An append-only record of significant system actions for accountability and compliance. |
 | **Hangfire** | The background job processing system used for scheduled and recurring tasks. |
 """,
 
@@ -630,7 +630,7 @@ public static class SectionHelpContent
 | **Limit Zone** | A GeoJSON polygon showing the boundary of the event site. |
 | **Containers** | Shipping containers assigned to barrios, shown as pentagons on the map. |
 | **Placement Phase** | The window during which barrio leads can draw or edit their camp polygons. |
-| **Map Admin** | Effective role for city-planning administration. Granted by holding `CampAdmin` or being in the `city-planning` team. |
+| **Map Admin** | Effective role for city-planning administration. Granted by holding `CampAdmin` or being a member of the `city-planning` team. |
 | **Barrio Lead** | The camp lead for a barrio — can place their barrio's polygon and containers while placement is open. |
 | **Measure tool** | A two-click tool that records straight-line distances on the map. Multiple measurements persist until cleared; right-click deletes one. |
 | **SignalR** | The real-time channel used to push polygon updates to all connected users simultaneously. |
@@ -647,13 +647,13 @@ public static class SectionHelpContent
 | **Barrio Lead** | The human responsible for a camp — the only non-admin who can edit that camp's polygon. |
 | **Placement Phase** | The window during which barrio leads can draw or edit their polygons. Opened and closed by Map Admins. |
 | **Placement Window / Dates** | Scheduled open and close times for the placement phase — the phase auto-opens/closes on these dates. |
-| **Map Admin** | Effective role for city-planning administration. Granted by holding `CampAdmin` **or** being a member of the `city-planning` team. |
+| **Map Admin** | Effective role for city-planning administration. Granted by holding `CampAdmin` or being a member of the `city-planning` team. |
 | **CampAdmin** | System role with full admin access to camps and city planning. |
 | **Limit Zone** | A GeoJSON polygon showing the boundary of the event site, displayed on the map for reference. |
 | **Official Zones** | A GeoJSON layer of pre-defined zones (e.g., quiet zones, sound stages) displayed as an overlay. |
 | **GeoJSON** | The open standard file format used for map polygons. Used for imports (limit zone, official zones) and exports. |
 | **Polygon History** | The append-only log of every save to a camp's polygon. Map Admins can view and restore previous versions. |
-| **SignalR** | The real-time channel used to push polygon updates to everyone on the map simultaneously. |
+| **SignalR** | The real-time channel used to push polygon updates to all connected users simultaneously. |
 """,
     };
 }

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -326,6 +326,15 @@ public class MySignupItem
     public string DepartmentName { get; set; } = string.Empty;
     public Instant AbsoluteStart { get; set; }
     public Instant AbsoluteEnd { get; set; }
+
+    /// <summary>
+    /// True when the Mine view must lock the bail/withdraw control for this signup:
+    /// it's an early-entry (build) shift, early-entry close has passed, and the viewer
+    /// cannot approve signups for the signup's own department — the per-team gate
+    /// ShiftSignupService.BailAsync/BailRangeAsync enforces server-side.
+    /// Only the Mine action sets this; other MySignupItem surfaces leave it false.
+    /// </summary>
+    public bool BailLocked { get; set; }
 }
 
 // === ShiftAdmin ===

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -5974,6 +5974,7 @@
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_SetupClosedBadge" xml:space="preserve"><value>Muntatge tancat</value></data>
   <data name="Shifts_SignupDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Les inscripcions de muntatge estan tancades — ja som al lloc.</value></data>
+  <data name="Shifts_BailDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Els torns de muntatge ja estan tancats — contacta amb la teva coordinació si no pots venir.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>
   <data name="Profile_DietaryMedical_MedicalConditions_Title" xml:space="preserve"><value>Medical conditions</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -5974,6 +5974,7 @@
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_SetupClosedBadge" xml:space="preserve"><value>Aufbau geschlossen</value></data>
   <data name="Shifts_SignupDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Aufbau-Anmeldungen sind geschlossen — wir sind bereits vor Ort.</value></data>
+  <data name="Shifts_BailDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Die Aufbau-Schichten stehen fest — melde dich bei deiner Koordination, wenn du nicht kommen kannst.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>
   <data name="Profile_DietaryMedical_MedicalConditions_Title" xml:space="preserve"><value>Medical conditions</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -6023,6 +6023,7 @@
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Primero cuéntanos tus necesidades alimentarias.</value></data>
   <data name="Shifts_SetupClosedBadge" xml:space="preserve"><value>Montaje cerrado</value></data>
   <data name="Shifts_SignupDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Las inscripciones de montaje están cerradas — ya estamos en el sitio.</value></data>
+  <data name="Shifts_BailDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Los turnos de montaje ya están cerrados — contacta con tu coordinación si no puedes venir.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Un momento — necesitamos tu información alimentaria antes de apuntarte a este turno.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Opcional</value></data>
   <data name="Profile_DietaryMedical_MedicalConditions_Title" xml:space="preserve"><value>Condiciones médicas</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -5974,6 +5974,7 @@
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_SetupClosedBadge" xml:space="preserve"><value>Montage fermé</value></data>
   <data name="Shifts_SignupDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Les inscriptions au montage sont closes — nous sommes déjà sur place.</value></data>
+  <data name="Shifts_BailDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Les shifts de montage sont verrouillés — contacte ta coordination si tu ne peux pas venir.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>
   <data name="Profile_DietaryMedical_MedicalConditions_Title" xml:space="preserve"><value>Medical conditions</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -5974,6 +5974,7 @@
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_SetupClosedBadge" xml:space="preserve"><value>Montaggio chiuso</value></data>
   <data name="Shifts_SignupDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Le iscrizioni al montaggio sono chiuse — siamo già sul posto.</value></data>
+  <data name="Shifts_BailDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>I turni di montaggio sono bloccati — contatta il tuo coordinamento se non puoi esserci.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>
   <data name="Profile_DietaryMedical_MedicalConditions_Title" xml:space="preserve"><value>Medical conditions</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2429,6 +2429,7 @@
   <data name="Shifts_SignupDisabledTooltip_MissingDietary" xml:space="preserve"><value>Tell us your food needs first.</value></data>
   <data name="Shifts_SetupClosedBadge" xml:space="preserve"><value>Set-up closed</value></data>
   <data name="Shifts_SignupDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Set-up sign-ups are closed — we're already on site.</value></data>
+  <data name="Shifts_BailDisabledTooltip_EarlyEntryClosed" xml:space="preserve"><value>Set-up shifts are locked in — contact your coordinator if you can't make it.</value></data>
   <data name="Shifts_DietaryRequiredBeforeSignup" xml:space="preserve"><value>Quick stop — we need your dietary info before signing up for this shift.</value></data>
   <data name="Common_Optional" xml:space="preserve"><value>Optional</value></data>
   <data name="Profile_DietaryMedical_MedicalConditions_Title" xml:space="preserve"><value>Medical conditions</value></data>

--- a/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
+++ b/src/Humans.Web/Services/Agent/AgentPreloadAugmentor.cs
@@ -11,23 +11,67 @@ public sealed class AgentPreloadAugmentor : IAgentPreloadAugmentor
         var sb = new StringBuilder();
         sb.AppendLine("# Access Matrix");
         sb.AppendLine();
-        foreach (var row in AccessMatrixDefinitions.Rows)
+        sb.AppendLine("Per section: the roles that can use each feature; \"(limited)\" marks partial/restricted access. Roles not listed for a feature do not have access.");
+        foreach (var section in AccessMatrixDefinitions.Sections.Values)
         {
-            sb.AppendLine(FormattableString.Invariant(
-                $"- **{row.Feature}** — {string.Join(", ", row.AllowedRoles)}"));
+            sb.AppendLine();
+            sb.AppendLine(FormattableString.Invariant($"## {section.SectionName}"));
+            var rolesByFeature = section.Features
+                .Select(f => (f.Name, Roles: f.RoleAccess
+                    .Where(kv => kv.Value != AccessLevel.Denied)
+                    .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                    .Select(kv => kv.Value == AccessLevel.Limited ? kv.Key + " (limited)" : kv.Key)
+                    .ToList()))
+                .Where(f => f.Roles.Count > 0);
+            foreach (var group in rolesByFeature.GroupBy(f => string.Join(", ", f.Roles), StringComparer.Ordinal))
+            {
+                sb.AppendLine(FormattableString.Invariant(
+                    $"- **{group.Key}** — {string.Join("; ", group.Select(f => f.Name))}"));
+            }
         }
         return sb.ToString();
     }
 
     public string BuildGlossariesMarkdown()
     {
+        var glossaries = SectionHelpContent.AllGlossaries()
+            .Select(g => (g.Section, Lines: g.Body.Split('\n').Select(l => l.TrimEnd()).ToList()))
+            .ToList();
+
+        // A term row that appears verbatim in more than one section glossary is shared:
+        // emitted once up front and omitted from the per-section tables.
+        var sharedRows = glossaries
+            .SelectMany(g => g.Lines.Where(IsTermRow))
+            .GroupBy(l => l, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToHashSet(StringComparer.Ordinal);
+
         var sb = new StringBuilder();
         sb.AppendLine("# Section Glossaries");
-        foreach (var (section, body) in SectionHelpContent.AllGlossaries())
+        sb.AppendLine();
+        sb.AppendLine("## Shared Terms");
+        sb.AppendLine();
+        sb.AppendLine("Terms used with the same meaning across sections — defined once here, omitted from the per-section tables.");
+        sb.AppendLine();
+        sb.AppendLine("| Term | Definition |");
+        sb.AppendLine("|------|-----------|");
+        var emitted = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in glossaries.SelectMany(g => g.Lines).Where(sharedRows.Contains))
+        {
+            if (emitted.Add(row))
+            {
+                sb.AppendLine(row);
+            }
+        }
+
+        foreach (var (_, lines) in glossaries)
         {
             sb.AppendLine();
-            sb.AppendLine(FormattableString.Invariant($"## {section}"));
-            sb.AppendLine(body);
+            foreach (var line in lines.Where(l => !sharedRows.Contains(l)))
+            {
+                sb.AppendLine(line);
+            }
         }
         return sb.ToString();
     }
@@ -51,4 +95,7 @@ public sealed class AgentPreloadAugmentor : IAgentPreloadAugmentor
         "# Frequently Asked Questions" + Environment.NewLine + Environment.NewLine +
         "Distilled from real user questions. Prefer these answers; they are verified against the live app." +
         Environment.NewLine + Environment.NewLine + SectionHelpContent.Faq;
+
+    /// <summary>A glossary table data row ("| **Term** | Definition |") — as opposed to headings and the table header.</summary>
+    private static bool IsTermRow(string line) => line.StartsWith("| **", StringComparison.Ordinal);
 }

--- a/src/Humans.Web/Views/Agent/Conversations.cshtml
+++ b/src/Humans.Web/Views/Agent/Conversations.cshtml
@@ -63,3 +63,33 @@ else
         .Build();
     <partial name="_Table" model="table" />
 }
+
+@if (Model.IsAdminView && (Model.Page > 0 || Model.HasNext))
+{
+    // Older/Newer paging, preserving the filter query params (refusalsOnly, userId).
+    var baseRoute = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    foreach (var pair in Context.Request.Query)
+    {
+        if (string.Equals(pair.Key, "page", StringComparison.OrdinalIgnoreCase)) { continue; }
+        baseRoute[pair.Key] = pair.Value.ToString();
+    }
+
+    Dictionary<string, string?> RouteFor(int page)
+    {
+        return new Dictionary<string, string?>(baseRoute, StringComparer.OrdinalIgnoreCase)
+        {
+            ["page"] = page.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+    }
+
+    <nav aria-label="Pagination">
+        <ul class="pagination justify-content-center">
+            <li class="page-item @(Model.Page <= 0 ? "disabled" : "")">
+                <a class="page-link" asp-action="Conversations" asp-all-route-data="@RouteFor(Model.Page - 1)">Newer</a>
+            </li>
+            <li class="page-item @(Model.HasNext ? "" : "disabled")">
+                <a class="page-link" asp-action="Conversations" asp-all-route-data="@RouteFor(Model.Page + 1)">Older</a>
+            </li>
+        </ul>
+    </nav>
+}

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -96,6 +96,9 @@
                             var first = block.OrderBy(b => b.Signup.Shift.DayOffset).First();
                             var last = block.OrderBy(b => b.Signup.Shift.DayOffset).Last();
                             var shift = first.Signup.Shift;
+                            // Early-entry close locks bails on build shifts unless the viewer can
+                            // approve signups for the block's own department (per-team, set by the controller).
+                            var bailLocked = block.Any(b => b.BailLocked);
                             <div class="d-flex justify-content-between align-items-center border-bottom py-2">
                                 <div>
                                     <span class="badge @GetPhaseBadge(shift, es) me-1">@GetPhase(shift, es)</span>
@@ -104,11 +107,23 @@
                                     <small class="text-muted">(@block.Count() days)</small>
                                     <span class="ms-1">@first.DepartmentName</span>
                                 </div>
-                                <form asp-action="BailRange" method="post" class="d-inline">
-                                    @Html.AntiForgeryToken()
-                                    <input type="hidden" name="signupBlockId" value="@block.Key" />
-                                    <button type="submit" class="btn btn-sm btn-outline-danger">@Localizer["Shifts_Bail"]</button>
-                                </form>
+                                @if (bailLocked)
+                                {
+                                    <button type="button" class="btn btn-sm btn-outline-danger"
+                                            disabled
+                                            aria-disabled="true"
+                                            title="@Localizer["Shifts_BailDisabledTooltip_EarlyEntryClosed"]">
+                                        <i class="fa-solid fa-lock me-1" aria-hidden="true"></i>@Localizer["Shifts_Bail"]
+                                    </button>
+                                }
+                                else
+                                {
+                                    <form asp-action="BailRange" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="signupBlockId" value="@block.Key" />
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">@Localizer["Shifts_Bail"]</button>
+                                    </form>
+                                }
                             </div>
                         }
                     }
@@ -119,11 +134,23 @@
                             <span class="badge @GetPhaseBadge(item.Signup.Shift, es)">@GetPhase(item.Signup.Shift, es)</span>
                         </text>;
                         Func<MySignupItem, IHtmlContent> upcomingActionCell = @<text>
-                            <form asp-action="Bail" method="post" class="d-inline">
-                                @Html.AntiForgeryToken()
-                                <input type="hidden" name="signupId" value="@item.Signup.Id" />
-                                <button type="submit" class="btn btn-sm btn-outline-danger">@Localizer["Shifts_Bail"]</button>
-                            </form>
+                            @if (item.BailLocked)
+                            {
+                                <button type="button" class="btn btn-sm btn-outline-danger"
+                                        disabled
+                                        aria-disabled="true"
+                                        title="@Localizer["Shifts_BailDisabledTooltip_EarlyEntryClosed"]">
+                                    <i class="fa-solid fa-lock me-1" aria-hidden="true"></i>@Localizer["Shifts_Bail"]
+                                </button>
+                            }
+                            else
+                            {
+                                <form asp-action="Bail" method="post" class="d-inline">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="signupId" value="@item.Signup.Id" />
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">@Localizer["Shifts_Bail"]</button>
+                                </form>
+                            }
                         </text>;
                         var upcomingTable = TableModel.For(individualItems)
                             .Column(Localizer["Shifts_Department"].Value, r => r.DepartmentName)
@@ -156,11 +183,23 @@
                             <span class="badge @GetPhaseBadge(item.Signup.Shift, es)">@GetPhase(item.Signup.Shift, es)</span>
                         </text>;
                         Func<MySignupItem, IHtmlContent> pendingActionCell = @<text>
-                            <form asp-action="Bail" method="post" class="d-inline">
-                                @Html.AntiForgeryToken()
-                                <input type="hidden" name="signupId" value="@item.Signup.Id" />
-                                <button type="submit" class="btn btn-sm btn-outline-secondary">@Localizer["Shifts_WithdrawButton"]</button>
-                            </form>
+                            @if (item.BailLocked)
+                            {
+                                <button type="button" class="btn btn-sm btn-outline-secondary"
+                                        disabled
+                                        aria-disabled="true"
+                                        title="@Localizer["Shifts_BailDisabledTooltip_EarlyEntryClosed"]">
+                                    <i class="fa-solid fa-lock me-1" aria-hidden="true"></i>@Localizer["Shifts_WithdrawButton"]
+                                </button>
+                            }
+                            else
+                            {
+                                <form asp-action="Bail" method="post" class="d-inline">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="signupId" value="@item.Signup.Id" />
+                                    <button type="submit" class="btn btn-sm btn-outline-secondary">@Localizer["Shifts_WithdrawButton"]</button>
+                                </form>
+                            }
                         </text>;
                         var pendingTable = TableModel.For(Model.Pending)
                             .Column(Localizer["Shifts_Department"].Value, r => r.DepartmentName)

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -208,6 +208,72 @@ public class AgentServiceTests
     }
 
     [HumansFact]
+    public async Task Ask_synthesizes_a_final_answer_when_the_tool_call_cap_is_reached()
+    {
+        var userId = Guid.NewGuid();
+        var dispatcher = Substitute.For<IAgentToolDispatcher>();
+        dispatcher.DispatchAsync(Arg.Any<AnthropicToolCall>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ci => new AnthropicToolResult(
+                ci.Arg<AnthropicToolCall>().Id, "guide content", IsError: false));
+        var rateLimitStore = new AgentRateLimitStore();
+        var (svc, client) = await BuildService(s => s.Enabled = true,
+            rateLimitStore: rateLimitStore, toolDispatcher: dispatcher);
+
+        // Iteration 1: the model burns the whole tool budget (MaxToolCallsPerTurn = 3).
+        client.EnqueueTurn(
+            new AgentTurnToken("Let me look that up. ", null, null),
+            new AgentTurnToken(null, new AnthropicToolCall("t1", "fetch_section_guide", """{"section":"teams"}"""), null),
+            new AgentTurnToken(null, new AnthropicToolCall("t2", "fetch_section_guide", """{"section":"camps"}"""), null),
+            new AgentTurnToken(null, new AnthropicToolCall("t3", "fetch_community_faq", "{}"), null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(100, 20, 5, 3, "claude-sonnet-4-6", "tool_use")));
+
+        // Iteration 2: the synthesis call (tools withheld) answers from the fetched results.
+        client.EnqueueTurn(
+            new AgentTurnToken("Teams are groups of volunteers; see the Teams page.", null, null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(40, 30, 7, 2, "claude-sonnet-4-6", "end_turn")));
+
+        var tokens = new List<AgentTurnToken>();
+        await foreach (var t in svc.AskAsync(
+            new AgentTurnRequest(ConversationId: Guid.Empty, UserId: userId, Message: "What are teams?", Locale: "es"),
+            Xunit.TestContext.Current.CancellationToken))
+        {
+            tokens.Add(t);
+        }
+
+        var streamedText = string.Concat(tokens.Where(t => t.TextDelta != null).Select(t => t.TextDelta));
+        streamedText.Should().Contain("Teams are groups of volunteers",
+            "hitting the cap must still end in an answer synthesized from the tool results, not just the preamble");
+
+        var finalizer = tokens.Last().Finalizer!;
+        finalizer.StopReason.Should().Be("end_turn",
+            "the synthesis call ends the turn normally");
+
+        await dispatcher.Received(3).DispatchAsync(
+            Arg.Any<AnthropicToolCall>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+
+        client.LastRequest!.DisallowToolUse.Should().BeTrue(
+            "the final synthesis call must withhold tool use so the model answers in text");
+
+        // Token accounting must cover BOTH provider requests (tool-use + synthesis),
+        // not just the last one — otherwise the tool-use request's tokens escape
+        // admin spend and DailyTokenCap accounting.
+        finalizer.InputTokens.Should().Be(140);
+        finalizer.OutputTokens.Should().Be(50);
+        finalizer.CacheReadTokens.Should().Be(12);
+        finalizer.CacheCreationTokens.Should().Be(5);
+
+        var transcript = await svc.GetConversationForUserAsync(
+            userId, finalizer.ConversationId, Xunit.TestContext.Current.CancellationToken);
+        var assistantMessage = transcript!.Messages.Single(m => m.Role == AgentRole.Assistant);
+        assistantMessage.PromptTokens.Should().Be(140);
+        assistantMessage.OutputTokens.Should().Be(50);
+        assistantMessage.CachedTokens.Should().Be(12);
+
+        rateLimitStore.Get(userId, new LocalDate(2026, 4, 21), hour: 12).TokensToday.Should().Be(190,
+            "the daily token cap must count prompt+output tokens from every request in the turn");
+    }
+
+    [HumansFact]
     public async Task Route_to_issue_handoff_is_surfaced_by_the_admin_handoffs_filter()
     {
         var userId = Guid.NewGuid();

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Humans.Application.Configuration;
+using Humans.Application.Constants;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Stores;
 using Humans.Application.Models;
@@ -206,6 +207,124 @@ public class AgentServiceTests
             "a count_tokens failure must never break the admin prompt-preview page");
     }
 
+    [HumansFact]
+    public async Task Route_to_issue_handoff_is_surfaced_by_the_admin_handoffs_filter()
+    {
+        var userId = Guid.NewGuid();
+        var dispatcher = Substitute.For<IAgentToolDispatcher>();
+        dispatcher.DispatchAsync(Arg.Any<AnthropicToolCall>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromResult(new AnthropicToolResult(
+                call.Arg<AnthropicToolCall>().Id, "Proposal queued.", IsError: false)));
+        var (svc, client) = await BuildService(s => s.Enabled = true, toolDispatcher: dispatcher);
+
+        // Turn 1 — plain answer, no handoff. Must NOT match the handoffs filter.
+        await StartConversation(svc, client, Guid.NewGuid());
+
+        // Turn 2 — the agent hands off via route_to_issue.
+        client.EnqueueTurn(
+            new AgentTurnToken("Let me draft an issue for you.", null, null),
+            new AgentTurnToken(null, new AnthropicToolCall(
+                "tc1", AgentToolNames.RouteToIssue,
+                """{"title":"Broken link","category":"Bug","description":"The camps page 404s."}"""), null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(0, 0, 0, 0, "claude-sonnet-4-6", "tool_use")));
+
+        Guid handoffConversationId = Guid.Empty;
+        await foreach (var t in svc.AskAsync(
+            new AgentTurnRequest(ConversationId: Guid.Empty, UserId: userId, Message: "the camps page is broken", Locale: "es"),
+            Xunit.TestContext.Current.CancellationToken))
+        {
+            if (t.Finalizer is { } f) handoffConversationId = f.ConversationId;
+        }
+
+        var rows = await svc.ListAllConversationsForAdminWithMessagesAsync(
+            refusalsOnly: false, handoffsOnly: true, userId: null, take: 50, skip: 0,
+            Xunit.TestContext.Current.CancellationToken);
+
+        var row = rows.Should().ContainSingle(
+            "only the route_to_issue conversation is a handoff").Subject;
+        row.Id.Should().Be(handoffConversationId);
+        // Same predicate the API uses for HandoffCount (nobodies-collective/Humans#931).
+        row.Messages.Count(m => m.HandedOffToFeedbackId != null
+                || m.FetchedDocs.Contains(AgentToolNames.RouteToIssue, StringComparer.Ordinal))
+            .Should().BeGreaterThan(0, "the saved assistant message must carry the handoff marker");
+    }
+
+    [HumansFact]
+    public async Task Failed_route_to_issue_dispatch_does_not_count_as_a_handoff()
+    {
+        var userId = Guid.NewGuid();
+        var dispatcher = Substitute.For<IAgentToolDispatcher>();
+        // Malformed args → AgentToolDispatcher returns IsError=true and no
+        // issueProposal frame is emitted, so the user never sees the Issues modal.
+        dispatcher.DispatchAsync(Arg.Any<AnthropicToolCall>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromResult(new AnthropicToolResult(
+                call.Arg<AnthropicToolCall>().Id, "Malformed tool arguments (expected JSON object).", IsError: true)));
+        var (svc, client) = await BuildService(s => s.Enabled = true, toolDispatcher: dispatcher);
+
+        client.EnqueueTurn(
+            new AgentTurnToken(null, new AnthropicToolCall(
+                "tc1", AgentToolNames.RouteToIssue, """{"title":"Broken"""), null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(0, 0, 0, 0, "claude-sonnet-4-6", "tool_use")));
+        // The loop continues after the failed tool call; script the follow-up turn.
+        client.EnqueueTurn(
+            new AgentTurnToken("Sorry, I could not draft that issue.", null, null),
+            new AgentTurnToken(null, null, new AgentTurnFinalizer(0, 0, 0, 0, "claude-sonnet-4-6", "end_turn")));
+
+        await foreach (var _ in svc.AskAsync(
+            new AgentTurnRequest(ConversationId: Guid.Empty, UserId: userId, Message: "the camps page is broken", Locale: "es"),
+            Xunit.TestContext.Current.CancellationToken))
+        {
+        }
+
+        var rows = await svc.ListAllConversationsForAdminWithMessagesAsync(
+            refusalsOnly: false, handoffsOnly: true, userId: null, take: 50, skip: 0,
+            Xunit.TestContext.Current.CancellationToken);
+        rows.Should().BeEmpty("a failed route_to_issue dispatch never showed the user the Issues modal");
+
+        // Same predicate the API uses for HandoffCount — must stay at zero.
+        var all = await svc.ListAllConversationsForAdminWithMessagesAsync(
+            refusalsOnly: false, handoffsOnly: false, userId: null, take: 50, skip: 0,
+            Xunit.TestContext.Current.CancellationToken);
+        all.Should().ContainSingle().Which.Messages
+            .Count(m => m.HandedOffToFeedbackId != null
+                || m.FetchedDocs.Contains(AgentToolNames.RouteToIssue, StringComparer.Ordinal))
+            .Should().Be(0, "failed handoff attempts must not carry the handoff marker");
+    }
+
+    [HumansFact]
+    public async Task Refused_conversations_are_surfaced_by_the_admin_refusals_filter()
+    {
+        var userId = Guid.NewGuid();
+        var store = new AgentRateLimitStore();
+        for (var h = 0; h < 30; h++)
+            store.Record(userId, new LocalDate(2026, 4, 21), hour: h, messagesDelta: 1, tokensDelta: 0);
+
+        var (svc, client) = await BuildService(s =>
+        {
+            s.Enabled = true;
+            s.DailyMessageCap = 30;
+        }, rateLimitStore: store);
+
+        // A second user with a normal, non-refused conversation. Must NOT match the filter.
+        await StartConversation(svc, client, Guid.NewGuid());
+
+        // The capped user trips the rate limit — PersistRefusal writes RefusalReason.
+        await foreach (var _ in svc.AskAsync(
+            new AgentTurnRequest(ConversationId: Guid.Empty, UserId: userId, Message: "hi", Locale: "es"),
+            Xunit.TestContext.Current.CancellationToken))
+        {
+        }
+
+        var rows = await svc.ListAllConversationsForAdminWithMessagesAsync(
+            refusalsOnly: true, handoffsOnly: false, userId: null, take: 50, skip: 0,
+            Xunit.TestContext.Current.CancellationToken);
+
+        var row = rows.Should().ContainSingle("only the rate-limited conversation is a refusal").Subject;
+        row.UserId.Should().Be(userId);
+        row.Messages.Should().Contain(m => m.RefusalReason == "rate_limited",
+            "the API's RefusalCount projects from RefusalReason");
+    }
+
     private static async Task<Guid> StartConversation(
         IAgentService svc, AnthropicClientFake client, Guid userId)
     {
@@ -225,7 +344,8 @@ public class AgentServiceTests
 
     private static async Task<(IAgentService Svc, AnthropicClientFake Client)> BuildService(
         Action<AgentSettings> tune,
-        IAgentRateLimitStore? rateLimitStore = null)
+        IAgentRateLimitStore? rateLimitStore = null,
+        IAgentToolDispatcher? toolDispatcher = null)
     {
         var dbOptions = new DbContextOptionsBuilder<HumansDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -266,7 +386,7 @@ public class AgentServiceTests
         var preload = Substitute.For<IAgentPreloadCorpusBuilder>();
         preload.BuildAsync(Arg.Any<AgentPreloadConfig>(), Arg.Any<CancellationToken>()).Returns("");
         var assembler = new AgentPromptAssembler();
-        var tools = Substitute.For<IAgentToolDispatcher>();
+        var tools = toolDispatcher ?? Substitute.For<IAgentToolDispatcher>();
         var client = new AnthropicClientFake();
         var options = Options.Create(new AnthropicOptions());
         var logger = NullLogger<AgentService>.Instance;

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientRetryTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientRetryTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Http.Headers;
+using AwesomeAssertions;
+using Humans.Application.Tests.AuditLog;
+using Humans.Infrastructure.Services.Mailer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Humans.Application.Tests.Services.Mailer;
+
+public class MailerLiteClientRetryTests
+{
+    private const string HumansGroupPage =
+        """{"data":[{"id":"42","name":"Humans - Test","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""";
+
+    [HumansFact]
+    public async Task AssignSubscriberToGroupAsync_RetriesAfter429_AndSucceeds()
+    {
+        var handler = new ScriptedHandler();
+        // Cache pre-populate: empty subscriber page, then a Humans-managed group.
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
+        handler.EnqueueJson(HttpStatusCode.OK, HumansGroupPage);
+        handler.Enqueue429(retryAfterSeconds: 0);
+        handler.EnqueueJson(HttpStatusCode.OK, "{}");
+        var client = NewClient(handler);
+        var callsBeforeAssign = 2;
+
+        await client.AssignSubscriberToGroupAsync("sub-1", "42", Xunit.TestContext.Current.CancellationToken);
+
+        handler.Calls.Should().Be(callsBeforeAssign + 2,
+            "the 429 must be retried once and succeed on the second attempt");
+    }
+
+    [HumansFact]
+    public async Task AssignSubscriberToGroupAsync_GivesUpAfterBoundedRetries()
+    {
+        var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
+        handler.EnqueueJson(HttpStatusCode.OK, HumansGroupPage);
+        for (var i = 0; i < 5; i++) handler.Enqueue429(retryAfterSeconds: 0);
+        var client = NewClient(handler);
+        var callsBeforeAssign = 2;
+
+        var act = async () => await client.AssignSubscriberToGroupAsync(
+            "sub-1", "42", Xunit.TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<HttpRequestException>(
+            "exhausting bounded retries must still surface the failure");
+        handler.Calls.Should().Be(callsBeforeAssign + 3,
+            "retries are bounded to 3 attempts, not an infinite loop");
+    }
+
+    [HumansFact]
+    public async Task AssignSubscriberToGroupAsync_ClampsAbsurdRetryAfter_ToCeiling()
+    {
+        var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
+        handler.EnqueueJson(HttpStatusCode.OK, HumansGroupPage);
+        handler.Enqueue429(retryAfterSeconds: 86400); // a day — clock skew / malformed header
+        var logger = new CapturingLogger<MailerLiteClient>();
+        var client = NewClient(handler, logger);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+            Xunit.TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromMilliseconds(250)); // don't sit out the (clamped) delay
+
+        var act = async () => await client.AssignSubscriberToGroupAsync("sub-1", "42", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "the clamped 90s delay is still pending when the token cancels");
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Warning && e.Message.Contains("retrying in 90s"),
+            "an absurd Retry-After must clamp to the 90s ceiling, not be honored verbatim");
+    }
+
+    private static MailerLiteClient NewClient(HttpMessageHandler handler, ILogger<MailerLiteClient>? logger = null) =>
+        new(new StubHttpClientFactory(handler),
+            NodaTime.SystemClock.Instance,
+            logger ?? NullLogger<MailerLiteClient>.Instance);
+
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new();
+        public int Calls { get; private set; }
+
+        public void EnqueueJson(HttpStatusCode status, string body)
+            => _responses.Enqueue(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+            });
+
+        public void Enqueue429(int retryAfterSeconds)
+        {
+            var resp = new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+            {
+                Content = new StringContent("""{"message":"Too Many Attempts."}""",
+                    System.Text.Encoding.UTF8, "application/json"),
+            };
+            resp.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(retryAfterSeconds));
+            _responses.Enqueue(resp);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
+        {
+            Calls++;
+            return Task.FromResult(_responses.Count > 0
+                ? _responses.Dequeue()
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json"),
+                });
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new(handler, disposeHandler: false) { BaseAddress = new Uri("https://example.test/") };
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/CampControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/CampControllerTests.cs
@@ -58,6 +58,27 @@ public class CampControllerTests
     }
 
     [HumansFact]
+    public async Task Index_InvalidFilterQueryValue_ClearsModelStateAndRendersWithDefaults()
+    {
+        // Regression for nobodies-collective/Humans#926: a scanner payload in a bool
+        // filter param leaves an invalid attempted value in ModelState, which the
+        // checkbox tag helper would throw a FormatException re-converting at render.
+        StubCampReadModel([]);
+        var controller = BuildController();
+        const string garbage = "test\")))EXTRACTVALUE(7966,...)";
+        controller.ModelState.SetModelValue(
+            "ShowLeadPositions", new Microsoft.AspNetCore.Mvc.ModelBinding.ValueProviderResult(garbage));
+        controller.ModelState.AddModelError(
+            "ShowLeadPositions", $"The value '{garbage}' is not valid for ShowLeadPositions.");
+
+        var result = await controller.Index(new CampFilterViewModel(), Xunit.TestContext.Current.CancellationToken);
+
+        result.Should().BeOfType<ViewResult>();
+        controller.ModelState.Should().BeEmpty(
+            "the invalid attempted value must not survive to view rendering");
+    }
+
+    [HumansFact]
     public async Task Index_RoleLeadPendingCamp_AppearsInMyCamps_FromCampInfo()
     {
         var userId = Guid.NewGuid();

--- a/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
+++ b/tests/Humans.Web.Tests/Services/AgentPreloadAugmentorTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Web.Models;
 using Humans.Web.Services.Agent;
 
 namespace Humans.Web.Tests.Services;
@@ -36,5 +37,61 @@ public class AgentPreloadAugmentorTests
         faq.Should().Contain("/Profile/Me/Emails");          // bought-under-other-email + change email
         faq.Should().Contain("/Profile/Me/Privacy");         // delete account / data export
         faq.Should().Contain("https://nobodies.team/");      // external comms channels
+    }
+
+    [HumansFact]
+    public void Glossaries_define_Human_exactly_once()
+    {
+        var glossaries = new AgentPreloadAugmentor().BuildGlossariesMarkdown();
+        glossaries.Split('\n').Count(l => l.StartsWith("| **Human** |", StringComparison.Ordinal)).Should().Be(1);
+    }
+
+    [HumansFact]
+    public void Glossaries_keep_every_term_and_definition()
+    {
+        var glossaries = new AgentPreloadAugmentor().BuildGlossariesMarkdown();
+        foreach (var (_, body) in SectionHelpContent.AllGlossaries())
+        {
+            foreach (var row in body.Split('\n').Select(l => l.TrimEnd()).Where(l => l.StartsWith("| **", StringComparison.Ordinal)))
+            {
+                glossaries.Should().Contain(row);
+            }
+        }
+    }
+
+    [HumansFact]
+    public void AccessMatrix_keeps_every_allowed_and_limited_role_fact_grouped_by_section()
+    {
+        var matrix = new AgentPreloadAugmentor().BuildAccessMatrixMarkdown();
+        foreach (var section in AccessMatrixDefinitions.Sections.Values)
+        {
+            matrix.Should().Contain($"## {section.SectionName}");
+            foreach (var feature in section.Features)
+            {
+                var roles = feature.RoleAccess
+                    .Where(kv => kv.Value != AccessLevel.Denied)
+                    .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                    .Select(kv => kv.Value == AccessLevel.Limited ? kv.Key + " (limited)" : kv.Key)
+                    .ToList();
+                if (roles.Count == 0)
+                {
+                    continue;
+                }
+                matrix.Split('\n').Should().Contain(l =>
+                    l.StartsWith("- ", StringComparison.Ordinal) &&
+                    l.Contains($"**{string.Join(", ", roles)}**", StringComparison.Ordinal) &&
+                    l.Contains(feature.Name, StringComparison.Ordinal));
+            }
+        }
+    }
+
+    [HumansFact]
+    public void AccessMatrix_collapses_features_sharing_a_role_set_onto_one_line()
+    {
+        var matrix = new AgentPreloadAugmentor().BuildAccessMatrixMarkdown();
+        matrix.Split('\n').Should().Contain(l =>
+            l.Contains("Browse shifts", StringComparison.Ordinal) &&
+            l.Contains("Sign up for shifts", StringComparison.Ordinal) &&
+            l.Contains("My Shifts & availability", StringComparison.Ordinal));
     }
 }

--- a/tests/Humans.Web.Tests/Services/ClientStatsMiddlewareTests.cs
+++ b/tests/Humans.Web.Tests/Services/ClientStatsMiddlewareTests.cs
@@ -98,6 +98,52 @@ public class ClientStatsMiddlewareTests
     }
 
     [HumansFact]
+    public async Task AbortedProfilePicture_AuthenticatedUser_IsNotRecorded()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 200, "image/webp", ctx =>
+        {
+            ctx.Request.Path = "/Profile/Picture";
+            ctx.Request.QueryString = new QueryString("?id=abc&v=1");
+            ctx.RequestAborted = new CancellationToken(canceled: true);
+            ctx.User = AuthenticatedUser();
+        });
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task AbortedProfilePicture_AnonymousUser_IsRecordedAs499()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 200, "image/webp", ctx =>
+        {
+            ctx.Request.Path = "/Profile/Picture";
+            ctx.RequestAborted = new CancellationToken(canceled: true);
+        });
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().ContainSingle()
+            .Which.StatusCode.Should().Be(499);
+    }
+
+    [HumansFact]
+    public async Task AbortedNonPicturePath_AuthenticatedUser_IsStillRecorded()
+    {
+        var tracker = await RunAsync(HttpMethods.Get, 200, "text/html", ctx =>
+        {
+            ctx.RequestAborted = new CancellationToken(canceled: true);
+            ctx.User = AuthenticatedUser();
+        });
+
+        tracker.GetErrorsSnapshot(10).Recent.Should().ContainSingle()
+            .Which.StatusCode.Should().Be(499);
+    }
+
+    private static System.Security.Claims.ClaimsPrincipal AuthenticatedUser()
+        => new(new System.Security.Claims.ClaimsIdentity(
+            [new System.Security.Claims.Claim(
+                System.Security.Claims.ClaimTypes.NameIdentifier, Guid.NewGuid().ToString())],
+            authenticationType: "Test"));
+
+    [HumansFact]
     public async Task ExceptionHandlerReExecute_RecordsOriginalPath()
     {
         var tracker = await RunAsync(HttpMethods.Get, 500, "text/html",


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

## Commits

- `b6fc9b81` fix(web): stop recording authenticated profile-picture aborts as 499s (peterdrier/Humans#1111)
- `5d0d4703` fix(agent): synthesize final answer when tool-call cap is reached (peterdrier/Humans#1107)
- `e46e5342` fix(dashboard): let request-driven cancellation abort instead of logging Error (nobodies-collective/Humans#890) (peterdrier/Humans#1110)
- `4ec71d78` fix(legal): log transient GitHub sync failures as single-line Warning (nobodies-collective/Humans#927) (peterdrier/Humans#1109)
- `78ab5fc9` refactor(agent): dedupe preload glossaries and compact access matrix (peterdrier/Humans#1108)
- `c2480ee9` fix(agent): derive handoff counters from route_to_issue markers in FetchedDocs (nobodies-collective/Humans#931) (peterdrier/Humans#1106)
- `6106258c` feat(agent): add Older/Newer paging to /Agent/Conversations admin view (nobodies-collective/Humans#930) (peterdrier/Humans#1105)
- `7c3682c2` fix(shifts): lock bail UI after early-entry close and quiet expected rejection log (peterdrier/Humans#1104)
- `76516c7b` fix(google-sync): log Drive permission grant/delete failures once (peterdrier/Humans#1102)
- `b1de2580` fix(notifications): retry MailerLite 429s honoring Retry-After (peterdrier/Humans#1103)
- `a9ca2f16` fix(store): derive catalog year from active event instead of 2026 hardcode (nobodies-collective/Humans#924) (peterdrier/Humans#1101)
- `cd1a14d3` fix(camps): return 400 for invalid /Barrios filter query params (nobodies-collective/Humans#926) (peterdrier/Humans#1100)

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly