### PR TITLE
Promote QA → production (1 commit)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,14 +35,26 @@ WORKDIR /app
 
 # Install native dependencies for SkiaSharp + curl for healthcheck
 # (libheif native binaries are provided by the LibHeif.Native NuGet package)
-# postgresql-client-16 matches the postgres:16 server and provides the pg_dump the
-# pre-migration snapshot shells out to (nobodies-collective/Humans#845).
+# postgresql-client-18 provides the pg_dump the pre-migration snapshot shells out to
+# (nobodies-collective/Humans#845). The client major must be >= the *server* major:
+# pg_dump refuses outright to dump a server newer than itself, and production runs
+# Postgres 18. It reads older servers fine, so this one client covers the postgres:16
+# in docker-compose.yml too — pin it to production's major, never to compose's.
+# Noble's own archive stops at 16, so the client comes from PGDG.
 # Swap to nl.archive.ubuntu.com — geographically closer and avoids archive.ubuntu.com flakiness
 RUN sed -i 's|archive\.ubuntu\.com|nl.archive.ubuntu.com|g; s|security\.ubuntu\.com|nl.archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources \
     && apt-get update && apt-get install -y --no-install-recommends \
         libfontconfig1 \
         curl \
-        postgresql-client-16 \
+        ca-certificates \
+        gnupg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        | gpg --dearmor -o /usr/share/keyrings/pgdg.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt noble-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        postgresql-client-18 \
+    && apt-get purge -y --auto-remove gnupg \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and give it ownership of the app directory.

--- a/docs/database-restore-runbook.md
+++ b/docs/database-restore-runbook.md
@@ -315,8 +315,16 @@ Implemented in `src/Humans.Infrastructure/Hosting/PreMigrationSnapshot.cs`
 - **If the dump fails, startup aborts and the migration does not run.** This is on purpose:
   the schema is left exactly as the previous release left it, so rolling the image back is a
   complete recovery. Fix the cause (usually the volume mount or a missing `pg_dump`) and
-  redeploy — do not work around it. `postgresql-client-16` is installed in the runtime image by
+  redeploy — do not work around it. `postgresql-client-18` is installed in the runtime image by
   the `Dockerfile`; the volume is declared in `docker-compose.yml`.
+- **The client major tracks production's server, not `docker-compose.yml`'s.** `pg_dump` refuses
+  to dump a server newer than itself but reads older ones fine, so the pinned client must be
+  `>=` the production server's major. Production runs Postgres 18; `docker-compose.yml` runs 16
+  for QA and local, and one client 18 covers both. Pinning it to the compose file instead is what
+  broke the first schema-changing production deploy after this feature shipped
+  (nobodies-collective/Humans#1187): the snapshot only runs when a deploy has pending migrations,
+  so the mismatch sat unexercised through every deploy that did not touch the schema, and QA —
+  on 16, where a client 16 works — could not reproduce it.
 
 > **Owner action — Coolify.** QA gets the `db_snapshots` volume from `docker-compose.yml`.
 > Production is deployed through Coolify, whose volume configuration is not in this repo, so it


### PR DESCRIPTION
## Summary

Batched promotion of QA-tested changes from `peterdrier/Humans:main` to production.

All issue/PR refs are qualified per `memory/process/issue-refs-qualified.md` — `peterdrier/Humans#NNN` for peter-fork PRs, `nobodies-collective/Humans#NNN` for upstream issues.

**This one unblocks production deploys.** The last two — `ba2323f15` and `ec7cdf019` — both aborted at startup before applying migrations:

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 18.2; pg_dump version: 16.14 (Ubuntu 16.14-0ubuntu0.24.04.1)
```

Production runs Postgres 18; the runtime image pinned `postgresql-client-16`, taken from `docker-compose.yml` rather than the real server. The pre-migration snapshot (nobodies-collective/Humans#845, shipped in peterdrier/Humans#1187) runs only on a deploy with pending migrations, so the mismatch sat unexercised until the first schema-changing deploy after it shipped. The abort behaved as designed — schema untouched, production kept serving `deee89ba1`.

Everything already merged here but never deployed goes live with this: the four Aug-7 column drops, and the Holded contact-list fix for nobodies-collective/Humans#994 (currently still throwing in production from the `deee89ba1` image).

## Commits

- `5cb0e331b` fix(ops): pin pg_dump to Postgres 18 so the pre-migration snapshot works in prod (peterdrier/Humans#1219)

## Test plan

- [ ] Rebase merge (each PR is already squashed)
- [ ] CI green on production
- [ ] Verify EF migrations apply cleanly — four are pending and have never run: `20260807155413_DropCampLeadsAndSpecialRoleDefault`, `20260807215606_DropProfileIsSuspended`, `20260807220438_DropProfilePictureData`, `20260807220909_DropUserEmailDisplayOrder`
- [ ] Confirm the deploy log shows a snapshot **written** rather than reused or failed — this is the first successful `pg_dump` in production, so it is also the first real test of nobodies-collective/Humans#845
- [ ] Confirm `/app/db-snapshots` is on a persistent volume in Coolify (the open owner action in `docs/database-restore-runbook.md`); without it the rollback point does not survive the container
- [ ] `GET /api/version` reports the new build, and `/Finance/Creditors` shows creditor names instead of blanks

## Follow-up

- nobodies-collective/Humans#1002 — QA runs Postgres 16 while production runs 18, so QA cannot exercise the dump path. Also notes that no CI job builds the Dockerfile at all, which is why this reached production.